### PR TITLE
Frontend main app refresh token support

### DIFF
--- a/FinanceFrontEnd/FinanceApp/.eslintrc.cjs
+++ b/FinanceFrontEnd/FinanceApp/.eslintrc.cjs
@@ -43,7 +43,7 @@ module.exports = {
         commonjs: true,
         es6: true,
     },
-    ignorePatterns: ["!**/.server", "!**/.client"],
+    ignorePatterns: ["!**/.server", "!**/.client", "app/components/ui/shadcn/**"],
 
     // Base config
     extends: ["eslint:recommended"],

--- a/FinanceFrontEnd/FinanceApp/app/routes/api.proxy.ts
+++ b/FinanceFrontEnd/FinanceApp/app/routes/api.proxy.ts
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { getUserAndTokens } from '@/services/auth/session.server';
 import { HttpStatusConstants } from '@/services/auth/auth.constants';
 import { JsonErrorResponse } from '@/utils/JsonResponse';
+import { refreshSessionTokens, isTokenExpired } from '@/services/auth/tokenRefresh.server';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -51,11 +52,19 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     throw JsonErrorResponse('Not authenticated', HttpStatusConstants.UNAUTHORIZED);
   }
 
-  const { tokens } = result;
-  const accessToken = tokens.accessToken;
+  const { user, tokens } = result;
+  let accessToken = tokens.accessToken as string | undefined;
 
-  if (!accessToken) {
-    throw JsonErrorResponse('Not authenticated', HttpStatusConstants.UNAUTHORIZED);
+  // If the access token is missing or expired, try to refresh it
+  if (!accessToken || isTokenExpired(accessToken)) {
+    const refreshResult = user.serverSessionId
+      ? await refreshSessionTokens(user.serverSessionId)
+      : null;
+    if (refreshResult) {
+      accessToken = refreshResult.accessToken;
+    } else {
+      throw JsonErrorResponse('Not authenticated', HttpStatusConstants.UNAUTHORIZED);
+    }
   }
 
   try {
@@ -139,11 +148,19 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     throw JsonErrorResponse('Not authenticated', HttpStatusConstants.UNAUTHORIZED);
   }
 
-  const { tokens } = result;
-  const accessToken = tokens.accessToken;
+  const { user, tokens } = result;
+  let accessToken = tokens.accessToken as string | undefined;
 
-  if (!accessToken) {
-    throw JsonErrorResponse('Not authenticated', HttpStatusConstants.UNAUTHORIZED);
+  // If the access token is missing or expired, try to refresh it
+  if (!accessToken || isTokenExpired(accessToken)) {
+    const refreshResult = user.serverSessionId
+      ? await refreshSessionTokens(user.serverSessionId)
+      : null;
+    if (refreshResult) {
+      accessToken = refreshResult.accessToken;
+    } else {
+      throw JsonErrorResponse('Not authenticated', HttpStatusConstants.UNAUTHORIZED);
+    }
   }
 
   try {

--- a/FinanceFrontEnd/FinanceApp/app/services/auth/auth.constants.ts
+++ b/FinanceFrontEnd/FinanceApp/app/services/auth/auth.constants.ts
@@ -25,7 +25,7 @@ const AuthConstants = {
     REDIRECT_URI:
         `${BASE_URL}/auth/callback` || `http://localhost:${PORT}/auth/callback`,
     RETURN_TO_URL: BASE_URL || `http://localhost:${PORT}`,
-    SCOPES: AUTH0_SCOPES?.split(",") ?? ["openid", "email", "profile"],
+    SCOPES: AUTH0_SCOPES?.split(",") ?? ["openid", "email", "profile", "offline_access"],
 };
 
 const SessionContants = {

--- a/FinanceFrontEnd/FinanceApp/app/services/auth/session.server.ts
+++ b/FinanceFrontEnd/FinanceApp/app/services/auth/session.server.ts
@@ -193,6 +193,10 @@ export async function requireAuth(request: Request) {
   // Check if token is expired (or about to expire within 60s) and try to refresh
   if (isTokenExpired(accessToken)) {
     SafeLogger.info('[requireAuth] Access token expired or about to expire, attempting refresh...');
+    if (!user.serverSessionId) {
+      await destroyUserSession(request);
+      throw redirect('/auth/login');
+    }
     const refreshResult = await refreshSessionTokens(user.serverSessionId);
     if (refreshResult) {
       accessToken = refreshResult.accessToken;

--- a/FinanceFrontEnd/FinanceApp/app/services/auth/session.server.ts
+++ b/FinanceFrontEnd/FinanceApp/app/services/auth/session.server.ts
@@ -4,6 +4,7 @@ import { verifyIdToken } from './auth.server';
 import type { SessionUser } from './types/SessionUser';
 import SafeLogger from '@/utils/SafeLogger';
 import { sessionLogger } from '@/middleware/logger.server';
+import { refreshSessionTokens, isTokenExpired } from './tokenRefresh.server';
 
 // User session storage (different from auth flow)
 const userSessionStorage = createCookieSessionStorage({
@@ -171,56 +172,43 @@ export async function requireAuth(request: Request) {
     tokens: Tokens;
   };
 
-  // Validate that access token exists and is not expired
-  const accessToken = tokens.accessToken as string;
+  // Validate that access token exists
+  let accessToken = tokens.accessToken as string;
   if (!accessToken) {
-    // No access token, clear session and redirect to login
-    await destroyUserSession(request);
-    throw redirect('/auth/login');
-  }
-
-  // Check if token is expired by decoding the JWT payload
-  try {
-    const tokenParts = accessToken.split('.');
-    if (tokenParts.length !== 3) {
-      throw new Error('Invalid JWT format');
-    }
-
-    const payload = JSON.parse(atob(tokenParts[1]));
-    const now = Math.floor(Date.now() / 1000); // Current time in seconds
-
-    if (payload.exp && payload.exp < now) {
-      // Token is expired, clear session and redirect to login
-      SafeLogger.info(
-        `[requireAuth] Token expired at ${new Date(
-          payload.exp * 1000
-        )}, current time: ${new Date()}`
-      );
+    // No access token — try to refresh if we have a refresh token
+    if (user.serverSessionId) {
+      const refreshResult = await refreshSessionTokens(user.serverSessionId);
+      if (refreshResult) {
+        accessToken = refreshResult.accessToken;
+      } else {
+        await destroyUserSession(request);
+        throw redirect('/auth/login');
+      }
+    } else {
       await destroyUserSession(request);
       throw redirect('/auth/login');
     }
-  } catch (tokenError) {
-    SafeLogger.error('[requireAuth] Token validation failed:', tokenError);
-    await destroyUserSession(request);
-    throw redirect('/auth/login');
   }
 
-  // Avoid printing full tokens to logs. Use a safe logger and only print a short preview.
-  try {
-    const { default: SafeLogger } = await import('@/utils/SafeLogger');
-    const tokenInfo = tokens as { accessToken?: string };
-    SafeLogger.info(
-      '[requireAuth] Access token preview:',
-      tokenInfo.accessToken ? `${tokenInfo.accessToken.substring(0, 10)}...` : null
-    );
-    SafeLogger.info('[requireAuth] Access token length:', tokenInfo.accessToken?.length);
-  } catch (e) {
-    // If logger import fails for any reason, don't block authentication flow.
+  // Check if token is expired (or about to expire within 60s) and try to refresh
+  if (isTokenExpired(accessToken)) {
+    SafeLogger.info('[requireAuth] Access token expired or about to expire, attempting refresh...');
+    const refreshResult = await refreshSessionTokens(user.serverSessionId);
+    if (refreshResult) {
+      accessToken = refreshResult.accessToken;
+      if (refreshResult.refreshed) {
+        SafeLogger.info('[requireAuth] Token refreshed successfully');
+      }
+    } else {
+      SafeLogger.info('[requireAuth] Token refresh failed, redirecting to login');
+      await destroyUserSession(request);
+      throw redirect('/auth/login');
+    }
   }
 
   return {
     ...user,
-    accessToken: tokens.accessToken as unknown as string | undefined,
+    accessToken,
     refreshToken: tokens.refreshToken as unknown as string | undefined,
   };
 }

--- a/FinanceFrontEnd/FinanceApp/app/services/auth/tokenRefresh.server.ts
+++ b/FinanceFrontEnd/FinanceApp/app/services/auth/tokenRefresh.server.ts
@@ -1,0 +1,110 @@
+import { AuthConstants } from './auth.constants';
+import redis from './redis.server';
+import SafeLogger from '@/utils/SafeLogger';
+
+interface Auth0TokenResponse {
+  access_token: string;
+  id_token?: string;
+  refresh_token?: string;
+  token_type: string;
+  expires_in: number;
+}
+
+/**
+ * Check whether a JWT access token is expired (or will expire within `bufferSeconds`).
+ * Returns `true` when the token should be refreshed.
+ */
+export function isTokenExpired(accessToken: string, bufferSeconds = 60): boolean {
+  try {
+    const parts = accessToken.split('.');
+    if (parts.length !== 3) return true;
+    const payload = JSON.parse(atob(parts[1]));
+    const now = Math.floor(Date.now() / 1000);
+    return !payload.exp || payload.exp < now + bufferSeconds;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Exchange a refresh token for a new access token (and optionally a new refresh token)
+ * using Auth0's `/oauth/token` endpoint.
+ */
+async function requestNewTokens(refreshToken: string): Promise<Auth0TokenResponse> {
+  const response = await fetch(`https://${AuthConstants.DOMAIN}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      client_id: AuthConstants.CLIENT_ID,
+      client_secret: AuthConstants.CLIENT_SECRET,
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    SafeLogger.error('[tokenRefresh] Auth0 token refresh failed:', response.status, errorBody);
+    throw new Error(`Token refresh failed: ${response.status}`);
+  }
+
+  return (await response.json()) as Auth0TokenResponse;
+}
+
+/**
+ * Attempt to refresh the tokens stored in Redis for the given server session.
+ *
+ * - If the access token is still valid, returns `{ refreshed: false }`.
+ * - If no refresh token is available, returns `null` (caller should redirect to login).
+ * - On success, updates Redis and returns the new access token.
+ */
+export async function refreshSessionTokens(
+  serverSessionId: string
+): Promise<{ refreshed: boolean; accessToken: string } | null> {
+  const raw = await redis.get(`serverSession:${serverSessionId}`);
+  if (!raw) return null;
+
+  const tokens = JSON.parse(raw) as {
+    accessToken?: string;
+    refreshToken?: string;
+    idToken?: string;
+  };
+
+  const { accessToken, refreshToken } = tokens;
+
+  // If the access token is still valid, nothing to do
+  if (accessToken && !isTokenExpired(accessToken)) {
+    return { refreshed: false, accessToken };
+  }
+
+  // No refresh token stored — can't refresh silently
+  if (!refreshToken) {
+    SafeLogger.warn('[tokenRefresh] No refresh token available for session:', serverSessionId);
+    return null;
+  }
+
+  try {
+    SafeLogger.info('[tokenRefresh] Refreshing tokens for session:', serverSessionId);
+    const newTokens = await requestNewTokens(refreshToken);
+
+    // Build updated payload — Auth0 may or may not return a rotated refresh token
+    const updatedPayload = {
+      accessToken: newTokens.access_token,
+      refreshToken: newTokens.refresh_token ?? refreshToken, // keep old if not rotated
+      idToken: newTokens.id_token ?? tokens.idToken, // keep old if not returned
+    };
+
+    await redis.set(
+      `serverSession:${serverSessionId}`,
+      JSON.stringify(updatedPayload),
+      'EX',
+      60 * 60 * 24 * 7 // 7 days
+    );
+
+    SafeLogger.info('[tokenRefresh] Tokens refreshed successfully for session:', serverSessionId);
+    return { refreshed: true, accessToken: newTokens.access_token };
+  } catch (error) {
+    SafeLogger.error('[tokenRefresh] Failed to refresh tokens:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
# Frontend Main App Refresh Token Support

## Summary

Implements automatic access token refresh using Auth0 refresh tokens in the FinanceApp frontend. When an access token is missing or expired, the app now silently refreshes it via the Auth0 `/oauth/token` endpoint instead of immediately redirecting to login, resulting in a smoother user experience.

## Changes

### New File

- **`app/services/auth/tokenRefresh.server.ts`** — Centralised token-refresh module:
  - `isTokenExpired(accessToken, bufferSeconds)` — Decodes a JWT and checks whether it is expired (or will expire within a configurable buffer, default 60 s).
  - `requestNewTokens(refreshToken)` — Calls Auth0's `POST /oauth/token` with the `refresh_token` grant to obtain a new access token (and optionally a rotated refresh token).
  - `refreshSessionTokens(serverSessionId)` — Reads the current tokens from Redis, checks expiry, refreshes if needed, persists the updated tokens back to Redis, and returns the result to the caller.

### Modified Files

- **`app/services/auth/auth.constants.ts`** — Added `"offline_access"` to the default OAuth scopes so Auth0 issues refresh tokens.
- **`app/services/auth/session.server.ts`** — Refactored `requireAuth`:
  - Replaced inline JWT-expiry checking and verbose logging with calls to `isTokenExpired` and `refreshSessionTokens` from the new module.
  - When the access token is missing or expired, attempts a silent refresh before falling back to a login redirect.
  - Simplified the return value to use the (potentially refreshed) `accessToken` directly.
- **`app/routes/api.proxy.ts`** — Updated both the `loader` and `action` handlers:
  - Imported `refreshSessionTokens` and `isTokenExpired`.
  - Before making backend requests, checks token validity and attempts a refresh rather than immediately throwing a 401.

## How It Works

1. **Token request** — The `offline_access` scope is now included in the Auth0 authorization request, which causes Auth0 to return a refresh token alongside the access token.
2. **Expiry detection** — `isTokenExpired` decodes the JWT payload and compares the `exp` claim against the current time (with a 60-second buffer) to pre-emptively refresh tokens before they actually expire.
3. **Silent refresh** — `refreshSessionTokens` reads the session from Redis, and if the access token is expired it calls Auth0 to exchange the refresh token for new credentials. The updated tokens are written back to Redis with a 7-day TTL.
4. **Fallback** — If no refresh token is available or the refresh call fails, the user is redirected to login (in `requireAuth`) or receives a 401 (in the API proxy).

## Testing

- Verified that login flow still works end-to-end with the new `offline_access` scope.
- Confirmed that expired tokens are transparently refreshed without user-visible interruption.
- Validated that missing or invalid refresh tokens correctly fall back to login redirect / 401.
