### PR TITLE
Backend: Fix command orchestration issues

### DIFF
--- a/FinanceBackEnd/CQRSDispatch/Dispatcher.cs
+++ b/FinanceBackEnd/CQRSDispatch/Dispatcher.cs
@@ -126,7 +126,13 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
 
             using var activity = DispatchActivity.StartActivity(commandType.Name, "dispatch.type", "command");
 
-            var handlerType = typeof(ICommandHandler<,>).MakeGenericType(commandType, typeof(CommandResult));
+            var twoParamHandlerType = typeof(ICommandHandler<,>).MakeGenericType(commandType, typeof(CommandResult));
+            var oneParamHandlerType = typeof(ICommandHandler<>).MakeGenericType(commandType);
+
+            var handlerType = ServiceProvider.GetService(twoParamHandlerType) != null
+                ? twoParamHandlerType
+                : oneParamHandlerType;
+
             var handler = ServiceProvider.GetRequiredService(handlerType);
 
             var executeMethod = handlerType.GetMethod("ExecuteAsync")

--- a/FinanceBackEnd/Finance.Application/Services/Orchestrators/CurrencyExchangeRateOrchestrations/OrchestrateSet.cs
+++ b/FinanceBackEnd/Finance.Application/Services/Orchestrators/CurrencyExchangeRateOrchestrations/OrchestrateSet.cs
@@ -36,7 +36,7 @@ public sealed partial class CurrencyExchangeRateOrchestrator
             ResourceId = request.Id,
             PermissionLevels = [PermissionLevelEnum.Owner]
         };
-        var permissionsResult = await Dispatcher.DispatchAsync(createCommand);
+        var permissionsResult = await Dispatcher.DispatchAsync(createCommand, httpRequest);
         if (!permissionsResult.IsSuccess || permissionsResult.Data == null)
         {
             throw new Exception(permissionsResult.ErrorMessage);

--- a/FinanceBackEnd/Finance.Application/Services/Orchestrators/FundPermissionsOrchestrations/OrchestrateDelete.cs
+++ b/FinanceBackEnd/Finance.Application/Services/Orchestrators/FundPermissionsOrchestrations/OrchestrateDelete.cs
@@ -14,7 +14,7 @@ public sealed partial class FundPermissionsOrchestrator : BaseResourcePermission
         {
             EntityId = request.Id
         };
-        var createResourceResult = await Dispatcher.DispatchAsync(deleteFundOwnerCommand);
+        var createResourceResult = await Dispatcher.DispatchAsync(deleteFundOwnerCommand, httpRequest);
 
         if (!createResourceResult.IsSuccess)
         {

--- a/FinanceBackEnd/Finance.Application/Services/Orchestrators/FundPermissionsOrchestrations/OrchestrateSet.cs
+++ b/FinanceBackEnd/Finance.Application/Services/Orchestrators/FundPermissionsOrchestrations/OrchestrateSet.cs
@@ -21,15 +21,15 @@ public sealed partial class FundPermissionsOrchestrator : BaseResourcePermission
         var createFundPermissionsCommand = new CreateFundPermissionsCommand
         {
             ResourceId = request.Id,
-            UserId = request.UserId!.Value,
+            UserId = request.UserId,
             PermissionLevels = [PermissionLevelEnum.Owner]
         };
-        var FundPermissionsResult = await Dispatcher.DispatchAsync(createFundPermissionsCommand);
-        if (!FundPermissionsResult.IsSuccess || FundPermissionsResult.Data == null)
+        var fundPermissionsResult = await Dispatcher.DispatchAsync(createFundPermissionsCommand, httpRequest);
+        if (!fundPermissionsResult.IsSuccess || fundPermissionsResult.Data == null)
         {
-            throw new Exception(FundPermissionsResult.ErrorMessage);
+            throw new Exception(fundPermissionsResult.ErrorMessage);
         }
 
-        return DataResult<FundPermissions>.Success(FundPermissionsResult.Data);
+        return DataResult<FundPermissions>.Success(fundPermissionsResult.Data);
     }
 }

--- a/FinanceBackEnd/Finance.Application/Services/Orchestrators/SubscriptionPermissionsOrchestrations/OrchestrateDelete.cs
+++ b/FinanceBackEnd/Finance.Application/Services/Orchestrators/SubscriptionPermissionsOrchestrations/OrchestrateDelete.cs
@@ -14,7 +14,7 @@ public sealed partial class SubscriptionPermissionsOrchestrator : BaseResourcePe
         {
             EntityId = request.Id
         };
-        var createResourceResult = await Dispatcher.DispatchAsync(deleteSubscriptionOwnerCommand);
+        var createResourceResult = await Dispatcher.DispatchAsync(deleteSubscriptionOwnerCommand, httpRequest);
 
         if (!createResourceResult.IsSuccess)
         {

--- a/FinanceBackEnd/Finance.Application/Services/Orchestrators/SubscriptionPermissionsOrchestrations/OrchestrateSet.cs
+++ b/FinanceBackEnd/Finance.Application/Services/Orchestrators/SubscriptionPermissionsOrchestrations/OrchestrateSet.cs
@@ -21,10 +21,10 @@ public sealed partial class SubscriptionPermissionsOrchestrator : BaseResourcePe
         var createSubscriptionPermissionsCommand = new CreateSubscriptionPermissionsCommand
         {
             ResourceId = request.Id,
-            UserId = request.UserId!.Value,
+            UserId = request.UserId,
             PermissionLevels = [PermissionLevelEnum.Owner]
         };
-        var SubscriptionPermissionsResult = await Dispatcher.DispatchAsync(createSubscriptionPermissionsCommand);
+        var SubscriptionPermissionsResult = await Dispatcher.DispatchAsync(createSubscriptionPermissionsCommand, httpRequest);
         if (!SubscriptionPermissionsResult.IsSuccess || SubscriptionPermissionsResult.Data == null)
         {
             throw new Exception(SubscriptionPermissionsResult.ErrorMessage);


### PR DESCRIPTION
# Why
Calling `DELETE /api/funds` (and similar endpoints) was throwing a runtime `InvalidOperationException` because the dispatcher could not resolve the handler for `DeleteFundsCommand`. The root cause was that `Dispatcher.DispatchCommandAsync` was only looking up handlers registered as `ICommandHandler<TCommand, CommandResult>`, but several handlers implement the single-type-param shorthand `ICommandHandler<TCommand>`. Additionally, orchestrators for Funds, Subscriptions, and CurrencyExchangeRate were dispatching context-aware commands without forwarding the `httpRequest`, causing the dispatch context (user identity, etc.) to be missing.

## What is the solution?
- **Dispatcher fallback** (`Dispatcher.cs`): `DispatchCommandAsync` now first checks whether an `ICommandHandler<TCommand, CommandResult>` is registered, and falls back to `ICommandHandler<TCommand>` if it is not. This makes both handler interface variants compatible with the non-generic dispatch path.
- **HTTP context propagation** (`OrchestrateSet.cs`, `OrchestrateDelete.cs`): All orchestrator `DispatchAsync` calls that were missing the `httpRequest` argument now pass it through, ensuring the dispatch context is built correctly from the incoming request.
- **Minor cleanup** (`FundPermissionsOrchestrations/OrchestrateSet.cs`): Fixed variable naming to camelCase (`fundPermissionsResult`) and removed unnecessary null-forgiving operators (`UserId = request.UserId!.Value` → `UserId = request.UserId`) in Fund and Subscription permission orchestrators.

## What areas of the site does it impact?
- **Funds** – Delete endpoint now works correctly; owner permission set/delete flows propagate HTTP context.
- **Subscriptions** – Owner permission set/delete flows propagate HTTP context.
- **Currency Exchange Rates** – Owner permission assignment now propagates HTTP context.
- **CQRS infrastructure** – `Dispatcher` resolution logic is more permissive, affecting any command dispatched via `DispatchCommandAsync`.

## Test scenarios

```gherkin
Scenario: Delete a fund
  Given an authenticated user with an existing fund
  When the user calls DELETE /api/funds with valid fund IDs
  Then the funds are deleted and a 200 OK is returned

Scenario: Set fund owner
  Given an authenticated admin user and an existing fund
  When the admin calls POST /api/funds/{id}/owner/{userId}
  Then the fund owner permissions are created and a 200 OK is returned

Scenario: Delete fund owner
  Given an authenticated admin user and a fund with an owner
  When the admin calls DELETE /api/funds/{id}/owner/{userId}
  Then the fund owner permissions are removed and a 200 OK is returned

Scenario: Set subscription owner
  Given an authenticated admin user and an existing subscription
  When the admin assigns an owner via the subscription permissions endpoint
  Then the subscription owner permissions are created successfully

Scenario: Set currency exchange rate with owner
  Given an authenticated admin user
  When a new currency exchange rate is created
  Then the owner permissions are assigned correctly without errors
```

## Other Notes
Any command handler implementing the single-param `ICommandHandler<TCommand>` interface is now fully supported by `DispatchCommandAsync` without needing to change the handler itself. This is the preferred shorthand for handlers whose result is always `CommandResult`.