### PR TITLE
Frontend: Implementing url wrapper for front and backend side of main…

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/data/fetchData.ts
+++ b/FinanceFrontEnd/FinanceApp/app/components/data/fetchData.ts
@@ -1,10 +1,10 @@
+import type { BackendUrl } from '@/utils/BackendUrl';
+
 export interface FetchData<T> {
   items: T[];
 }
 
-export async function fetchData<T>(
-  url: string,
-): Promise<T> {
-  const response = await fetch(`${url}`);
+export async function fetchData<T>(url: BackendUrl | string): Promise<T> {
+  const response = await fetch(String(url));
   return await response.json();
 }

--- a/FinanceFrontEnd/FinanceApp/app/components/data/fetchPaginatedData.ts
+++ b/FinanceFrontEnd/FinanceApp/app/components/data/fetchPaginatedData.ts
@@ -1,29 +1,26 @@
-import { objectToUrlParams, parseUrl } from "@/utils/urlTreatment";
-import { fetchData } from "@/components/data/fetchData";
+import { fetchData } from '@/components/data/fetchData';
+import { BackendUrl } from '@/utils/BackendUrl';
 
 export interface PaginationData<T> {
-    items: T[];
-    totalItems: number;
-    totalPages: number;
-    currentPage: number;
+  items: T[];
+  totalItems: number;
+  totalPages: number;
+  currentPage: number;
 }
 
 export async function fetchPaginatedData<T>(
-    url: string,
-    page: number,
-    pageSize: number = 10
+  url: BackendUrl | string,
+  page: number,
+  pageSize: number = 10
 ): Promise<PaginationData<T>> {
-    const { queryParams, baseUrl } = parseUrl(url);
-    queryParams["Page"] = page.toString();
-    queryParams["PageSize"] = pageSize.toString();
-    const params = objectToUrlParams(queryParams);
-    const paginatedUrl = `${baseUrl}?${params}`;
+  const backendUrl = url instanceof BackendUrl ? url : new BackendUrl(String(url));
+  const paginatedUrl = backendUrl.with({ Page: page, PageSize: pageSize });
 
-    const result = await fetchData<PaginationData<T>>(`${paginatedUrl}`);
-    return {
-        items: result.items,
-        totalItems: result.totalItems,
-        totalPages: result.totalPages,
-        currentPage: result.currentPage,
-    };
+  const result = await fetchData<PaginationData<T>>(paginatedUrl);
+  return {
+    items: result.items,
+    totalItems: result.totalItems,
+    totalPages: result.totalPages,
+    currentPage: result.currentPage,
+  };
 }

--- a/FinanceFrontEnd/FinanceApp/app/components/data/handleRequest.ts
+++ b/FinanceFrontEnd/FinanceApp/app/components/data/handleRequest.ts
@@ -1,51 +1,52 @@
-import { fetchData } from "./fetchData";
-import SafeLogger from "@/utils/SafeLogger";
+import { fetchData } from './fetchData';
+import SafeLogger from '@/utils/SafeLogger';
+import type { BackendUrl } from '@/utils/BackendUrl';
 
 export const handleRequest = async <T = unknown>(
-    url: string,
-    method: string,
-    record?: T,
-    reload: boolean = false
+  url: BackendUrl | string,
+  method: string,
+  record?: T,
+  reload: boolean = false
 ): Promise<T | undefined> => {
-    let responseData: T | undefined;
+  let responseData: T | undefined;
 
-    try {
-        const headers: HeadersInit = {
-            "Content-Type": "application/json",
-        };
-        if (method === "DELETE") {
-            headers["accept"] = "application/octet-stream";
-        }
-
-        const response = await fetch(url ?? "", {
-            method: method,
-            headers: headers,
-            body: record === undefined ? undefined : JSON.stringify(record),
-        });
-
-        if (response.ok) {
-            try {
-                // attempt to parse JSON, but guard in case there's no body
-                responseData = (await response.json()) as T;
-            } catch (parseError) {
-                // no JSON body or parse failed
-                responseData = undefined;
-            }
-        } else {
-            const errorText = await response.text().catch(() => "");
-            SafeLogger.error("Request failed", {
-                status: response.status,
-                body: errorText,
-            });
-        }
-    } catch (error) {
-        SafeLogger.error("Error:", error);
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+    if (method === 'DELETE') {
+      headers['accept'] = 'application/octet-stream';
     }
 
-    // Avoid returning from inside finally. If reload is requested, return the refreshed data.
-    if (url && reload) {
-        return fetchData<T>(url);
-    }
+    const response = await fetch(String(url ?? ''), {
+      method: method,
+      headers: headers,
+      body: record === undefined ? undefined : JSON.stringify(record),
+    });
 
-    return responseData;
+    if (response.ok) {
+      try {
+        // attempt to parse JSON, but guard in case there's no body
+        responseData = (await response.json()) as T;
+      } catch (parseError) {
+        // no JSON body or parse failed
+        responseData = undefined;
+      }
+    } else {
+      const errorText = await response.text().catch(() => '');
+      SafeLogger.error('Request failed', {
+        status: response.status,
+        body: errorText,
+      });
+    }
+  } catch (error) {
+    SafeLogger.error('Error:', error);
+  }
+
+  // Avoid returning from inside finally. If reload is requested, return the refreshed data.
+  if (url && reload) {
+    return fetchData<T>(url);
+  }
+
+  return responseData;
 };

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -142,7 +142,7 @@ function CreateStatementModal({
     e.preventDefault();
     setSubmitting(true);
     try {
-      const res = await fetch(urls.proxy(urls.creditCardStatements.endpoint), {
+      const res = await fetch(String(urls.creditCardStatements.endpoint), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -226,9 +226,11 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
   const fetchStatements = useCallback(async () => {
     try {
       const res = await fetch(
-        urls.proxy(urls.creditCardStatements.endpoint, {
-          CreditCardId: card.id,
-        })
+        String(
+          urls.creditCardStatements.endpoint.with({
+            CreditCardId: card.id,
+          })
+        )
       );
       const data = await res.json();
       const items: CreditCardStatement[] = Array.isArray(data) ? data : (data.items ?? []);
@@ -249,10 +251,10 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
 
     setLoading(true);
     try {
-      let url: string;
+      let url: ReturnType<typeof urls.creditCardMovements.latest.with>;
 
       if (statementIndex === 0) {
-        url = urls.proxy(urls.creditCardMovements.latest, {
+        url = urls.creditCardMovements.latest.with({
           CreditCardId: card.id,
           Page: 1,
           PageSize: 200,
@@ -267,10 +269,10 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
         if (prevStatement) {
           params.From = prevStatement.closureDate;
         }
-        url = urls.proxy(urls.creditCardTransactions.endpoint + '/all', params);
+        url = urls.creditCardTransactions.endpoint.append('/all').with(params);
       }
 
-      const res = await fetch(url);
+      const res = await fetch(String(url));
       const data = await res.json();
       const items: CreditCardTransaction[] = Array.isArray(data) ? data : (data.items ?? []);
       setTransactions(items);

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -237,7 +237,22 @@ export default function Dashboard() {
         <section id="expenses-actions">
           <div className="container-fluid mt-4 ml-4 mr-4">
             <div className="grid grid-cols-3 gap-4">
-              <div className="column flex-wrap">
+              <div id="investments-section" className="column flex-wrap justify-content-center">
+                {urls.summary.currentInvestments && (
+                  <FetchTable
+                    name={`Investments`}
+                    title={{
+                      text: `Inversiones`,
+                      class: `text-center medium bg-purple-500 text-white`,
+                    }}
+                    url={urls.summary.currentInvestments}
+                    columns={InvestmentsTableSettings.columns as unknown as unknown[]}
+                    classes={tableClasses}
+                  />
+                )}
+                {!urls.summary.currentFunds && <div>AASAS</div>}
+              </div>
+              <div id="summary-section" className="column flex-wrap">
                 {urls.summary.general && (
                   <div className={tableContainer}>
                     <FetchTable
@@ -246,7 +261,7 @@ export default function Dashboard() {
                         text: `Resúmen`,
                         class: `text-center bg-blue-500 text-white`,
                       }}
-                      url={urls.proxy(urls.summary.general, { DailyUse: true })}
+                      url={urls.summary.general.with({ DailyUse: true })}
                       columns={SummaryTableSettings.columns}
                       classes={tableClasses}
                       showTotals={false}
@@ -261,7 +276,7 @@ export default function Dashboard() {
                         text: `Gastos`,
                         class: `text-center bg-red-500 text-white`,
                       }}
-                      url={urls.proxy(urls.summary.totalExpenses)}
+                      url={urls.summary.totalExpenses}
                       columns={ExpensesTableSettings.columns}
                       classes={tableClasses}
                     />
@@ -275,7 +290,7 @@ export default function Dashboard() {
                         text: `Conversiones de moneda`,
                         class: `text-center bg-sky-500 text-white`,
                       }}
-                      url={urls.proxy(urls.currencyExchangeRates.latest)}
+                      url={urls.currencyExchangeRates.latest}
                       columns={CurrencyExchangeRatesTableSettings.columns}
                       classes={tableClasses}
                       showTotals={false}
@@ -290,7 +305,7 @@ export default function Dashboard() {
                         text: `Fondos`,
                         class: `text-center bg-indigo-500 text-white`,
                       }}
-                      url={urls.proxy(urls.summary.currentFunds, { DailyUse: true })}
+                      url={urls.summary.currentFunds.with({ DailyUse: true })}
                       columns={FundsTableSettings.columns}
                       classes={tableClasses}
                     />
@@ -304,7 +319,7 @@ export default function Dashboard() {
                         text: `Otros Fondos`,
                         class: `text-center bg-indigo-500 text-white`,
                       }}
-                      url={urls.proxy(urls.summary.currentFunds, { DailyUse: false })}
+                      url={urls.summary.currentFunds.with({ DailyUse: false })}
                       columns={FundsTableSettings.columns}
                       classes={tableClasses}
                     />
@@ -314,7 +329,7 @@ export default function Dashboard() {
                   <div className={tableContainer}>
                     {urls.debits.monthly.latest &&
                       debitModules.map((appModuleId) => {
-                        const url = urls.proxy(urls.debits.monthly.latest, {
+                        const url = urls.debits.monthly.latest.with({
                           AppModuleId: appModuleId,
                           IncludeDeactivated: false,
                         });
@@ -343,7 +358,7 @@ export default function Dashboard() {
                   </div>
                 )}
               </div>
-              <div className="justify-content-center">
+              <div id="credit-cards-section" className="justify-content-center">
                 {creditCards &&
                   creditCards.map((c: unknown, _index: number) => {
                     const data = c as {
@@ -351,7 +366,7 @@ export default function Dashboard() {
                       name?: string;
                       bank?: { name?: string };
                     };
-                    const url = urls.proxy(urls.creditCardMovements.latest, {
+                    const url = urls.creditCardMovements.latest.with({
                       CreditCardId: data.id,
                       Page: 1,
                       PageSize: 10,
@@ -379,21 +394,6 @@ export default function Dashboard() {
                       />
                     );
                   })}
-              </div>
-              <div className="column flex-wrap justify-content-center">
-                {urls.summary.currentInvestments && (
-                  <FetchTable
-                    name={`Investments`}
-                    title={{
-                      text: `Inversiones`,
-                      class: `text-center medium bg-purple-500 text-white`,
-                    }}
-                    url={urls.proxy(urls.summary.currentInvestments)}
-                    columns={InvestmentsTableSettings.columns as unknown as unknown[]}
-                    classes={tableClasses}
-                  />
-                )}
-                {!urls.summary.currentFunds && <div>AASAS</div>}
               </div>
             </div>
           </div>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -1,212 +1,195 @@
-import React, { useState } from "react";
-import { useLoaderData } from "react-router";
-import dayjs from "dayjs";
-import urls from "@/utils/urls";
-import BankCurrencySelector from "@/components/ui/utils/BankCurrencySelector";
-import PaginatedTable, { Column } from "@/components/ui/utils/PaginatedTable";
-import { InputType } from "@/components/ui/utils/InputType";
-import { toNumber } from "@/utils/common";
-import { cn } from "@/lib/utils";
+import React, { useState } from 'react';
+import { useLoaderData } from 'react-router';
+import dayjs from 'dayjs';
+import urls from '@/utils/urls';
+import BankCurrencySelector from '@/components/ui/utils/BankCurrencySelector';
+import PaginatedTable, { Column } from '@/components/ui/utils/PaginatedTable';
+import { InputType } from '@/components/ui/utils/InputType';
+import { toNumber } from '@/utils/common';
+import { cn } from '@/lib/utils';
 
 // Define types for the props and states
 interface PickerData {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
 }
 
 interface LoaderData {
-    banks: PickerData[];
-    currencies: PickerData[];
+  banks: PickerData[];
+  currencies: PickerData[];
 }
 
-const dateFormat = "DD/MM/YYYY";
+const dateFormat = 'DD/MM/YYYY';
 
 const buildFundsEndpoint = (bankId: string, currencyId: string) => {
-    return urls.proxy(urls.funds.paginated, {
-        BankId: bankId,
-        CurrencyId: currencyId,
-        Page: 1,
-        PageSize: 10,
-    });
+  return urls.funds.paginated.with({
+    BankId: bankId,
+    CurrencyId: currencyId,
+    Page: 1,
+    PageSize: 10,
+  });
 };
 
 const Funds: React.FC = () => {
-    const { banks, currencies } = useLoaderData<LoaderData>();
-    const [selectedBankId, setSelectedBankId] = useState<string>(banks[0].id);
-    const [selectedCurrencyId, setSelectedCurrencyId] = useState<string>(
-        currencies[0].id
-    );
-    const [fundsEndpoint, setFundsEndpoint] = useState<string>(
-        buildFundsEndpoint(selectedBankId, selectedCurrencyId)
-    );
-    const [reloadTable, setReloadTable] = useState<boolean>(true);
+  const { banks, currencies } = useLoaderData<LoaderData>();
+  const [selectedBankId, setSelectedBankId] = useState<string>(banks[0].id);
+  const [selectedCurrencyId, setSelectedCurrencyId] = useState<string>(currencies[0].id);
+  const [fundsEndpoint, setFundsEndpoint] = useState(
+    buildFundsEndpoint(selectedBankId, selectedCurrencyId)
+  );
+  const [reloadTable, setReloadTable] = useState<boolean>(true);
 
-    // Removed updateFundsEndpoint helper to keep effect dependencies stable.
+  // Removed updateFundsEndpoint helper to keep effect dependencies stable.
 
-    const onBankPickerChange = (picker: { value: string }) => {
-        const newBankId =
-            selectedBankId !== picker.value ? picker.value : selectedBankId;
-        setSelectedBankId(newBankId);
-    };
+  const onBankPickerChange = (picker: { value: string }) => {
+    const newBankId = selectedBankId !== picker.value ? picker.value : selectedBankId;
+    setSelectedBankId(newBankId);
+  };
 
-    const onCurrencyPickerChange = (picker: { value: string }) => {
-        const newCurrencyId =
-            selectedCurrencyId !== picker.value
-                ? picker.value
-                : selectedCurrencyId;
-        setSelectedCurrencyId(newCurrencyId);
-    };
+  const onCurrencyPickerChange = (picker: { value: string }) => {
+    const newCurrencyId = selectedCurrencyId !== picker.value ? picker.value : selectedCurrencyId;
+    setSelectedCurrencyId(newCurrencyId);
+  };
 
-    const valueConditionalClass = {
-        class: "text-success fw-bold",
-        eval: (field: unknown) => field != null && toNumber(field) > 0,
-    };
+  const valueConditionalClass = {
+    class: 'text-success fw-bold',
+    eval: (field: unknown) => field != null && toNumber(field) > 0,
+  };
 
-    const valueMapper = (field: unknown) =>
-        field != null ? toNumber(field) : null;
+  const valueMapper = (field: unknown) => (field != null ? toNumber(field) : null);
 
-    const numericHeader = {
-        classes: "text-end",
+  const numericHeader = {
+    classes: 'text-end',
+    style: {
+      width: '140px',
+    },
+  };
+
+  const TableColumns: Column[] = [
+    {
+      id: 'timeStamp',
+      label: 'Fecha',
+      placeholder: 'Fecha',
+      type: InputType.DateTime,
+      editable: {
+        defaultValue: () => {
+          const rowSelector = document.querySelector('.bank-table-data-row > td > span');
+
+          if (!rowSelector?.textContent) return dayjs().format(dateFormat);
+
+          return dayjs(rowSelector.textContent, `${dateFormat}`).format(dateFormat);
+        },
+      },
+      datetime: {
+        timeFormat: 'HH:mm',
+        timeIntervals: 15,
+        dateFormat: dateFormat,
+        placeholder: 'Seleccionar fecha',
+      },
+      header: {
         style: {
-            width: "140px",
+          width: '160px',
         },
-    };
+      },
+    },
+    {
+      id: 'bank',
+      label: 'Banco/Entidad',
+      placeholder: 'Seleccione un banco',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.banks.endpoint,
+      mapper: {
+        id: 'id',
+        label: 'name',
+      },
+    },
+    {
+      id: 'currency',
+      label: 'Moneda',
+      placeholder: 'Seleccione una moneda',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.currencies.endpoint,
+      mapper: {
+        id: 'id',
+        label: 'name',
+      },
+    },
+    {
+      id: 'amount',
+      label: 'Monto',
+      placeholder: 'Monto',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: {
+        defaultValue: 0.0,
+      },
+      mapper: valueMapper,
+      conditionalClass: valueConditionalClass,
+    },
+    {
+      id: 'dailyUse',
+      label: 'Use diario',
+      placeholder: 'Use diario',
+      type: InputType.Boolean,
+      header: {
+        classes: '',
+        style: {
+          width: '80px',
+        },
+      },
+      class: 'text-center',
+      editable: {
+        defaultValue: false,
+      },
+    },
+  ];
 
-    const TableColumns: Column[] = [
-        {
-            id: "timeStamp",
-            label: "Fecha",
-            placeholder: "Fecha",
-            type: InputType.DateTime,
-            editable: {
-                defaultValue: () => {
-                    const rowSelector = document.querySelector(
-                        ".bank-table-data-row > td > span"
-                    );
+  // Update the endpoint whenever selectedBankId or selectedCurrencyId changes
+  React.useEffect(() => {
+    if (selectedBankId && selectedCurrencyId) {
+      setFundsEndpoint(buildFundsEndpoint(selectedBankId, selectedCurrencyId));
+      setReloadTable(true);
+    }
+  }, [selectedBankId, selectedCurrencyId]);
 
-                    if (!rowSelector?.textContent)
-                        return dayjs().format(dateFormat);
-
-                    return dayjs(
-                        rowSelector.textContent,
-                        `${dateFormat}`
-                    ).format(dateFormat);
-                },
-            },
-            datetime: {
-                timeFormat: "HH:mm",
-                timeIntervals: 15,
-                dateFormat: dateFormat,
-                placeholder: "Seleccionar fecha",
-            },
-            header: {
-                style: {
-                    width: "160px",
-                },
-            },
-        },
-        {
-            id: "bank",
-            label: "Banco/Entidad",
-            placeholder: "Seleccione un banco",
-            editable: false,
-            type: InputType.Dropdown,
-            endpoint: urls.banks.endpoint,
-            mapper: {
-                id: "id",
-                label: "name",
-            },
-        },
-        {
-            id: "currency",
-            label: "Moneda",
-            placeholder: "Seleccione una moneda",
-            editable: false,
-            type: InputType.Dropdown,
-            endpoint: urls.currencies.endpoint,
-            mapper: {
-                id: "id",
-                label: "name",
-            },
-        },
-        {
-            id: "amount",
-            label: "Monto",
-            placeholder: "Monto",
-            type: InputType.Decimal,
-            min: 0.0,
-            header: numericHeader,
-            class: "text-end",
-            editable: {
-                defaultValue: 0.0,
-            },
-            mapper: valueMapper,
-            conditionalClass: valueConditionalClass,
-        },
-        {
-            id: "dailyUse",
-            label: "Use diario",
-            placeholder: "Use diario",
-            type: InputType.Boolean,
-            header: {
-                classes: "",
-                style: {
-                    width: "80px",
-                },
-            },
-            class: "text-center",
-            editable: {
-                defaultValue: false,
-            },
-        },
-    ];
-
-    // Update the endpoint whenever selectedBankId or selectedCurrencyId changes
-    React.useEffect(() => {
-        if (selectedBankId && selectedCurrencyId) {
-            setFundsEndpoint(
-                buildFundsEndpoint(selectedBankId, selectedCurrencyId)
-            );
-            setReloadTable(true);
-        }
-    }, [selectedBankId, selectedCurrencyId]);
-
-    return (
-        <div className={cn(["py-10", "px-40"])}>
-            <BankCurrencySelector
-                banks={banks}
-                currencies={currencies}
-                bankId={selectedBankId}
-                currencyId={selectedCurrencyId}
-                onBankChange={onBankPickerChange}
-                onCurrencyChange={onCurrencyPickerChange}
-            />
-            {(!fundsEndpoint || fundsEndpoint.trim() === "") && (
-                <div className="text-center">Cargando datos</div>
-            )}
-            {fundsEndpoint && (
-                <PaginatedTable
-                        name={"funds-table"}
-                        url={fundsEndpoint}
-                        reloadData={reloadTable}
-                        columns={TableColumns}
-                        admin={{
-                            endpoint: urls.funds.endpoint,
-                            key: [
-                                {
-                                    id: "BankId",
-                                    value: selectedBankId,
-                                },
-                                {
-                                    id: "CurrencyId",
-                                    value: selectedCurrencyId,
-                                },
-                            ],
-                        }}
-                    />
-                )}
-        </div>
-    );
+  return (
+    <div className={cn(['py-10', 'px-40'])}>
+      <BankCurrencySelector
+        banks={banks}
+        currencies={currencies}
+        bankId={selectedBankId}
+        currencyId={selectedCurrencyId}
+        onBankChange={onBankPickerChange}
+        onCurrencyChange={onCurrencyPickerChange}
+      />
+      {!fundsEndpoint && <div className="text-center">Cargando datos</div>}
+      {fundsEndpoint && (
+        <PaginatedTable
+          name={'funds-table'}
+          url={fundsEndpoint}
+          reloadData={reloadTable}
+          columns={TableColumns}
+          admin={{
+            endpoint: urls.funds.endpoint,
+            key: [
+              {
+                id: 'BankId',
+                value: selectedBankId,
+              },
+              {
+                id: 'CurrencyId',
+                value: selectedCurrencyId,
+              },
+            ],
+          }}
+        />
+      )}
+    </div>
+  );
 };
 
 export default Funds;

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
@@ -1,143 +1,136 @@
-import { useEffect, useState } from "react";
-import urls from "@/utils/urls";
-import Uploader from "@/components/ui/utils/Uploader";
-import PaginatedTable, { Column } from "@/components/ui/utils/PaginatedTable";
-import { InputType } from "@/components/ui/utils/InputType";
+import { useEffect, useState } from 'react';
+import urls from '@/utils/urls';
+import Uploader from '@/components/ui/utils/Uploader';
+import PaginatedTable, { Column } from '@/components/ui/utils/PaginatedTable';
+import { InputType } from '@/components/ui/utils/InputType';
 
 type InvestmentField = {
-    symbol: string;
-    description: string;
+  symbol: string;
+  description: string;
 };
 
 function Movements() {
-    const [reloadData, setReloadData] = useState<boolean>(false);
+  const [reloadData, setReloadData] = useState<boolean>(false);
 
-    const AppModuleTypeEnumFundsId = 3;
+  const AppModuleTypeEnumFundsId = 3;
 
-    const IOLInvestmentsUploadEndpoint = urls.proxy(
-        urls.iolInvestments.upload,
-        { DateKind: "Local", AppModuleId: AppModuleTypeEnumFundsId }
-    );
-    const iolInvestmentsEndpoint = urls.proxy(urls.iolInvestments.paginated);
+  const IOLInvestmentsUploadEndpoint = urls.iolInvestments.upload.with({
+    DateKind: 'Local',
+    AppModuleId: AppModuleTypeEnumFundsId,
+  });
+  const iolInvestmentsEndpoint = urls.iolInvestments.paginated;
 
-    const onFetchInvestmentsTable = () => {};
+  const onFetchInvestmentsTable = () => {};
 
-    useEffect(() => {}, [AppModuleTypeEnumFundsId]);
+  useEffect(() => {}, [AppModuleTypeEnumFundsId]);
 
-    const numericColumn = (columnId: string, label: string): Column => ({
-        id: columnId,
-        label: label,
-        placeholder,
-        header: {
-            classes: ["text-end"],
+  const numericColumn = (columnId: string, label: string): Column => ({
+    id: columnId,
+    label: label,
+    placeholder,
+    header: {
+      classes: ['text-end'],
+    },
+    class: 'text-end',
+    editable: true,
+    mapper: (field: unknown) => {
+      const num = typeof field === 'number' ? field : Number(String(field));
+      return Number.isFinite(num) ? parseFloat(num.toFixed(2)) : num;
+    },
+    conditionalClass: [
+      {
+        class: 'text-success fw-bold',
+        eval: (field: unknown) => {
+          const num = typeof field === 'number' ? field : Number(String(field));
+          return Number(num) > 0;
         },
-        class: "text-end",
-        editable: true,
-        mapper: (field: unknown) => {
-            const num =
-                typeof field === "number" ? field : Number(String(field));
-            return Number.isFinite(num) ? parseFloat(num.toFixed(2)) : num;
+      },
+      {
+        class: 'text-danger fw-bold',
+        eval: (field: unknown) => {
+          const num = typeof field === 'number' ? field : Number(String(field));
+          return Number(num) < 0;
         },
-        conditionalClass: [
-            {
-                class: "text-success fw-bold",
-                eval: (field: unknown) => {
-                    const num =
-                        typeof field === "number"
-                            ? field
-                            : Number(String(field));
-                    return Number(num) > 0;
-                },
-            },
-            {
-                class: "text-danger fw-bold",
-                eval: (field: unknown) => {
-                    const num =
-                        typeof field === "number"
-                            ? field
-                            : Number(String(field));
-                    return Number(num) < 0;
-                },
-            },
-        ],
-    });
+      },
+    ],
+  });
 
-    const placeholder = "Ingrese un valor";
+  const placeholder = 'Ingrese un valor';
 
-    const investmentsTableColumns: Column[] = [
-        {
-            id: "timeStamp",
-            label: "Fecha",
-            placeholder,
-            type: InputType.DateTime,
-            editable: true,
-            datetime: {
-                timeIntervals: 15,
-                dateFormat: "DD/MM/yyyy",
-                timeFormat: "HH:mm",
-                placeholder: "Seleccionar fecha",
-            },
-            header: {
-                style: {
-                    width: "160px",
-                },
-            },
+  const investmentsTableColumns: Column[] = [
+    {
+      id: 'timeStamp',
+      label: 'Fecha',
+      placeholder,
+      type: InputType.DateTime,
+      editable: true,
+      datetime: {
+        timeIntervals: 15,
+        dateFormat: 'DD/MM/yyyy',
+        timeFormat: 'HH:mm',
+        placeholder: 'Seleccionar fecha',
+      },
+      header: {
+        style: {
+          width: '160px',
         },
-        {
-            id: "asset",
-            label: "Activo",
-            placeholder,
-            editable: true,
-            mapper: (field: unknown) => {
-                const f = field as InvestmentField;
-                return `${f?.symbol ?? ""} - ${f?.description ?? ""}`;
-            },
-        },
-        numericColumn("alarms", "Alarmas"),
-        numericColumn("quantity", "Cantidad"),
-        numericColumn("assets", "Activos comp."),
-        numericColumn("dailyVariation", "Variación diaria"),
-        numericColumn("lastPrice", "Último precio"),
-        numericColumn("averageBuyPrice", "Precio prom. compra"),
-        numericColumn("averageReturnPercent", "Rendimiento (%)"),
-        numericColumn("averageReturn", "Rendimiento prom."),
-        numericColumn("valued", "Valorado"),
-    ];
+      },
+    },
+    {
+      id: 'asset',
+      label: 'Activo',
+      placeholder,
+      editable: true,
+      mapper: (field: unknown) => {
+        const f = field as InvestmentField;
+        return `${f?.symbol ?? ''} - ${f?.description ?? ''}`;
+      },
+    },
+    numericColumn('alarms', 'Alarmas'),
+    numericColumn('quantity', 'Cantidad'),
+    numericColumn('assets', 'Activos comp.'),
+    numericColumn('dailyVariation', 'Variación diaria'),
+    numericColumn('lastPrice', 'Último precio'),
+    numericColumn('averageBuyPrice', 'Precio prom. compra'),
+    numericColumn('averageReturnPercent', 'Rendimiento (%)'),
+    numericColumn('averageReturn', 'Rendimiento prom.'),
+    numericColumn('valued', 'Valorado'),
+  ];
 
-    const enabled = Boolean(iolInvestmentsEndpoint);
+  const enabled = Boolean(iolInvestmentsEndpoint);
 
-    return (
-        <>
-            <div className="container pt-3 pb-3">
-                {!enabled && <div>Cargando...</div>}
-                {enabled && (
-                    <div>
-                        <hr className="py-1" />
-                        <Uploader
-                            url={IOLInvestmentsUploadEndpoint}
-                            extensions={[".xls", ".xlsx"]}
-                            onSuccess={() => {
-                                setReloadData(true);
-                            }}
-                        />
-                        <hr className="py-1" />
-                        <PaginatedTable
-                            name={"investments-table"}
-                            url={iolInvestmentsEndpoint}
-                            rowCount={20}
-                            admin={{
-                                endpoint: urls.iolInvestments.endpoint,
-                                addEnabled: false,
-                            }}
-                            onFetch={onFetchInvestmentsTable}
-                            columns={investmentsTableColumns}
-                            reloadData={reloadData}
-                        />
-                    </div>
-                )}
-            </div>
-        </>
-    );
+  return (
+    <>
+      <div className="container pt-3 pb-3">
+        {!enabled && <div>Cargando...</div>}
+        {enabled && (
+          <div>
+            <hr className="py-1" />
+            <Uploader
+              url={IOLInvestmentsUploadEndpoint}
+              extensions={['.xls', '.xlsx']}
+              onSuccess={() => {
+                setReloadData(true);
+              }}
+            />
+            <hr className="py-1" />
+            <PaginatedTable
+              name={'investments-table'}
+              url={iolInvestmentsEndpoint}
+              rowCount={20}
+              admin={{
+                endpoint: urls.iolInvestments.endpoint,
+                addEnabled: false,
+              }}
+              onFetch={onFetchInvestmentsTable}
+              columns={investmentsTableColumns}
+              reloadData={reloadData}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  );
 }
 
 export default Movements;

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Subscriptions/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Subscriptions/index.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react';
 import { useLoaderData, useRevalidator } from 'react-router';
-import type {
-  Subscription,
-  SubscriptionsData,
-} from '@/types/subscription';
+import type { Subscription, SubscriptionsData } from '@/types/subscription';
 import { SubscriptionFrequency } from '@/types/subscription';
 import {
   Table,
@@ -211,7 +208,9 @@ function Subscriptions() {
 
   const isMonthly = (s: Subscription) => {
     if (typeof s.frequency === 'string') {
-      return s.frequency.toLowerCase() === 'monthly' || s.frequency === SubscriptionFrequency.Monthly;
+      return (
+        s.frequency.toLowerCase() === 'monthly' || s.frequency === SubscriptionFrequency.Monthly
+      );
     }
     if (typeof s.frequency === 'number') {
       return s.frequency === 0;
@@ -255,7 +254,7 @@ function Subscriptions() {
     }
 
     try {
-      const response = await fetch(urls.proxy(urls.subscriptions.endpoint), {
+      const response = await fetch(String(urls.subscriptions.endpoint), {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids: [subscription.id] }),
@@ -273,7 +272,7 @@ function Subscriptions() {
   };
 
   const handleSave = async (data: Partial<Subscription>) => {
-    const endpoint = urls.proxy(urls.subscriptions.endpoint);
+    const endpoint = String(urls.subscriptions.endpoint);
     const method = editingSubscription ? 'PUT' : 'POST';
 
     const payload = editingSubscription
@@ -345,7 +344,12 @@ function Subscriptions() {
           <TableBody>
             {subs.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={3 + (showCurrency ? 1 : 0) + (showFrequency ? 1 : 0) + (showPaymentDate ? 1 : 0)} className="text-center text-gray-500">
+                <TableCell
+                  colSpan={
+                    3 + (showCurrency ? 1 : 0) + (showFrequency ? 1 : 0) + (showPaymentDate ? 1 : 0)
+                  }
+                  className="text-center text-gray-500"
+                >
                   No se encontraron suscripciones
                 </TableCell>
               </TableRow>
@@ -353,7 +357,9 @@ function Subscriptions() {
               subs.map((sub) => (
                 <TableRow key={sub.id}>
                   <TableCell>{sub.name}</TableCell>
-                  <TableCell className="text-right">{toNumber(sub.price as ValueLike, 0)}</TableCell>
+                  <TableCell className="text-right">
+                    {toNumber(sub.price as ValueLike, 0)}
+                  </TableCell>
                   {showCurrency && <TableCell>{sub.currency?.shortName ?? '-'}</TableCell>}
                   {showFrequency && <TableCell>{getFrequencyName(sub.frequency)}</TableCell>}
                   {showPaymentDate && <TableCell>{sub.paymentDate ?? 'N/D'}</TableCell>}
@@ -385,7 +391,9 @@ function Subscriptions() {
             <TableFooter>
               <TableRow>
                 <TableCell className="font-medium">Total</TableCell>
-                <TableCell className="text-right font-medium">{toNumber(total as ValueLike, 0)}</TableCell>
+                <TableCell className="text-right font-medium">
+                  {toNumber(total as ValueLike, 0)}
+                </TableCell>
                 <TableCell></TableCell>
                 <TableCell></TableCell>
               </TableRow>
@@ -415,13 +423,10 @@ function Subscriptions() {
           <h2 className="text-lg font-medium mb-4">Suscripciones Mensuales</h2>
           {Object.entries(monthlyCurrencyGroups).map(([currency, subs]) => (
             <div key={`monthly-${currency}`} className="mb-6">
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600 mb-3 px-2">{currency}</h3>
-              <SubscriptionTable
-                subs={subs}
-                title=""
-                showTotal={true}
-                showCurrency={false}
-              />
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600 mb-3 px-2">
+                {currency}
+              </h3>
+              <SubscriptionTable subs={subs} title="" showTotal={true} showCurrency={false} />
             </div>
           ))}
         </div>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from 'react';
 import SafeLogger from '@/utils/SafeLogger';
+import type { BackendUrl } from '@/utils/BackendUrl';
 import dates from '@/utils/dates';
 import LoadingSpinner from '@/components/ui/utils/LoadingSpinner';
 import { InputType } from '@/components/ui/utils/InputType';
@@ -44,7 +45,7 @@ interface Column {
 interface FetchTableProps {
   name: string;
   data?: Row[] | null;
-  url?: string;
+  url?: BackendUrl | string;
   columns: unknown[];
   classes?: string[];
   wrapper?: { classes?: string[] } | null;
@@ -85,56 +86,39 @@ const FetchTable: React.FC<FetchTableProps> = ({
   useEffect(() => {
     if (!url) return;
 
-    SafeLogger.log(`[FetchTable:${name}] Starting fetch for URL:`, url);
-
     const fetchData = async () => {
       setLoading(true);
       setError(null);
       try {
-        SafeLogger.log(`[FetchTable:${name}] Fetching...`);
-        const response = await fetch(url);
-        SafeLogger.log(`[FetchTable:${name}] Response status:`, response.status);
+        const response = await fetch(String(url));
 
         if (!response.ok) {
-          const errorText = `FetchTable request failed for ${url} with status ${response.status}`;
           let responseBody = '';
           try {
             responseBody = await response.text();
-            SafeLogger.log(responseBody);
-          } catch (e) {
+          } catch {
             responseBody = '[Unable to read response body]';
           }
-          SafeLogger.error(errorText, {
-            url,
-            response: { status: response.status },
-            responseBody,
-          });
+          const errorText = `FetchTable request failed for ${url} with status ${response.status}`;
+          SafeLogger.error(errorText, { url, status: response.status, responseBody });
           throw new Error(`${errorText}\n${responseBody}`);
         }
+
         const result = await response.json();
-        SafeLogger.log(`[FetchTable:${name}] Data received:`, result);
 
         if (result && Array.isArray(result.items)) {
-          SafeLogger.log(
-            `[FetchTable:${name}] Setting ${result.items.length} items from result.items`
-          );
           setData(result.items as Row[]);
           onFetch?.(result.items as Row[]);
         } else if (Array.isArray(result)) {
-          SafeLogger.log(`[FetchTable:${name}] Setting ${result.length} items from result array`);
           setData(result as Row[]);
           onFetch?.(result as Row[]);
         } else {
-          SafeLogger.log(`[FetchTable:${name}] Result is not an array, setting empty`);
           setData([]);
           onFetch?.([]);
         }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        SafeLogger.error('FetchTable error', {
-          error: msg,
-          url,
-        });
+        SafeLogger.error('FetchTable error', { error: msg, url });
         setError(msg);
       } finally {
         setLoading(false);
@@ -142,7 +126,7 @@ const FetchTable: React.FC<FetchTableProps> = ({
     };
 
     fetchData();
-  }, [url, name, onFetch]);
+  }, [url, onFetch]);
 
   if (loading)
     return (

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/InputControl.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/InputControl.tsx
@@ -1,135 +1,121 @@
-import React from "react";
-import { InputType } from "@/components/ui/utils/InputType";
-import Picker, { MapperType } from "@/components/ui/utils/Picker";
-import { Input } from "@/components/ui/shadcn/input";
-import { Checkbox } from "@/components/ui/utils/Checkbox";
+import React from 'react';
+import { InputType } from '@/components/ui/utils/InputType';
+import Picker, { MapperType } from '@/components/ui/utils/Picker';
+import { Input } from '@/components/ui/shadcn/input';
+import { Checkbox } from '@/components/ui/utils/Checkbox';
+import type { BackendUrl } from '@/utils/BackendUrl';
 
 export interface Settings {
-    id?: string;
-    type: InputType;
-    description?: string;
-    label?: string;
-    placeholder?: string;
-    className?: string;
-    visible?: boolean;
-    style?: React.CSSProperties;
-    min?: number;
-    endpoint?: string;
-    mapper?: MapperType;
+  id?: string;
+  type: InputType;
+  description?: string;
+  label?: string;
+  placeholder?: string;
+  className?: string;
+  visible?: boolean;
+  style?: React.CSSProperties;
+  min?: number;
+  endpoint?: BackendUrl | string;
+  mapper?: MapperType;
 }
 
 interface InputControlProps {
-    value?: string | number | boolean;
-    settings: Settings;
-    handleValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: string | number | boolean;
+  settings: Settings;
+  handleValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const classesToString = (classes: string[]): string => classes.join(" ");
+const classesToString = (classes: string[]): string => classes.join(' ');
 
 const nullablePropertyResolver = (name: string, property: unknown) => {
-    if (property !== undefined && property !== null) {
-        return { [name]: property } as Record<string, unknown>;
-    }
-    return {} as Record<string, unknown>;
+  if (property !== undefined && property !== null) {
+    return { [name]: property } as Record<string, unknown>;
+  }
+  return {} as Record<string, unknown>;
 };
 
 // Input Components
 
-const IntegerInputControl: React.FC<InputControlProps> = ({
-    settings,
-    value,
-}) => (
-    <Input
-        id={settings.id}
-        type="number"
-        className={classesToString([
-            "form-control",
-            settings.visible ? "visible" : "invisible",
-        ])}
-        step="1"
-        {...nullablePropertyResolver("min", settings.min)}
-        pattern="\d+"
-        title="Ingresar un número entero válido"
-        style={settings.style}
-        defaultValue={value as string | number}
-    />
+const IntegerInputControl: React.FC<InputControlProps> = ({ settings, value }) => (
+  <Input
+    id={settings.id}
+    type="number"
+    className={classesToString(['form-control', settings.visible ? 'visible' : 'invisible'])}
+    step="1"
+    {...nullablePropertyResolver('min', settings.min)}
+    pattern="\d+"
+    title="Ingresar un número entero válido"
+    style={settings.style}
+    defaultValue={value as string | number}
+  />
 );
 
-const DecimalInputControl: React.FC<InputControlProps> = ({
-    settings,
-    value,
-}) => (
-    <Input
-        id={settings.id}
-        type="number"
-        className={classesToString([
-            "form-control",
-            settings.visible ? "visible" : "invisible",
-        ])}
-        {...nullablePropertyResolver("min", settings.min)}
-        step="0.01"
-        pattern="\d+(\.\d{2})?"
-        title="Ingresar un número decimal válido"
-        style={settings.style}
-        defaultValue={value as string | number}
-    />
+const DecimalInputControl: React.FC<InputControlProps> = ({ settings, value }) => (
+  <Input
+    id={settings.id}
+    type="number"
+    className={classesToString(['form-control', settings.visible ? 'visible' : 'invisible'])}
+    {...nullablePropertyResolver('min', settings.min)}
+    step="0.01"
+    pattern="\d+(\.\d{2})?"
+    title="Ingresar un número decimal válido"
+    style={settings.style}
+    defaultValue={value as string | number}
+  />
 );
 
-const BooleanInputControl: React.FC<InputControlProps> = ({
-    settings,
-    value,
-}) => (
-    <div className="mb-2">
-        <Checkbox
-            id={settings.id}
-            className={settings.visible ? "visible" : "invisible"}
-            checked={Boolean(value)}
-            disabled={false}
-        />
-    </div>
+const BooleanInputControl: React.FC<InputControlProps> = ({ settings, value }) => (
+  <div className="mb-2">
+    <Checkbox
+      id={settings.id}
+      className={settings.visible ? 'visible' : 'invisible'}
+      checked={Boolean(value)}
+      disabled={false}
+    />
+  </div>
 );
 
 const DropdownInput: React.FC<InputControlProps> = ({ settings }) => (
-    <Picker
-        id={settings.id ?? ""}
-        url={settings.endpoint || ""}
-        mapper={settings.mapper}
-        // style={settings.style}
-    />
+  <Picker
+    id={settings.id ?? ''}
+    url={settings.endpoint ? String(settings.endpoint) : ''}
+    mapper={settings.mapper}
+    // style={settings.style}
+  />
 );
 
 // Main InputControl Component
 
 const InputControl: React.FC<InputControlProps> = (props) => {
-    const { settings, value, handleValueChange } = props;
+  const { settings, value, handleValueChange } = props;
 
-    switch (settings.type) {
-        case InputType.Integer:
-            return <IntegerInputControl {...props} />;
-        case InputType.Decimal:
-            return <DecimalInputControl {...props} />;
-        case InputType.Boolean:
-            return <BooleanInputControl {...props} />;
-        case InputType.Dropdown:
-            return <DropdownInput {...props} />;
-        default:
-            return (
-                <Input
-                    id={settings.id}
-                    placeholder={settings.placeholder}
-                    type="text"
-                    style={settings.style}
-                    className={classesToString([
-                        settings.className ?? "",
-                        "form-control",
-                        settings.visible ? "visible" : "invisible",
-                    ])}
-                    value={value as string}
-                    onChange={handleValueChange}
-                    required
-                />
-            );
-    }
+  switch (settings.type) {
+    case InputType.Integer:
+      return <IntegerInputControl {...props} />;
+    case InputType.Decimal:
+      return <DecimalInputControl {...props} />;
+    case InputType.Boolean:
+      return <BooleanInputControl {...props} />;
+    case InputType.Dropdown:
+      return <DropdownInput {...props} />;
+    default:
+      return (
+        <Input
+          id={settings.id}
+          placeholder={settings.placeholder}
+          type="text"
+          style={settings.style}
+          className={classesToString([
+            settings.className ?? '',
+            'form-control',
+            settings.visible ? 'visible' : 'invisible',
+          ])}
+          value={value as string}
+          onChange={handleValueChange}
+          required
+        />
+      );
+  }
 };
 
 export default InputControl;

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
@@ -13,6 +13,7 @@ import { InputType } from '@/components/ui/utils/InputType';
 import { fetchData } from '@/components/data/fetchData';
 import { fetchPaginatedData } from '@/components/data/fetchPaginatedData';
 import { handleRequest } from '@/components/data/handleRequest';
+import type { BackendUrl } from '@/utils/BackendUrl';
 import {
   Table,
   TableBody,
@@ -29,7 +30,7 @@ import { Checkbox } from '@/components/ui/utils/Checkbox';
 
 // Type Definitions
 interface Admin {
-  endpoint: string;
+  endpoint: BackendUrl | string;
   key?:
     | string
     | string[]
@@ -49,7 +50,7 @@ export interface Column {
   class?: string;
   label?: string;
   placeholder?: string;
-  endpoint?: string;
+  endpoint?: BackendUrl | string;
   header?: {
     classes?: string | string[];
     style?: React.CSSProperties;
@@ -82,7 +83,7 @@ export interface ConditionalClass {
 export interface PaginatedTableProps {
   name: string;
   data?: Data | null;
-  url?: string;
+  url?: BackendUrl | string;
   admin?: Admin;
   rowCount?: number;
   columns: Column[];
@@ -339,14 +340,18 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
     return (
       <TableRow>
         {header ? (
-          <TableHead className={'w-[100px]'} colSpan={columnCount}>
-            <AddButton />
-            <DeleteButton />
+          <TableHead colSpan={columnCount}>
+            <div className={cn(['flex', 'justify-end'])}>
+              <AddButton />
+              <DeleteButton />
+            </div>
           </TableHead>
         ) : (
           <TableCell colSpan={columnCount}>
-            <AddButton />
-            <DeleteButton />
+            <div className={cn(['flex', 'justify-end'])}>
+              <AddButton />
+              <DeleteButton />
+            </div>
           </TableCell>
         )}
       </TableRow>
@@ -437,7 +442,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
                     id={String(record.id)}
                     checked={Boolean(record.isSelected)}
                     onChange={() => handleRowCheckChange(record.id ?? index)}
-                      className='flex items-center'
+                    className="flex items-center"
                   />
                 </TableCell>
               )}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Picker.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Picker.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils';
 import React, { useState, useEffect, useCallback } from 'react';
 import SafeLogger from '@/utils/SafeLogger';
+import type { BackendUrl } from '@/utils/BackendUrl';
 
 // Define types for the props
 type MapperObject = {
@@ -14,7 +15,7 @@ export type MapperType = ((record: unknown) => string | number) | MapperObject;
 interface PickerProps {
   id: string;
   value?: string | number;
-  url?: string;
+  url?: BackendUrl | string;
   data?: unknown[];
   mapper?: MapperType;
   onChange?: ((event: { value: string | number }) => void) | ((picker: { value: string }) => void);
@@ -74,7 +75,7 @@ const Picker: React.FC<PickerProps> = ({
   const fetchData = useCallback(async () => {
     if (!url) return;
     try {
-      const response = await fetch(url);
+      const response = await fetch(String(url));
       const responseData: unknown = await response.json();
       if (Array.isArray(responseData)) {
         setInternalData(responseData);
@@ -100,9 +101,14 @@ const Picker: React.FC<PickerProps> = ({
       id={id}
       value={value?.toString() ?? ''}
       onChange={(e) => onPickerChange(e.target.value)}
-      className={cn('h-9 rounded-md border border-gray-300 bg-white px-3 py-1 text-sm text-gray-950 shadow-sm outline-none focus:border-gray-950 focus:ring-2 focus:ring-gray-950/20 dark:bg-gray-950 dark:text-gray-50 dark:border-gray-700', className)}
+      className={cn(
+        'h-9 rounded-md border border-gray-300 bg-white px-3 py-1 text-sm text-gray-950 shadow-sm outline-none focus:border-gray-950 focus:ring-2 focus:ring-gray-950/20 dark:bg-gray-950 dark:text-gray-50 dark:border-gray-700',
+        className
+      )}
     >
-      <option value="" disabled className="text-gray-500">{placeholder ?? 'Select an item'}</option>
+      <option value="" disabled className="text-gray-500">
+        {placeholder ?? 'Select an item'}
+      </option>
       {internalData.map((item) => {
         const recordId = getRecordId(item);
         const label = getRecordLabel(item);

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Uploader.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Uploader.tsx
@@ -1,118 +1,112 @@
-import { useState, useRef } from "react";
-import { useFetcher } from "react-router";
-import {
-    Toast,
-    ToastContainer,
-    ToastHeader,
-    ToastBody,
-} from "@/components/ui/utils/Toast";
-import ActionButton, { ButtonType } from "@/components/ui/utils/ActionButton";
-import SafeLogger from "../../../utils/SafeLogger";
+import { useState, useRef } from 'react';
+import { useFetcher } from 'react-router';
+import type { BackendUrl } from '@/utils/BackendUrl';
+import { Toast, ToastContainer, ToastHeader, ToastBody } from '@/components/ui/utils/Toast';
+import ActionButton, { ButtonType } from '@/components/ui/utils/ActionButton';
+import SafeLogger from '../../../utils/SafeLogger';
 
 interface UploaderProps {
-    url: string;
-    extensions: string[];
-    onSuccess?: () => void;
-    onError?: () => void;
+  url: BackendUrl | string;
+  extensions: string[];
+  onSuccess?: () => void;
+  onError?: () => void;
 }
 
 const Uploader = ({ url, extensions, onSuccess, onError }: UploaderProps) => {
-    const [showToast, setShowToast] = useState<boolean>(false); // State for controlling toast visibility
-    const [toastMessage, setToastMessage] = useState<string>(""); // Message for the toast
-    const [toastType, setToastType] = useState<"success" | "error">("success"); // Toast type
-    type UploadResponse = {
-        success?: boolean;
-        error?: string;
-        [key: string]: unknown;
-    } | null;
-    const fetcher = useFetcher<UploadResponse>();
-    const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [showToast, setShowToast] = useState<boolean>(false); // State for controlling toast visibility
+  const [toastMessage, setToastMessage] = useState<string>(''); // Message for the toast
+  const [toastType, setToastType] = useState<'success' | 'error'>('success'); // Toast type
+  type UploadResponse = {
+    success?: boolean;
+    error?: string;
+    [key: string]: unknown;
+  } | null;
+  const fetcher = useFetcher<UploadResponse>();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-    const uploadFile = () => {
-        const fileInput = fileInputRef.current;
-        const file = fileInput?.files?.[0];
+  const uploadFile = () => {
+    const fileInput = fileInputRef.current;
+    const file = fileInput?.files?.[0];
 
-        if (file) {
-            const formData = new FormData();
-            formData.append("file", file);
+    if (file) {
+      const formData = new FormData();
+      formData.append('file', file);
 
-            SafeLogger.log("URL", url);
+      SafeLogger.log('URL', url);
 
-            fetcher.submit(formData, {
-                method: "post",
-                action: url, // URL for the upload action
-                encType: "multipart/form-data",
-            });
-        } else {
-            setToastMessage("No file selected.");
-            setToastType("error");
-            setShowToast(true); // Show the toast
-        }
-    };
-
-    if (fetcher.state === "submitting") {
-        setToastMessage("");
+      fetcher.submit(formData, {
+        method: 'post',
+        action: String(url), // URL for the upload action
+        encType: 'multipart/form-data',
+      });
+    } else {
+      setToastMessage('No file selected.');
+      setToastType('error');
+      setShowToast(true); // Show the toast
     }
+  };
 
-    if (fetcher.data && fetcher.data.success) {
-        fileInputRef.current!.value = "";
-        if (onSuccess) onSuccess();
-        setToastMessage("File uploaded successfully!");
-        setToastType("success");
-        setShowToast(true); // Show success toast
-    } else if (fetcher.data && fetcher.data.error) {
-        setToastMessage(fetcher.data.error ?? String(fetcher.data));
-        if (onError) onError();
-        setToastMessage(fetcher.data.error || "File upload failed.");
-        setToastType("error");
-        setShowToast(true); // Show error toast
-    }
+  if (fetcher.state === 'submitting') {
+    setToastMessage('');
+  }
 
-    return (
-        <>
-            <div className="container">
-                <form className="row">
-                    <div className="input-group">
-                        <input
-                            ref={fileInputRef}
-                            type="file"
-                            className="form-control"
-                            accept={extensions.join(",")}
-                            aria-describedby="inputGroupFileAddon04"
-                            aria-label="Subir"
-                        />
-                        <ActionButton
-                            text={"Subir"}
-                            //variant={OUTLINE_VARIANT.WARNING}
-                            type={ButtonType.None}
-                            //classes={["btn", "btn-outline-secondary"]}
-                            action={uploadFile}
-                            disabled={false}
-                        />
-                    </div>
-                </form>
-            </div>
+  if (fetcher.data && fetcher.data.success) {
+    fileInputRef.current!.value = '';
+    if (onSuccess) onSuccess();
+    setToastMessage('File uploaded successfully!');
+    setToastType('success');
+    setShowToast(true); // Show success toast
+  } else if (fetcher.data && fetcher.data.error) {
+    setToastMessage(fetcher.data.error ?? String(fetcher.data));
+    if (onError) onError();
+    setToastMessage(fetcher.data.error || 'File upload failed.');
+    setToastType('error');
+    setShowToast(true); // Show error toast
+  }
 
-            {/* Toast Component */}
-            <ToastContainer position="top-end" className="p-3">
-                <Toast
-                    onClose={() => setShowToast(false)}
-                    show={showToast}
-                    delay={3000}
-                    autohide
-                    bg={toastType === "success" ? "success" : "danger"} // Change color based on type
-                >
-                    <ToastHeader>
-                        <strong className="me-auto">
-                            {toastType === "success" ? "Success" : "Error"}
-                        </strong>
-                        <small>Just now</small>
-                    </ToastHeader>
-                    <ToastBody>{toastMessage}</ToastBody>
-                </Toast>
-            </ToastContainer>
-        </>
-    );
+  return (
+    <>
+      <div className="container">
+        <form className="row">
+          <div className="input-group">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="form-control"
+              accept={extensions.join(',')}
+              aria-describedby="inputGroupFileAddon04"
+              aria-label="Subir"
+            />
+            <ActionButton
+              text={'Subir'}
+              //variant={OUTLINE_VARIANT.WARNING}
+              type={ButtonType.None}
+              //classes={["btn", "btn-outline-secondary"]}
+              action={uploadFile}
+              disabled={false}
+            />
+          </div>
+        </form>
+      </div>
+
+      {/* Toast Component */}
+      <ToastContainer position="top-end" className="p-3">
+        <Toast
+          onClose={() => setShowToast(false)}
+          show={showToast}
+          delay={3000}
+          autohide
+          bg={toastType === 'success' ? 'success' : 'danger'} // Change color based on type
+        >
+          <ToastHeader>
+            <strong className="me-auto">{toastType === 'success' ? 'Success' : 'Error'}</strong>
+            <small>Just now</small>
+          </ToastHeader>
+          <ToastBody>{toastMessage}</ToastBody>
+        </Toast>
+      </ToastContainer>
+    </>
+  );
 };
 
 export default Uploader;

--- a/FinanceFrontEnd/FinanceApp/app/data/base/BasePaginatedQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/base/BasePaginatedQuery.ts
@@ -1,46 +1,47 @@
-import axios from "axios";
-import { Agent } from "https";
-import { BaseQuery, QueryEndpoints } from "./BaseQuery";
-import serverLogger from "@/utils/logger.server";
+import axios from 'axios';
+import { Agent } from 'https';
+import { BaseQuery, QueryEndpoints } from './BaseQuery';
+import serverLogger from '@/utils/logger.server';
+import { BackendUrl } from '@/utils/BackendUrl';
 
 export interface PaginatedQueryEndpoints extends QueryEndpoints {
-    getPaginated: string;
+  getPaginated: string | BackendUrl;
 }
 
 export interface PaginatedQueryFilters {
-    From?: string;
-    To?: string;
-    Page: number;
-    PageSize: number;
+  From?: string;
+  To?: string;
+  Page: number;
+  PageSize: number;
 }
 
 export class BasePaginatedQuery extends BaseQuery {
-    protected getPaginatedEndpoint: string;
+  protected getPaginatedEndpoint: string | BackendUrl;
 
-    constructor(
-        httpsAgent: Agent,
-        accessToken: string,
-        endpoints: PaginatedQueryEndpoints
-    ) {
-        super(httpsAgent, accessToken, endpoints);
+  constructor(httpsAgent: Agent, accessToken: string, endpoints: PaginatedQueryEndpoints) {
+    super(httpsAgent, accessToken, endpoints);
 
-        this.getPaginatedEndpoint = endpoints.getPaginated;
+    this.getPaginatedEndpoint = endpoints.getPaginated;
+  }
+
+  async getPaginated<T extends PaginatedQueryFilters>(filters: T) {
+    try {
+      const endpointUrl =
+        this.getPaginatedEndpoint instanceof BackendUrl
+          ? this.getPaginatedEndpoint.toRaw()
+          : String(this.getPaginatedEndpoint);
+      const response = await axios.get(endpointUrl, {
+        params: filters,
+        httpsAgent: this.httpsAgent,
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+        },
+      });
+
+      return response.data;
+    } catch (error) {
+      serverLogger.error('Error:', error);
+      throw error;
     }
-
-    async getPaginated<T extends PaginatedQueryFilters>(filters: T) {
-        try {
-            const response = await axios.get(this.getPaginatedEndpoint, {
-                params: filters,
-                httpsAgent: this.httpsAgent,
-                headers: {
-                    Authorization: `Bearer ${this.accessToken}`,
-                },
-            });
-
-            return response.data;
-        } catch (error) {
-            serverLogger.error("Error:", error);
-            throw error;
-        }
-    }
+  }
 }

--- a/FinanceFrontEnd/FinanceApp/app/data/base/BaseQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/base/BaseQuery.ts
@@ -1,42 +1,43 @@
-import axios from "axios";
-import { Agent } from "https";
-import serverLogger from "@/utils/logger.server";
+import axios from 'axios';
+import { Agent } from 'https';
+import serverLogger from '@/utils/logger.server';
+import { BackendUrl } from '@/utils/BackendUrl';
 
 export interface QueryEndpoints {
-    get: string;
+  get: BackendUrl | string;
 }
 
 export class BaseQuery {
-    protected httpsAgent: Agent;
-    protected getEndpoint: string;
-    protected accessToken: string;
+  protected httpsAgent: Agent;
+  protected getEndpoint: string | BackendUrl;
+  protected accessToken: string;
 
-    constructor(
-        httpsAgent: Agent,
-        accessToken: string,
-        endpoints: QueryEndpoints
-    ) {
-        this.httpsAgent = httpsAgent;
-        this.getEndpoint = endpoints.get;
-        this.accessToken = accessToken;
+  constructor(httpsAgent: Agent, accessToken: string, endpoints: QueryEndpoints) {
+    this.httpsAgent = httpsAgent;
+    this.getEndpoint = endpoints.get;
+    this.accessToken = accessToken;
+  }
+
+  async get<TFilter>(filters?: TFilter) {
+    try {
+      const config = {
+        params: filters ?? {},
+        httpsAgent: this.httpsAgent,
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+        },
+      };
+      const endpointUrl =
+        this.getEndpoint instanceof BackendUrl
+          ? this.getEndpoint.toRaw()
+          : String(this.getEndpoint);
+      const response = await axios.get(endpointUrl, config);
+
+      return response.data;
+    } catch (error) {
+      serverLogger.error('this.getEndpoint:', this.getEndpoint);
+      serverLogger.error('Error:', error);
+      throw error;
     }
-
-    async get<TFilter>(filters?: TFilter) {
-        try {
-            const config = {
-                params: filters ?? {},
-                httpsAgent: this.httpsAgent,
-                headers: {
-                    Authorization: `Bearer ${this.accessToken}`,
-                },
-            };
-            const response = await axios.get(this.getEndpoint, config);
-
-            return response.data;
-        } catch (error) {
-            serverLogger.error("this.getEndpoint:", this.getEndpoint);
-            serverLogger.error("Error:", error);
-            throw error;
-        }
-    }
+  }
 }

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/CreditCardStatementQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/CreditCardStatementQuery.ts
@@ -1,8 +1,8 @@
-import axios from "axios";
-import urls from "@/utils/urls";
-import { Agent } from "https";
-import { BaseQuery } from "../base/BaseQuery";
-import serverLogger from "@/utils/logger.server";
+import axios from 'axios';
+import urls from '@/utils/urls';
+import { Agent } from 'https';
+import { BaseQuery } from '../base/BaseQuery';
+import serverLogger from '@/utils/logger.server';
 
 export class CreditCardStatementQuery extends BaseQuery {
   constructor(httpsAgent: Agent, accessToken: string) {
@@ -19,10 +19,10 @@ export class CreditCardStatementQuery extends BaseQuery {
           Authorization: `Bearer ${this.accessToken}`,
         },
       };
-      const response = await axios.get(urls.creditCardStatements.latest, config);
+      const response = await axios.get(urls.creditCardStatements.latest.toRaw(), config);
       return response.data;
     } catch (error) {
-      serverLogger.error("Error fetching latest statements:", error);
+      serverLogger.error('Error fetching latest statements:', error);
       throw error;
     }
   }

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/CurrencyExchangeRatesQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/CurrencyExchangeRatesQuery.ts
@@ -1,11 +1,14 @@
-import urls from "@/utils/urls";
-import { Agent } from "https";
-import { BaseQuery } from "../base/BaseQuery";
+import urls from '@/utils/urls';
+import { Agent } from 'https';
+import { BaseQuery } from '../base/BaseQuery';
 
 export class CurrencyExchangeRatesQuery extends BaseQuery {
   constructor(httpsAgent: Agent, accessToken: string) {
     super(httpsAgent, accessToken, {
-      get: `${urls.currencyExchangeRates.latestByShortName}/USDTC/latest`,
+      // TODO: 'USDTC' is hardcoded here — consider making this configurable or
+      // deriving it from a user/app setting so the dashboard CC dollar conversion
+      // rate isn't silently broken if the short name ever changes.
+      get: urls.currencyExchangeRates.latestByShortName.append('/USDTC/latest'),
     });
   }
 }

--- a/FinanceFrontEnd/FinanceApp/app/root.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/root.tsx
@@ -52,14 +52,17 @@ export const loader: LoaderFunction = async ({ request }) => {
   };
 };
 
-type RootLoaderData = { isAuthenticated: boolean; otel: { enabled: boolean; httpEndpoint: string } };
+type RootLoaderData = {
+  isAuthenticated: boolean;
+  otel: { enabled: boolean; httpEndpoint: string };
+};
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const data = useRouteLoaderData<RootLoaderData>('root');
   const otel = data?.otel ?? { enabled: false, httpEndpoint: 'http://localhost:4318' };
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -124,7 +127,7 @@ export function ErrorBoundary() {
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <title>{(`${error.status ?? ''} ${error.statusText ?? ''}`).trim()}</title>
+          <title>{`${error.status ?? ''} ${error.statusText ?? ''}`.trim()}</title>
           <Meta />
           <Links />
         </head>

--- a/FinanceFrontEnd/FinanceApp/app/routes/incomes.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/incomes.tsx
@@ -1,77 +1,73 @@
-import { LoaderFunctionArgs } from "react-router";
-import { getBackendClient } from "@/data/getBackendClient";
-import urls from "@/utils/urls";
-import Incomes from "@/components/ui/Incomes/Index";
-import CommonUtils from "@/utils/common";
-import { requireAuth } from "@/services/auth/session.server";
+import { LoaderFunctionArgs } from 'react-router';
+import { getBackendClient } from '@/data/getBackendClient';
+import urls from '@/utils/urls';
+import Incomes from '@/components/ui/Incomes/Index';
+import { requireAuth } from '@/services/auth/session.server';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 100;
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-    // Get the session cookie and user from session storage (same pattern as dashboard)
-    const user = await requireAuth(request);
+  // Get the session cookie and user from session storage (same pattern as dashboard)
+  const user = await requireAuth(request);
 
-    if (!user.accessToken) {
-        throw new Error("No access token available");
-    }
+  if (!user.accessToken) {
+    throw new Error('No access token available');
+  }
 
-    const url = new URL(request.url);
-    const page = Number(url.searchParams.get("page") ?? DEFAULT_PAGE);
-    const pageSize = Number(
-        url.searchParams.get("pageSize") ?? DEFAULT_PAGE_SIZE
-    );
-    let selectedBankId = url.searchParams.get("bankId") ?? undefined;
-    let selectedCurrencyId = url.searchParams.get("currencyId") ?? undefined;
+  const url = new URL(request.url);
+  const page = Number(url.searchParams.get('page') ?? DEFAULT_PAGE);
+  const pageSize = Number(url.searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE);
+  let selectedBankId = url.searchParams.get('bankId') ?? undefined;
+  let selectedCurrencyId = url.searchParams.get('currencyId') ?? undefined;
 
-    const client = await getBackendClient(user.accessToken!);
+  const client = await getBackendClient(user.accessToken!);
 
-    const getDataPromise = (bankId: string, currencyId: string) => {
-        const url = `${urls.incomes.paginated}?${CommonUtils.Params({
-            Page: page,
-            PageSize: pageSize,
-            BankId: bankId,
-            CurrencyId: currencyId,
-        })}`;
-        return client.get(url);
-    };
+  const getDataPromise = (bankId: string, currencyId: string) => {
+    const url = urls.incomes.paginated
+      .with({
+        Page: page,
+        PageSize: pageSize,
+        BankId: bankId,
+        CurrencyId: currencyId,
+      })
+      .toRaw();
+    return client.get(url);
+  };
 
-    const queries = [
-        await client.GetBanksQuery().get(),
-        await client.GetCurrenciesQuery().get(),
-    ];
+  const queries = [await client.GetBanksQuery().get(), await client.GetCurrenciesQuery().get()];
 
-    if (selectedBankId && selectedCurrencyId) {
-        queries.push(getDataPromise(selectedBankId, selectedCurrencyId));
-    }
+  if (selectedBankId && selectedCurrencyId) {
+    queries.push(getDataPromise(selectedBankId, selectedCurrencyId));
+  }
 
-    const results = await Promise.all(queries);
-    const banks = results[0];
-    const currencies = results[1];
-    let data = results[2] ?? null;
+  const results = await Promise.all(queries);
+  const banks = results[0];
+  const currencies = results[1];
+  let data = results[2] ?? null;
 
-    if (!data && banks?.length > 0 && currencies?.length > 0) {
-        selectedBankId ??= banks[0].id;
-        selectedCurrencyId ??= currencies[0].id;
-        data = await getDataPromise(selectedBankId!, selectedCurrencyId!);
-    }
+  if (!data && banks?.length > 0 && currencies?.length > 0) {
+    selectedBankId ??= banks[0].id;
+    selectedCurrencyId ??= currencies[0].id;
+    data = await getDataPromise(selectedBankId!, selectedCurrencyId!);
+  }
 
-    return {
-        banks,
-        currencies,
-        data: data ?? [],
-        bankId: selectedBankId,
-        currencyId: selectedCurrencyId,
-    };
+  return {
+    banks,
+    currencies,
+    data: data ?? [],
+    bankId: selectedBankId,
+    currencyId: selectedCurrencyId,
+  };
 };
 
 export const meta = () => {
-    return [
-        {
-            title: "Ingresos",
-            description: "",
-        },
-    ];
+  return [
+    {
+      title: 'Ingresos',
+      description: '',
+    },
+  ];
 };
 
 export default Incomes;

--- a/FinanceFrontEnd/FinanceApp/app/utils/BackendUrl.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/BackendUrl.ts
@@ -1,0 +1,53 @@
+/**
+ * Wraps a backend URL. Call .with(params) to attach query params, .append(path) to extend the path.
+ * toString() returns the authenticated /api/proxy?path=... URL — pass directly via String().
+ */
+export class BackendUrl {
+  constructor(
+    private readonly raw: string,
+    private readonly _params?: Record<string, unknown>
+  ) {}
+
+  /** Returns a new BackendUrl with additional query parameters merged in. */
+  with(params: Record<string, unknown>): BackendUrl {
+    return new BackendUrl(this.raw, { ...this._params, ...params });
+  }
+
+  /** Returns a new BackendUrl with the given path segment appended. */
+  append(path: string): BackendUrl {
+    return new BackendUrl(this.raw + path, this._params);
+  }
+
+  /**
+   * Returns the raw backend URL with params appended as a query string.
+   * Use this for server-side HTTP calls (axios, fetch with full URL) that
+   * already provide their own Authorization header directly to the backend.
+   */
+  toRaw(): string {
+    if (!this._params) return this.raw;
+    const search = Object.entries(this._params)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+      .join('&');
+    const sep = this.raw.includes('?') ? '&' : '?';
+    return `${this.raw}${sep}${search}`;
+  }
+
+  toString(): string {
+    let path = this.raw;
+    if (this.raw.startsWith('http')) {
+      try {
+        const u = new URL(this.raw);
+        path = u.pathname + (u.search || '');
+      } catch {
+        // keep raw as path
+      }
+    }
+    const search = this._params
+      ? '&' +
+        Object.entries(this._params)
+          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+          .join('&')
+      : '';
+    return `/api/proxy?path=${encodeURIComponent(path)}${search}`;
+  }
+}

--- a/FinanceFrontEnd/FinanceApp/app/utils/urlTreatment.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/urlTreatment.ts
@@ -1,35 +1,34 @@
-export const parseUrl = (
-    url: string
-): {
-    queryParams: {
-        [k: string]: string;
-    };
-    baseUrl: string;
-} => {
-    let urlObject: URL;
-    try {
-        urlObject = new URL(url);
-    } catch (e) {
-        // If url is relative (starts with /), provide a base using the current origin in the browser
-        // or fallback to http://localhost for environments without `window`.
-        const base =
-            typeof window !== "undefined"
-                ? window.location.origin
-                : "http://localhost";
-        urlObject = new URL(url, base);
-    }
+// TODO: Remove once BackendUrl is confirmed to be provide similar functionality
 
-    const queryParams = Object.fromEntries(urlObject.searchParams.entries());
-    const baseUrl = urlObject.origin + urlObject.pathname + urlObject.hash;
-    return { queryParams, baseUrl };
+export const parseUrl = (
+  url: string
+): {
+  queryParams: {
+    [k: string]: string;
+  };
+  baseUrl: string;
+} => {
+  let urlObject: URL;
+  try {
+    urlObject = new URL(url);
+  } catch (e) {
+    // If url is relative (starts with /), provide a base using the current origin in the browser
+    // or fallback to http://localhost for environments without `window`.
+    const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    urlObject = new URL(url, base);
+  }
+
+  const queryParams = Object.fromEntries(urlObject.searchParams.entries());
+  const baseUrl = urlObject.origin + urlObject.pathname + urlObject.hash;
+  return { queryParams, baseUrl };
 };
 
 export const objectToUrlParams = (params: Record<string, string | number>) => {
-    const urlSearchParams = new URLSearchParams();
-    for (const key in params) {
-        if (Object.hasOwn(params, key)) {
-            urlSearchParams.append(key, params[key].toString());
-        }
+  const urlSearchParams = new URLSearchParams();
+  for (const key in params) {
+    if (Object.hasOwn(params, key)) {
+      urlSearchParams.append(key, params[key].toString());
     }
-    return urlSearchParams.toString();
+  }
+  return urlSearchParams.toString();
 };

--- a/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
@@ -1,10 +1,12 @@
+import { BackendUrl } from '@/utils/BackendUrl';
+
 // Configuration for both local development and containerized environments
 const getBaseUrl = () => {
   // Check if we're on the client side
   if (typeof window !== 'undefined') {
     // Client-side: determine based on current hostname
     const hostname = window.location.hostname;
-    
+
     if (hostname === 'localhost' || hostname === '127.0.0.1') {
       // Local development
       return 'http://localhost:5000';
@@ -14,13 +16,13 @@ const getBaseUrl = () => {
       return `http://${hostname}:5000`;
     }
   }
-  
+
   // Server-side: use environment variable API_URL if available
   // This is critical for container environments where localhost refers to the container itself
   if (process.env.API_URL) {
     return process.env.API_URL;
   }
-  
+
   // Fallback for local development without environment variable
   return 'http://localhost:5000';
 };
@@ -31,125 +33,196 @@ const getDebitsBaseUrl = () => `${getApiBaseUrl()}/debits`;
 
 const urls = {
   appModules: {
-    get endpoint() { return `${getApiBaseUrl()}/app-modules/`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/app-modules/`);
+    },
   },
   banks: {
-    get endpoint() { return `${getApiBaseUrl()}/banks/`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/banks/`);
+    },
   },
   currencies: {
-    get endpoint() { return `${getApiBaseUrl()}/currencies/`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/currencies/`);
+    },
   },
   currencyExchangeRates: {
-    get endpoint() { return `${getApiBaseUrl()}/currencies/exchange-rates`; },
-    get latest() { return `${getApiBaseUrl()}/currencies/exchange-rates/latest`; },
-    get paginated() { return `${getApiBaseUrl()}/currencies/exchange-rates/paginated`; },
-    get latestByShortName() { return `${getApiBaseUrl()}/currencies/exchange-rates`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/currencies/exchange-rates`);
+    },
+    get latest() {
+      return new BackendUrl(`${getApiBaseUrl()}/currencies/exchange-rates/latest`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/currencies/exchange-rates/paginated`);
+    },
+    get latestByShortName() {
+      return new BackendUrl(`${getApiBaseUrl()}/currencies/exchange-rates`);
+    },
   },
   creditCards: {
-    get get() { return `${getApiBaseUrl()}/credit-cards/`; },
+    get get() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-cards/`);
+    },
   },
   creditCardTransactions: {
-    get endpoint() { return `${getApiBaseUrl()}/credit-card-transactions`; },
-    get latest() { return `${getApiBaseUrl()}/credit-card-transactions/latest`; },
-    get paginated() { return `${getApiBaseUrl()}/credit-card-transactions/paginated`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-transactions`);
+    },
+    get latest() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-transactions/latest`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-transactions/paginated`);
+    },
   },
   creditCardStatements: {
-    get endpoint() { return `${getApiBaseUrl()}/credit-card-statements`; },
-    get latest() { return `${getApiBaseUrl()}/credit-card-statements/latest`; },
-    get paginated() { return `${getApiBaseUrl()}/credit-card-statements/paginated`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements`);
+    },
+    get latest() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements/latest`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements/paginated`);
+    },
   },
   creditCardPayments: {
-    get endpoint() { return `${getApiBaseUrl()}/credit-card-payments`; },
-    get latest() { return `${getApiBaseUrl()}/credit-card-payments/latest`; },
-    get paginated() { return `${getApiBaseUrl()}/credit-card-payments/paginated`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-payments`);
+    },
+    get latest() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-payments/latest`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-payments/paginated`);
+    },
   },
   // Keep old creditCardMovements for backward compatibility, but point to statement transactions for dashboard
   creditCardMovements: {
-    get endpoint() { return `${getApiBaseUrl()}/credit-card-statement-transactions`; },
-    get latest() { return `${getApiBaseUrl()}/credit-card-statement-transactions/latest`; },
-    get paginated() { return `${getApiBaseUrl()}/credit-card-statement-transactions/paginated`; },
-    get upload() { return `${getApiBaseUrl()}/credit-card-transactions/upload`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statement-transactions`);
+    },
+    get latest() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statement-transactions/latest`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statement-transactions/paginated`);
+    },
+    get upload() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-transactions/upload`);
+    },
   },
   debits: {
     monthly: {
-      get endpoint() { return `${getDebitsBaseUrl()}/monthly/`; },
-      get paginated() { return `${getDebitsBaseUrl()}/monthly/paginated`; },
-      get latest() { return `${getDebitsBaseUrl()}/monthly/latest`; },
+      get endpoint() {
+        return new BackendUrl(`${getDebitsBaseUrl()}/monthly/`);
+      },
+      get paginated() {
+        return new BackendUrl(`${getDebitsBaseUrl()}/monthly/paginated`);
+      },
+      get latest() {
+        return new BackendUrl(`${getDebitsBaseUrl()}/monthly/latest`);
+      },
     },
     annual: {
-      get endpoint() { return `${getDebitsBaseUrl()}/annual/`; },
-      get paginated() { return `${getDebitsBaseUrl()}/annual/paginated`; },
-      get latest() { return `${getDebitsBaseUrl()}/annual/latest`; },
+      get endpoint() {
+        return new BackendUrl(`${getDebitsBaseUrl()}/annual/`);
+      },
+      get paginated() {
+        return new BackendUrl(`${getDebitsBaseUrl()}/annual/paginated`);
+      },
+      get latest() {
+        return new BackendUrl(`${getDebitsBaseUrl()}/annual/latest`);
+      },
     },
   },
   debitOrigins: {
-    get endpoint() { return `${getApiBaseUrl()}/debit-origins`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/debit-origins`);
+    },
   },
   frequencies: {
-    get endpoint() { return `${getApiBaseUrl()}/frequencies/`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/frequencies/`);
+    },
   },
   funds: {
-    get endpoint() { return `${getApiBaseUrl()}/funds/`; },
-    get upload() { return `${getApiBaseUrl()}/funds/upload`; },
-    get paginated() { return `${getApiBaseUrl()}/funds/paginated`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/funds/`);
+    },
+    get upload() {
+      return new BackendUrl(`${getApiBaseUrl()}/funds/upload`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/funds/paginated`);
+    },
   },
   incomes: {
-    get endpoint() { return `${getApiBaseUrl()}/incomes/`; },
-    get upload() { return `${getApiBaseUrl()}/incomes/upload`; },
-    get paginated() { return `${getApiBaseUrl()}/incomes/paginated`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/incomes/`);
+    },
+    get upload() {
+      return new BackendUrl(`${getApiBaseUrl()}/incomes/upload`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/incomes/paginated`);
+    },
   },
   iolInvestments: {
-    get endpoint() { return `${getApiBaseUrl()}/iol-investment/`; },
-    get upload() { return `${getApiBaseUrl()}/iol-investment/upload`; },
-    get paginated() { return `${getApiBaseUrl()}/iol-investment/paginated`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/iol-investment/`);
+    },
+    get upload() {
+      return new BackendUrl(`${getApiBaseUrl()}/iol-investment/upload`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/iol-investment/paginated`);
+    },
   },
   iolInvestmentAssets: {
-    get endpoint() { return `${getApiBaseUrl()}/iol-investment-asset/`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/iol-investment-asset/`);
+    },
   },
   iolInvestmentAssetTypes: {
-    get endpoint() { return `${getApiBaseUrl()}/iol-investment-asset-type/`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/iol-investment-asset-type/`);
+    },
   },
   movements: {
-    get endpoint() { return `${getApiBaseUrl()}/movements/`; },
-    get paginated() { return `${getApiBaseUrl()}/movements/paginated`; },
-    get upload() { return `${getApiBaseUrl()}/movements/upload`; },
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/movements/`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/movements/paginated`);
+    },
+    get upload() {
+      return new BackendUrl(`${getApiBaseUrl()}/movements/upload`);
+    },
   },
   summary: {
-    get currentFunds() { return `${getApiBaseUrl()}/summary/currentFunds`; },
-    get totalExpenses() { return `${getApiBaseUrl()}/summary/totalExpenses`; },
-    get currentInvestments() { return `${getApiBaseUrl()}/summary/currentInvestments`; },
-    get general() { return `${getApiBaseUrl()}/summary/general`; },
+    get currentFunds() {
+      return new BackendUrl(`${getApiBaseUrl()}/summary/currentFunds`);
+    },
+    get totalExpenses() {
+      return new BackendUrl(`${getApiBaseUrl()}/summary/totalExpenses`);
+    },
+    get currentInvestments() {
+      return new BackendUrl(`${getApiBaseUrl()}/summary/currentInvestments`);
+    },
+    get general() {
+      return new BackendUrl(`${getApiBaseUrl()}/summary/general`);
+    },
   },
   subscriptions: {
-    get endpoint() { return `${getApiBaseUrl()}/subscriptions/`; },
-    get paginated() { return `${getApiBaseUrl()}/subscriptions/paginated`; },
-  },
-
-  /**
-   * Returns a proxy URL for a backend API path and optional params object.
-   * Example: urls.proxy('/summary/general', { DailyUse: true })
-   *
-   * Accepts a full backend URL or a path, but always extracts just the path for the proxy.
-   */
-  proxy: (urlOrPath: string, params?: Record<string, unknown>) => {
-    // If urlOrPath is a full URL, extract the path and search
-    let path = urlOrPath;
-    try {
-      if (urlOrPath.startsWith('http')) {
-        const u = new URL(urlOrPath);
-        path = u.pathname + (u.search || '');
-      }
-    } catch {
-      // ignore invalid URL and treat input as a path
-    }
-
-    const search = params
-      ? '&' +
-        Object.entries(params)
-          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
-          .join('&')
-      : '';
-    return `/api/proxy?path=${encodeURIComponent(path)}${search}`;
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/subscriptions/`);
+    },
+    get paginated() {
+      return new BackendUrl(`${getApiBaseUrl()}/subscriptions/paginated`);
+    },
   },
 };
 


### PR DESCRIPTION
# Why
All backend URLs in the frontend were plain strings. This meant client-side code (components using `fetch`) and server-side code (loaders using `axios`) both received raw backend URLs, making it easy to accidentally expose the backend directly to the browser or send a proxy URL to an axios server-side call. Building URLs with query params was also inconsistent — some places used `objectToUrlParams`/`parseUrl`, others concatenated strings manually, and others called `urls.proxy()`.

## What is the solution?

### New `BackendUrl` wrapper (`app/utils/BackendUrl.ts`)
A new `BackendUrl` class wraps every backend URL. It provides:
- **`.with(params)`** — returns a new `BackendUrl` with query params merged in (immutable, fluent).
- **`.append(path)`** — returns a new `BackendUrl` with a path segment appended.
- **`.toRaw()`** — returns the full raw backend URL with query string. Used by server-side code (`axios`) that provides its own `Authorization` header.
- **`.toString()`** — returns `/api/proxy?path=...` for client-side usage so the raw backend host is never exposed to the browser.

### `urls.ts` migration
Every URL entry now returns a `BackendUrl` instance instead of a plain string. The old `urls.proxy()` helper has been removed; its logic is now encapsulated in `BackendUrl.toString()`.

### Server-side query classes (`BaseQuery`, `BasePaginatedQuery`)
Both base query classes accept `BackendUrl | string` and call `.toRaw()` before passing to axios, ensuring server-side calls always use the direct backend URL.

### Client-side data helpers (`fetchData`, `fetchPaginatedData`, `handleRequest`)
Accept `BackendUrl | string` and call `String(url)`, which triggers `BackendUrl.toString()` to produce the `/api/proxy?path=...` URL for browser-side `fetch` calls.
`fetchPaginatedData` was simplified: instead of parsing the URL and rebuilding query params via `objectToUrlParams`, it now calls `.with({ Page, PageSize })` on the `BackendUrl`.

### UI components (`FetchTable`, `PaginatedTable`, `InputControl`, `Picker`, `Uploader`, `Dashboard`, `Funds`, `Investments`, `CreditCardDetail`, `Subscriptions`)
All URL props updated from `string` to `BackendUrl | string`. Client-side `fetch` and `fetcher.submit` calls now go through `String(url)` or direct `BackendUrl` usage, routing correctly through the proxy.

### Route loaders
- **`incomes.tsx`**: replaced manual `CommonUtils.Params` query-string building with `urls.incomes.paginated.with({ ... }).toRaw()`.
- **`CurrencyExchangeRatesQuery`**: uses `urls.currencyExchangeRates.latestByShortName.append('/USDTC/latest')` instead of string concatenation. A TODO was added noting the hardcoded `'USDTC'`.
- **`CreditCardStatementQuery`**: updated to call `.toRaw()` for the server-side axios call.

### `root.tsx`
Added `suppressHydrationWarning` to `<html>` to silence React hydration mismatches caused by browser extensions modifying attributes.

### `urlTreatment.ts`
Marked with a TODO for removal once `BackendUrl` is confirmed to cover all remaining usage.

## What areas of the site does it impact?
- **All pages** — Every data-fetching path goes through `BaseQuery`/`BasePaginatedQuery` or the `fetchData`/`handleRequest` helpers, all of which now use `BackendUrl`.
- **Incomes** — Pagination URL construction refactored to use `BackendUrl.with()`.
- **Dashboard** — Currency exchange rate and credit card statement queries updated.
- **Funds, Investments, Credit Cards, Subscriptions** — Component URL props updated; client-side mutations (delete, save) correctly route through the proxy.

## Test scenarios

```gherkin
Scenario: Client-side DELETE uses proxy URL
  Given the user is on the Subscriptions page
  When the user deletes a subscription
  Then the DELETE request goes to /api/proxy?path=... (not directly to the backend)

Scenario: Server-side loader uses raw backend URL
  Given the Incomes page loader runs on the server
  When the loader fetches paginated incomes
  Then axios receives the raw backend URL with correct query params (Page, PageSize, BankId, CurrencyId)

Scenario: Paginated table loads data with correct page
  Given a PaginatedTable component with a BackendUrl
  When the user navigates to page 2
  Then the fetch call includes Page=2 and PageSize in the proxy URL

Scenario: Incomes page loads with filters
  Given an authenticated user
  When the user navigates to /incomes with bankId and currencyId query params
  Then the correct paginated data is fetched and displayed

Scenario: Currency exchange rate query resolves correctly
  Given the Dashboard loader runs on the server
  When the CurrencyExchangeRatesQuery fetches the USDTC rate
  Then the raw URL /currencies/exchange-rates/USDTC/latest is called via axios
```

## Other Notes
- `BackendUrl` is immutable — `.with()` and `.append()` always return new instances, making it safe to share URL definitions from `urls.ts` across multiple callers.
- `urlTreatment.ts` (`parseUrl`, `objectToUrlParams`) is kept for backward compatibility but marked for removal.