### PR TITLE
Frontend MainApp: Fix incomes displayed values

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Debits/Annual/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Debits/Annual/index.tsx
@@ -1,161 +1,152 @@
-import urls from "@/utils/urls";
-import { useLoaderData } from "react-router";
-import { toNumber, ValueLike } from "@/utils/common";
+import urls from '@/utils/urls';
+import { useLoaderData } from 'react-router';
+import { toNumber, ValueLike } from '@/utils/common';
 import type {
-    Column as TableColumn,
-    PaginatedTableProps,
-} from "@/components/ui/utils/PaginatedTable";
-import { InputType } from "@/components/ui/utils/InputType";
-import PaginatedTable from "@/components/ui/utils/PaginatedTable";
+  Column as TableColumn,
+  PaginatedTableProps,
+} from '@/components/ui/utils/PaginatedTable';
+import { InputType } from '@/components/ui/utils/InputType';
+import PaginatedTable from '@/components/ui/utils/PaginatedTable';
 
 interface EndpointsCollection {
-    pesosEndpoint?: string;
-    dollarsEndpoint?: string;
-    pesosModuleId?: string;
-    dollarsModuleId?: string;
+  pesosEndpoint?: string;
+  dollarsEndpoint?: string;
+  pesosModuleId?: string;
+  dollarsModuleId?: string;
 }
 
 function AnnualDebits() {
-    // Use the loader data
-    const { pesosEndpoint, dollarsEndpoint, pesosModuleId, dollarsModuleId } =
-        useLoaderData<EndpointsCollection>();
+  // Use the loader data
+  const { pesosEndpoint, dollarsEndpoint, pesosModuleId, dollarsModuleId } =
+    useLoaderData<EndpointsCollection>();
 
-    const pesosTableName = "pesos-debit-table";
-    const dollarsTableName = "dollars-debit-table";
+  const pesosTableName = 'pesos-debit-table';
+  const dollarsTableName = 'dollars-debit-table';
 
-    const onFetchMovementsTable = () => {};
+  const onFetchMovementsTable = () => {};
 
-    const valueConditionalClass = {
-        class: "text-success fw-bold",
-        eval: (field: unknown) =>
-            field != null && toNumber(field as ValueLike) > 0,
-    };
+  const valueConditionalClass = {
+    class: 'text-success fw-bold',
+    eval: (field: unknown) => field != null && toNumber(field as ValueLike) > 0,
+  };
 
-    const valueMapper = (field: unknown) =>
-        field != null ? toNumber(field as ValueLike) : null;
+  const valueMapper = (field: unknown) => (field != null ? toNumber(field as ValueLike) : null);
 
-    const numericHeader = {
-        classes: "text-end",
+  const numericHeader = {
+    classes: 'text-end',
+    style: {
+      width: '120px',
+    },
+  };
+
+  const TableColumns = [
+    {
+      id: 'timeStamp',
+      label: 'Fecha',
+      placeholder: 'Fecha',
+      type: InputType.DateTime,
+      editable: false,
+      datetime: {
+        timeFormat: 'HH:mm',
+        timeIntervals: 15,
+        dateFormat: 'DD/MM/YYYY',
+        placeholder: 'Seleccionar fecha',
+      },
+      header: {
         style: {
-            width: "120px",
+          width: '160px',
         },
-    };
+      },
+    },
+    {
+      id: 'origin',
+      label: 'Gasto/Servicio',
+      placeholder: 'Gasto/Servicio',
+      editable: true,
+    },
+    {
+      id: 'amount',
+      label: 'Monto',
+      placeholder: 'Monto',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: true,
+      mapper: valueMapper,
+      conditionalClass: valueConditionalClass,
+    },
+  ];
 
-    const TableColumns = [
-        {
-            id: "timeStamp",
-            label: "Fecha",
-            placeholder: "Fecha",
-            type: InputType.DateTime,
-            editable: false,
-            datetime: {
-                timeFormat: "HH:mm",
-                timeIntervals: 15,
-                dateFormat: "DD/MM/YYYY",
-                placeholder: "Seleccionar fecha",
-            },
-            header: {
-                style: {
-                    width: "160px",
-                },
-            },
-        },
-        {
-            id: "origin",
-            label: "Gasto/Servicio",
-            placeholder: "Gasto/Servicio",
-            editable: true,
-        },
-        {
-            id: "amount",
-            label: "Monto",
-            placeholder: "Monto",
-            type: InputType.Decimal,
-            min: 0.0,
-            header: numericHeader,
-            class: "text-end",
-            editable: true,
-            mapper: valueMapper,
-            conditionalClass: valueConditionalClass,
-        },
-    ];
+  type AdminType = PaginatedTableProps['admin'];
 
-    type AdminType = PaginatedTableProps["admin"];
+  interface ColumnProps {
+    title: string;
+    tableName: string;
+    url?: string;
+    adminSettings?: AdminType;
+    onFetch?: (arg?: unknown) => void;
+    columns: TableColumn[];
+  }
 
-    interface ColumnProps {
-        title: string;
-        tableName: string;
-        url?: string;
-        adminSettings?: AdminType;
-        onFetch?: (arg?: unknown) => void;
-        columns: TableColumn[];
-    }
-
-    const Column = ({
-        title,
-        tableName,
-        url,
-        adminSettings,
-        onFetch,
-        columns,
-    }: ColumnProps) => {
-        return (
-            <div className="col">
-                <div className="row">
-                    <div className="col text-center">
-                        <span className="fs-5">{title}</span>
-                    </div>
-                </div>
-                <hr className="mt-1 mb-1" />
-                <PaginatedTable
-                    name={tableName}
-                    admin={adminSettings}
-                    url={url}
-                    onFetch={onFetch}
-                    columns={columns}
-                />
-            </div>
-        );
-    };
-
+  const Column = ({ title, tableName, url, adminSettings, onFetch, columns }: ColumnProps) => {
     return (
-        <div className="container pt-3 pb-3">
-            <div className="row">
-                <Column
-                    title={"Monto"}
-                    tableName={pesosTableName}
-                    url={pesosEndpoint}
-                    adminSettings={{
-                        endpoint: urls.debits.monthly.endpoint,
-                        key: [
-                            {
-                                id: "AppModuleId",
-                                value: pesosModuleId,
-                            },
-                        ],
-                    }}
-                    onFetch={onFetchMovementsTable}
-                    columns={TableColumns as TableColumn[]}
-                />
-                <Column
-                    title={"Dólares"}
-                    tableName={dollarsTableName}
-                    url={dollarsEndpoint}
-                    adminSettings={{
-                        endpoint: urls.debits.monthly.endpoint,
-                        key: [
-                            {
-                                id: "AppModuleId",
-                                value: dollarsModuleId,
-                            },
-                        ],
-                    }}
-                    onFetch={onFetchMovementsTable}
-                    columns={TableColumns as TableColumn[]}
-                />
-            </div>
+      <div className="col">
+        <div className="row">
+          <div className="col text-center">
+            <span className="fs-5">{title}</span>
+          </div>
         </div>
+        <hr className="mt-1 mb-1" />
+        <PaginatedTable
+          name={tableName}
+          admin={adminSettings}
+          url={url}
+          onFetch={onFetch}
+          columns={columns}
+        />
+      </div>
     );
+  };
+
+  return (
+    <div className="container pt-3 pb-3">
+      <div className="row">
+        <Column
+          title={'Monto'}
+          tableName={pesosTableName}
+          url={pesosEndpoint}
+          adminSettings={{
+            endpoint: urls.debits.monthly.endpoint,
+            key: [
+              {
+                id: 'AppModuleId',
+                value: pesosModuleId,
+              },
+            ],
+          }}
+          onFetch={onFetchMovementsTable}
+          columns={TableColumns as TableColumn[]}
+        />
+        <Column
+          title={'Dólares'}
+          tableName={dollarsTableName}
+          url={dollarsEndpoint}
+          adminSettings={{
+            endpoint: urls.debits.monthly.endpoint,
+            key: [
+              {
+                id: 'AppModuleId',
+                value: dollarsModuleId,
+              },
+            ],
+          }}
+          onFetch={onFetchMovementsTable}
+          columns={TableColumns as TableColumn[]}
+        />
+      </div>
+    </div>
+  );
 }
 
 export default AnnualDebits;

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
@@ -63,9 +63,7 @@ const Incomes: React.FC = () => {
     eval: (field: unknown) => field != null && Number(String(field)) > 0,
   };
 
-  const valueMapper = function (field: unknown) {
-    return field != null ? Number(String(field)) : null;
-  };
+  const valueMapper = (field: unknown) => (field != null ? Number(String(field)) : null);
 
   const numericHeader = {
     classes: 'text-end',
@@ -130,10 +128,7 @@ const Incomes: React.FC = () => {
       editable: {
         defaultValue: 0.0,
       },
-      mapper: (record) => {
-        console.log('Mapping amount for record:', record);
-        return valueMapper(record.amount);
-      },
+      mapper: (record) => valueMapper(record.amount),
       conditionalClass: valueConditionalClass,
     },
   ];

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
@@ -11,6 +11,7 @@ import PaginatedTable, {
   Row,
 } from '@/components/ui/utils/PaginatedTable';
 import { cn } from '@/lib/utils';
+import type { IncomeRecord } from '@/types/income';
 
 // Define types for the props and states
 interface PickerData {
@@ -18,37 +19,7 @@ interface PickerData {
   name: string;
 }
 
-interface BankData {
-  id: string;
-  name: string;
-  deactivated: boolean;
-  creditCards: unknown[];
-}
-
-interface CurrencyData {
-  id: string;
-  name: string;
-  shortName: string;
-  deactivated: boolean;
-  baseExchangeRates: unknown[];
-  quoteExchangeRates: unknown[];
-  iolInvestmentAssets: unknown[];
-  subscriptions: unknown[];
-  symbols: unknown[];
-}
-
-interface IncomeRecord extends Row {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  timeStamp: string;
-  deactivated: boolean;
-  amount: number;
-  bankId: string;
-  currencyId: string;
-  bank: BankData;
-  currency: CurrencyData;
-}
+interface IncomeRow extends IncomeRecord, Omit<Row, 'id'> {}
 
 interface LoaderData {
   banks: PickerData[];
@@ -103,7 +74,7 @@ const Incomes: React.FC = () => {
     },
   };
 
-  const TableColumns: Column<IncomeRecord>[] = [
+  const TableColumns: Column<IncomeRow>[] = [
     {
       id: 'createdAt',
       label: 'Fecha',
@@ -184,7 +155,7 @@ const Incomes: React.FC = () => {
         onBankChange={onBankPickerChange}
         onCurrencyChange={onCurrencyPickerChange}
       />
-      <PaginatedTable<IncomeRecord>
+      <PaginatedTable<IncomeRow>
         name="incomes-table"
         columns={TableColumns}
         data={paginatedData}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
@@ -1,179 +1,211 @@
-import React from "react";
-import urls from "@/utils/urls";
-import dayjs from "dayjs";
-import CommonUtils from "@/utils/common";
-import BankCurrencySelector from "@/components/ui/utils/BankCurrencySelector";
-import { useLoaderData, useLocation, useNavigate } from "react-router";
-import { InputType } from "@/components/ui/utils/InputType";
+import React from 'react';
+import urls from '@/utils/urls';
+import dayjs from 'dayjs';
+import CommonUtils from '@/utils/common';
+import BankCurrencySelector from '@/components/ui/utils/BankCurrencySelector';
+import { useLoaderData, useLocation, useNavigate } from 'react-router';
+import { InputType } from '@/components/ui/utils/InputType';
 import PaginatedTable, {
-    Column,
-    ConditionalClass,
-} from "@/components/ui/utils/PaginatedTable";
-import { cn } from "@/lib/utils";
+  Column,
+  ConditionalClass,
+  Row,
+} from '@/components/ui/utils/PaginatedTable';
+import { cn } from '@/lib/utils';
 
 // Define types for the props and states
 interface PickerData {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
+}
+
+interface BankData {
+  id: string;
+  name: string;
+  deactivated: boolean;
+  creditCards: unknown[];
+}
+
+interface CurrencyData {
+  id: string;
+  name: string;
+  shortName: string;
+  deactivated: boolean;
+  baseExchangeRates: unknown[];
+  quoteExchangeRates: unknown[];
+  iolInvestmentAssets: unknown[];
+  subscriptions: unknown[];
+  symbols: unknown[];
+}
+
+interface IncomeRecord extends Row {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  timeStamp: string;
+  deactivated: boolean;
+  amount: number;
+  bankId: string;
+  currencyId: string;
+  bank: BankData;
+  currency: CurrencyData;
 }
 
 interface LoaderData {
-    banks: PickerData[];
-    currencies: PickerData[];
-    data: unknown[];
-    bankId: string;
-    currencyId: string;
+  banks: PickerData[];
+  currencies: PickerData[];
+  data: IncomeRecord[];
+  bankId: string;
+  currencyId: string;
 }
 
-const dateFormat = "DD/MM/YYYY";
+const dateFormat = 'DD/MM/YYYY';
 
 const Incomes: React.FC = () => {
-    const { banks, currencies, data, bankId, currencyId } =
-        useLoaderData<LoaderData>();
-    const navigate = useNavigate();
-    const location = useLocation();
+  const { banks, currencies, data, bankId, currencyId } = useLoaderData<LoaderData>();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-    const reload = ({
-        currentBankId,
-        currentCurrencyId,
-    }: {
-        currentBankId?: string;
-        currentCurrencyId?: string;
-    }) => {
-        const params = CommonUtils.Params({
-            bankId: currentBankId ?? bankId,
-            currencyId: currentCurrencyId ?? currencyId,
-        });
-        navigate(`${location.pathname}?${params}`);
-    };
+  const reload = ({
+    currentBankId,
+    currentCurrencyId,
+  }: {
+    currentBankId?: string;
+    currentCurrencyId?: string;
+  }) => {
+    const params = CommonUtils.Params({
+      bankId: currentBankId ?? bankId,
+      currencyId: currentCurrencyId ?? currencyId,
+    });
+    navigate(`${location.pathname}?${params}`);
+  };
 
-    const onBankPickerChange = (picker: { value: string }) => {
-        reload({ currentBankId: picker.value });
-    };
+  const onBankPickerChange = (picker: { value: string }) => {
+    reload({ currentBankId: picker.value });
+  };
 
-    const onCurrencyPickerChange = (picker: { value: string }) => {
-        reload({ currentCurrencyId: picker.value });
-    };
+  const onCurrencyPickerChange = (picker: { value: string }) => {
+    reload({ currentCurrencyId: picker.value });
+  };
 
-    const valueConditionalClass: ConditionalClass = {
-        class: "text-success fw-bold",
-        eval: (field: unknown) => field != null && Number(String(field)) > 0,
-    };
+  const valueConditionalClass: ConditionalClass = {
+    class: 'text-success fw-bold',
+    eval: (field: unknown) => field != null && Number(String(field)) > 0,
+  };
 
-    const valueMapper = (field: unknown) =>
-        field != null ? Number(String(field)) : null;
+  const valueMapper = function (field: unknown) {
+    return field != null ? Number(String(field)) : null;
+  };
 
-    const numericHeader = {
-        classes: "text-end",
+  const numericHeader = {
+    classes: 'text-end',
+    style: {
+      width: '180px',
+    },
+  };
+
+  const TableColumns: Column<IncomeRecord>[] = [
+    {
+      id: 'createdAt',
+      label: 'Fecha',
+      placeholder: 'Fecha',
+      type: InputType.DateTime,
+      editable: {
+        defaultValue: () => dayjs().format(dateFormat),
+      },
+      datetime: {
+        timeFormat: 'HH:mm',
+        timeIntervals: 15,
+        dateFormat: dateFormat,
+        placeholder: 'Seleccionar fecha',
+      },
+      header: {
         style: {
-            width: "180px",
+          width: '160px',
         },
-    };
+      },
+    },
+    {
+      id: 'bank',
+      label: 'Banco/Entidad',
+      placeholder: 'Seleccione un banco',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.banks.endpoint,
+      mapper: {
+        id: 'id',
+        label: (record) => record.bank.name,
+      },
+    },
+    {
+      id: 'currency',
+      label: 'Moneda',
+      placeholder: 'Seleccione una moneda',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.currencies.endpoint,
+      mapper: {
+        id: 'id',
+        label: (record) => record.currency.name,
+      },
+    },
+    {
+      id: 'amount',
+      label: 'Monto',
+      placeholder: 'Monto',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: {
+        defaultValue: 0.0,
+      },
+      mapper: (record) => {
+        console.log('Mapping amount for record:', record);
+        return valueMapper(record.amount);
+      },
+      conditionalClass: valueConditionalClass,
+    },
+  ];
 
-    const TableColumns: Column[] = [
-        {
-            id: "createdAt",
-            label: "Fecha",
-            placeholder: "Fecha",
-            type: InputType.DateTime,
-            editable: {
-                defaultValue: () => dayjs().format(dateFormat),
-            },
-            datetime: {
-                timeFormat: "HH:mm",
-                timeIntervals: 15,
-                dateFormat: dateFormat,
-                placeholder: "Seleccionar fecha",
-            },
-            header: {
-                style: {
-                    width: "160px",
-                },
-            },
-        },
-        {
-            id: "bank",
-            label: "Banco/Entidad",
-            placeholder: "Seleccione un banco",
-            editable: false,
-            type: InputType.Dropdown,
-            endpoint: urls.banks.endpoint,
-            mapper: {
-                id: "id",
-                label: (record: unknown) => `${(record as PickerData).name}`,
-            },
-        },
-        {
-            id: "currency",
-            label: "Moneda",
-            placeholder: "Seleccione una moneda",
-            editable: false,
-            type: InputType.Dropdown,
-            endpoint: urls.currencies.endpoint,
-            mapper: {
-                id: "id",
-                label: (record: unknown) => `${(record as PickerData).name}`,
-            },
-        },
-        {
-            id: "amount",
-            label: "Monto",
-            placeholder: "Monto",
-            type: InputType.Decimal,
-            min: 0.0,
-            header: numericHeader,
-            class: "text-end",
-            editable: {
-                defaultValue: 0.0,
-            },
-            mapper: valueMapper,
-            conditionalClass: valueConditionalClass,
-        },
-    ];
+  const paginatedData = Array.isArray(data)
+    ? {
+        items: data,
+        totalPages: 1,
+      }
+    : data;
 
-    type LocalPaginatedData = {
-        items: Record<string, unknown>[];
-        totalPages: number;
-    } | null;
-    const paginatedData: LocalPaginatedData = Array.isArray(data)
-        ? {
-              items: data.map((d) => d as Record<string, unknown>),
-              totalPages: 1,
-          }
-        : (data as LocalPaginatedData);
-
-    return (
-        <div className={cn(["py-10", "px-40"])}>
-            <BankCurrencySelector
-                banks={banks}
-                currencies={currencies}
-                bankId={bankId}
-                currencyId={currencyId}
-                onBankChange={onBankPickerChange}
-                onCurrencyChange={onCurrencyPickerChange}
-            />
-            <PaginatedTable
-                name="incomes-table"
-                columns={TableColumns}
-                data={paginatedData}
-                onAdd={() => reload({})}
-                onDelete={() => reload({})}
-                admin={{
-                    endpoint: urls.incomes.endpoint,
-                    key: [
-                        {
-                            id: "BankId",
-                            value: bankId,
-                        },
-                        {
-                            id: "CurrencyId",
-                            value: currencyId,
-                        },
-                    ],
-                }}
-            />
-        </div>
-    );
+  return (
+    <div className={cn(['py-10', 'px-40'])}>
+      <BankCurrencySelector
+        banks={banks}
+        currencies={currencies}
+        bankId={bankId}
+        currencyId={currencyId}
+        onBankChange={onBankPickerChange}
+        onCurrencyChange={onCurrencyPickerChange}
+      />
+      <PaginatedTable<IncomeRecord>
+        name="incomes-table"
+        columns={TableColumns}
+        data={paginatedData}
+        onAdd={() => reload({})}
+        onDelete={() => reload({})}
+        admin={{
+          endpoint: urls.incomes.endpoint,
+          key: [
+            {
+              id: 'BankId',
+              value: bankId,
+            },
+            {
+              id: 'CurrencyId',
+              value: currencyId,
+            },
+          ],
+        }}
+      />
+    </div>
+  );
 };
 
 export default Incomes;

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
@@ -42,7 +42,12 @@ interface Admin {
   deleteEnabled?: boolean;
 }
 
-export interface Column {
+export interface Row {
+  id?: string | number;
+  isSelected?: boolean;
+}
+
+export interface Column<T extends Row = Row> {
   id?: string;
   key?: string;
   min?: number;
@@ -64,9 +69,9 @@ export interface Column {
   mapper?:
     | {
         id: string;
-        label?: string | ((record: Row) => string);
+        label?: string | ((record: T) => string);
       }
-    | ((record: Row) => React.ReactNode);
+    | ((record: T) => React.ReactNode);
   datetime?: {
     timeFormat: 'HH:mm';
     timeIntervals: number;
@@ -80,31 +85,25 @@ export interface ConditionalClass {
   class: string;
 }
 
-export interface PaginatedTableProps {
+interface Data<T extends Row = Row> {
+  items: T[];
+  totalPages: number;
+}
+
+export interface PaginatedTableProps<T extends Row = Row> {
   name: string;
-  data?: Data | null;
+  data?: Data<T> | null;
   url?: BackendUrl | string;
   admin?: Admin;
   rowCount?: number;
-  columns: Column[];
+  columns: Column<T>[];
   onFetch?: (data: unknown) => void;
   onAdd?: (data: unknown) => void;
   onDelete?: (data: unknown) => void;
   reloadData?: boolean;
 }
 
-interface Row {
-  id?: string | number;
-  isSelected?: boolean;
-  [key: string]: unknown;
-}
-
-interface Data {
-  items: Row[];
-  totalPages: number;
-}
-
-const PaginatedTable: React.FC<PaginatedTableProps> = ({
+function PaginatedTable<T extends Row = Row>({
   name,
   data,
   url,
@@ -114,8 +113,8 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
   onAdd,
   onDelete,
   // onFetch and reloadData intentionally unused in this component
-}) => {
-  const [tableData, setTableData] = useState<Data>({
+}: PaginatedTableProps<T>) {
+  const [tableData, setTableData] = useState<Data<T>>({
     items: [],
     totalPages: 0,
   });
@@ -136,11 +135,14 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
     if (url) {
       setLoading(true);
 
-      fetchPaginatedData<Data>(url, page, 10).then((result) => {
-        const extendedItems = result.items.map((item) => ({
-          ...item,
-          isSelected: false,
-        }));
+      fetchPaginatedData<Data<T>>(url, page, 10).then((result) => {
+        const extendedItems = result.items.map(
+          (item) =>
+            ({
+              ...item,
+              isSelected: false,
+            }) as unknown as T
+        );
 
         setTableData({
           ...result,
@@ -249,7 +251,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
     await handleCreate(values);
   };
 
-  const ColumnValue = ({ columnSettings, record }: { columnSettings: Column; record: Row }) => {
+  const ColumnValue = ({ columnSettings, record }: { columnSettings: Column<T>; record: T }) => {
     const columnId = String(columnSettings.id ?? columnSettings.key ?? '');
     let columnValue: unknown = (record as Record<string, unknown>)[columnId];
 
@@ -260,7 +262,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
       if (typeof mapper === 'function') {
         columnValue = mapper(record);
       } else if (mapper && Object.hasOwn(mapper, 'label')) {
-        const label = (mapper as { label?: string | ((r: Row) => string) }).label;
+        const label = (mapper as { label?: string | ((r: T) => string) }).label;
 
         if (typeof label !== 'function') {
           columnValue = (record as Record<string, unknown>)[String(label)];
@@ -363,7 +365,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
       <TableRow id={adminRowId} className={cn(`${name}-edit-row`)}>
         <TableCell></TableCell>
         {columns &&
-          columns.map((column: Column, index: number) => {
+          columns.map((column: Column<T>, index: number) => {
             const columnId = column.key ?? column.id;
             if (column.editable) {
               return (
@@ -425,14 +427,14 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
     admin,
     adminAddEnabled,
   }: {
-    tableData: Data;
+    tableData: Data<T>;
     admin: Admin | undefined;
     adminAddEnabled: boolean;
   }) => {
     return (
       <TableBody>
         {admin && adminAddEnabled && <EditRow />}
-        {tableData.items.map((record: Row, index: number) => {
+        {tableData.items.map((record: T, index: number) => {
           const rowId = `${name}-data-row-${index}`;
           return (
             <TableRow key={rowId} id={rowId} className={`${name}-data-row`}>
@@ -446,7 +448,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
                   />
                 </TableCell>
               )}
-              {columns.map((column: Column, index: number) => (
+              {columns.map((column: Column<T>, index: number) => (
                 <TableCell key={index} className={column.class}>
                   <ColumnValue columnSettings={column} record={record} />
                 </TableCell>
@@ -547,6 +549,6 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({
       />
     </div>
   );
-};
+}
 
 export default PaginatedTable;

--- a/FinanceFrontEnd/FinanceApp/app/types/income.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/income.ts
@@ -1,0 +1,31 @@
+export interface BankData {
+  id: string;
+  name: string;
+  deactivated: boolean;
+  creditCards: unknown[];
+}
+
+export interface CurrencyData {
+  id: string;
+  name: string;
+  shortName: string;
+  deactivated: boolean;
+  baseExchangeRates: unknown[];
+  quoteExchangeRates: unknown[];
+  iolInvestmentAssets: unknown[];
+  subscriptions: unknown[];
+  symbols: unknown[];
+}
+
+export interface IncomeRecord {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  timeStamp: string;
+  deactivated: boolean;
+  amount: number;
+  bankId: string;
+  currencyId: string;
+  bank: BankData;
+  currency: CurrencyData;
+}


### PR DESCRIPTION
# Why
Fixes [#37](https://github.com/luisluna-arg/finanzas/issues/37) — The Incomes section table was showing `undefined` or `NaN` for the Banco, Moneda, and Monto columns because the column mapper functions didn't have proper type information about the row data shape from the API.

## What is the solution?
- Made `PaginatedTable` a generic component (`PaginatedTable<T extends Row>`) so consumers can pass their own row type and get full type safety in column mapper functions.
- `Column<T>`, `Data<T>`, and `PaginatedTableProps<T>` are now all generic, defaulting to `Row` for backward compatibility.
- Exported the `Row` base interface and removed the `[key: string]: unknown` index signature since the generic parameter now carries the real shape.
- Changed the component from `React.FC<PaginatedTableProps>` to a generic `function PaginatedTable<T>()` declaration (`React.FC` doesn't support generics).
- Created `IncomeRecord`, `BankData`, and `CurrencyData` interfaces matching the actual API response shape.
- Column mappers now use the typed record directly (e.g. `record.currency.name`, `record.bank.name`) instead of casting through `unknown`.

## What areas of the site does it impact?
- **PaginatedTable** (`components/ui/utils/PaginatedTable.tsx`): Generic type parameter added — all existing consumers (Funds, Investments, Debits) continue working unchanged via default type parameter.
- **Incomes** (`components/ui/Incomes/Index.tsx`): Column mappers fixed to correctly access nested `bank.name`, `currency.name`, and `amount` properties.
- **Annual Debits** (`components/ui/Debits/Annual/index.tsx`): Formatting/style consistency (quotes, indentation).

## Test scenarios

```gherkin
Scenario: Incomes table displays correct values for all columns
  Given the user navigates to the Incomes section
  And selects a bank and currency from the pickers
  When the table data loads
  Then the Fecha column shows formatted dates
  And the Banco/Entidad column shows the bank name (e.g. "BBVA")
  And the Moneda column shows the currency name (e.g. "Peso")
  And the Monto column shows a numeric amount (not NaN or undefined)

Scenario: Other PaginatedTable consumers are unaffected
  Given the user navigates to Debits or Investments sections
  When the table data loads
  Then all columns display correctly as before
```

## Other Notes
- The generic defaults (`<T extends Row = Row>`) ensure this is a non-breaking change for all existing PaginatedTable consumers.
- `IncomeRecord extends Row` so it satisfies the base constraint while providing full type safety for its specific fields.
