### PR TITLE
Frontend Mainapp: Fix misc on income paginated table

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Incomes/Index.tsx
@@ -74,7 +74,7 @@ const Incomes: React.FC = () => {
 
   const TableColumns: Column<IncomeRow>[] = [
     {
-      id: 'createdAt',
+      id: 'timeStamp',
       label: 'Fecha',
       placeholder: 'Fecha',
       type: InputType.DateTime,

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
@@ -172,6 +172,8 @@ function PaginatedTable<T extends Row = Row>({
         columnValue = i.checked;
       } else if (column?.type === InputType.DateTime) {
         columnValue = dates.tryGet(i.value);
+      } else if (column?.type === InputType.Decimal || column?.type === InputType.Integer) {
+        columnValue = i.value === '' ? null : Number(i.value);
       } else {
         columnValue = i.value;
       }


### PR DESCRIPTION
# Why
Related to #42 — Two small bugs in the Incomes table were causing incorrect data to be read and filtered.

## What is the solution?
- Fixed the Fecha column `id` in `Incomes/Index.tsx` from `'createdAt'` to `'timeStamp'` to match the actual field name in the API response.
- Added numeric coercion in `PaginatedTable` for `Decimal` and `Integer` column types: empty string is now treated as `null` instead of being passed as-is, and non-empty values are converted with `Number()`.

## What areas of the site does it impact?
- **Incomes** (`components/ui/Incomes/Index.tsx`): Fecha column now reads the correct field from the API response.
- **PaginatedTable** (`components/ui/utils/PaginatedTable.tsx`): Decimal and Integer filter inputs now produce proper numeric values (or `null`) instead of raw strings.

## Test scenarios

```gherkin
Scenario: Incomes table shows correct dates
  Given the user navigates to the Incomes section
  When the table data loads
  Then the Fecha column shows the correct date for each income record

Scenario: Filtering by a numeric column works correctly
  Given the user is on a table with a Decimal or Integer column
  When the user enters a numeric value in the filter input
  Then the filter value is treated as a number
  And when the input is cleared the filter value is null
```
