### PR TITLE
Backend: Better implementation of command disptacher and handler registration

### DIFF
--- a/.bin/bash/rebuild-shared-backend-local.sh
+++ b/.bin/bash/rebuild-shared-backend-local.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Script to rebuild and restart only the backend service in the Shared stack
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running. Please start Docker Desktop."
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHARED_COMPOSE="$SCRIPT_DIR/../.infra/local/shared/docker-compose.yaml"
+
+if [ ! -f "$SHARED_COMPOSE" ]; then
+  echo "Error: Shared compose file not found: $SHARED_COMPOSE"
+  exit 1
+fi
+
+SHARED_ENV="$(dirname "$SHARED_COMPOSE")/.env"
+
+if [ -f "$SHARED_ENV" ] && grep -q "^COMPOSE_PROJECT_NAME=" "$SHARED_ENV"; then
+  PROJECT_SHARED=$(grep "^COMPOSE_PROJECT_NAME=" "$SHARED_ENV" | cut -d'=' -f2 | tr -d '"')
+else
+  PROJECT_SHARED="shared"
+fi
+
+echo "Rebuilding backend service (project: $PROJECT_SHARED)..."
+docker compose -p "$PROJECT_SHARED" -f "$SHARED_COMPOSE" up --build -d backend
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "Backend rebuild failed with exit code: $EXIT_CODE"
+  exit 1
+fi
+
+echo ""
+echo "Backend service rebuilt and restarted successfully."

--- a/.bin/powershell/rebuild-shared-backend-local.ps1
+++ b/.bin/powershell/rebuild-shared-backend-local.ps1
@@ -1,0 +1,31 @@
+# PowerShell script to rebuild and restart only the backend service in the Shared stack
+$dockerProcess = Get-Process -Name "Docker Desktop" -ErrorAction SilentlyContinue
+if (-not $dockerProcess) {
+    Write-Host "Docker Desktop is not running. Please start Docker Desktop."
+    exit 1
+}
+
+$sharedCompose = Join-Path $PSScriptRoot "..\..\.infra\local\shared\docker-compose.yaml"
+
+if (-not (Test-Path $sharedCompose)) {
+    Write-Host "Error: Shared compose file not found: $sharedCompose"
+    exit 1
+}
+
+$sharedEnv = Join-Path (Split-Path -Parent $sharedCompose) '.env'
+
+$projectShared = if (Test-Path $sharedEnv) {
+    $envValue = Get-Content $sharedEnv | Where-Object { $_ -match '^COMPOSE_PROJECT_NAME=' } | ForEach-Object { $_.Split('=')[1].Trim('"') }
+    if ($envValue) { $envValue } else { "shared" }
+} else { "shared" }
+
+Write-Host "Rebuilding backend service (project: $projectShared)..."
+docker compose -p $projectShared -f $sharedCompose up --build -d backend
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    Write-Host "Backend rebuild failed with exit code: $exitCode"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Backend service rebuilt and restarted successfully."

--- a/FinanceBackEnd/CQRSDispatch/CommandHandlerTypeRegistry.cs
+++ b/FinanceBackEnd/CQRSDispatch/CommandHandlerTypeRegistry.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+
+namespace CQRSDispatch;
+
+/// <summary>
+/// Maps command types to their registered handler interface types.
+/// Built once at startup during <see cref="Extensions.ServiceCollectionExtensions.AddRequestHandlers"/>
+/// and consumed by the dispatcher to resolve handlers without runtime assembly scanning.
+/// </summary>
+public sealed class CommandHandlerTypeRegistry
+{
+    private readonly ConcurrentDictionary<Type, List<Type>> _map = new();
+
+    /// <summary>
+    /// Records that <paramref name="handlerInterfaceType"/> handles commands of type <paramref name="commandType"/>.
+    /// </summary>
+    public void Register(Type commandType, Type handlerInterfaceType)
+    {
+        _map.AddOrUpdate(
+            commandType,
+            _ => [handlerInterfaceType],
+            (_, list) => { list.Add(handlerInterfaceType); return list; });
+    }
+
+    /// <summary>
+    /// Returns all handler interface types registered for the given command type, or null if none.
+    /// </summary>
+    public IReadOnlyList<Type>? GetHandlerInterfaceTypes(Type commandType)
+    {
+        return _map.TryGetValue(commandType, out var list) ? list : null;
+    }
+}

--- a/FinanceBackEnd/CQRSDispatch/Dispatcher.cs
+++ b/FinanceBackEnd/CQRSDispatch/Dispatcher.cs
@@ -12,7 +12,7 @@ namespace CQRSDispatch;
 /// Handles logging and error management for dispatch operations.
 /// </summary>
 /// <typeparam name="TContext">The type of dispatch context.</typeparam>
-public class Dispatcher<TContext> : IDispatcher<TContext>
+public sealed class Dispatcher<TContext> : IDispatcher<TContext>
     where TContext : DispatchContext, new()
 {
     /// <summary>
@@ -20,9 +20,10 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// </summary>
     public static readonly TaggedActivitySource DispatchActivity = new("Finance.Api.Dispatcher");
 
-    protected readonly ILogger<Dispatcher<TContext>> Logger;
-    protected readonly IServiceProvider ServiceProvider;
-    protected readonly IDispatchContextBuilderAsync<TContext> ExecutionContextBuilder;
+    private readonly ILogger<Dispatcher<TContext>> Logger;
+    private readonly IServiceProvider ServiceProvider;
+    private readonly IDispatchContextBuilderAsync<TContext> ExecutionContextBuilder;
+    private readonly CommandHandlerTypeRegistry HandlerRegistry;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Dispatcher{TContext}"/> class.
@@ -30,11 +31,17 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// <param name="logger">Logger instance for logging operations.</param>
     /// <param name="serviceProvider">Service provider for dependency injection.</param>
     /// <param name="executionContextBuilder">Builder for execution context.</param>
-    public Dispatcher(ILogger<Dispatcher<TContext>> logger, IServiceProvider serviceProvider, IDispatchContextBuilderAsync<TContext> executionContextBuilder)
+    /// <param name="handlerRegistry">Registry mapping command types to their handler interface types, built at startup.</param>
+    public Dispatcher(
+        ILogger<Dispatcher<TContext>> logger,
+        IServiceProvider serviceProvider,
+        IDispatchContextBuilderAsync<TContext> executionContextBuilder,
+        CommandHandlerTypeRegistry handlerRegistry)
     {
         Logger = logger;
         ServiceProvider = serviceProvider;
         ExecutionContextBuilder = executionContextBuilder;
+        HandlerRegistry = handlerRegistry;
     }
 
     /// <summary>
@@ -44,7 +51,7 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// <param name="command">The command to dispatch.</param>
     /// <param name="httpRequest">The HTTP request context.</param>
     /// <returns>The command execution result.</returns>
-    public virtual async Task<TResult> DispatchAsync<TResult>(IContextAwareCommand<TContext, TResult> command, HttpRequest? httpRequest)
+    public async Task<TResult> DispatchAsync<TResult>(IContextAwareCommand<TContext, TResult> command, HttpRequest? httpRequest)
         where TResult : RequestResult
     {
         Logger.LogInformation("Dispatching command: {CommandType}", command.GetType().Name);
@@ -63,7 +70,7 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// <typeparam name="TResult">The result type that inherits from RequestResult.</typeparam>
     /// <param name="command">The command to dispatch.</param>
     /// <returns>The command execution result.</returns>
-    public virtual async Task<TResult> DispatchAsync<TResult>(ICommand<TResult> command)
+    public async Task<TResult> DispatchAsync<TResult>(ICommand<TResult> command)
         where TResult : RequestResult
     {
         var cancellationToken = CreateCancellationToken();
@@ -100,7 +107,7 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// <param name="command">The command to dispatch.</param>
     /// <param name="httpRequest">The HTTP request context.</param>
     /// <returns>A CommandResult indicating success or failure.</returns>
-    public virtual async Task<CommandResult> DispatchCommandAsync(IContextAwareCommand<TContext> command, HttpRequest? httpRequest)
+    public async Task<CommandResult> DispatchCommandAsync(IContextAwareCommand<TContext> command, HttpRequest? httpRequest)
     {
         Logger.LogInformation("Dispatching command: {CommandType}", command.GetType().Name);
 
@@ -117,7 +124,7 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// </summary>
     /// <param name="command">The command to dispatch.</param>
     /// <returns>A CommandResult indicating success or failure.</returns>
-    public virtual async Task<CommandResult> DispatchCommandAsync(ICommand command)
+    public async Task<CommandResult> DispatchCommandAsync(ICommand command)
     {
         var cancellationToken = CreateCancellationToken();
         try
@@ -126,25 +133,28 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
 
             using var activity = DispatchActivity.StartActivity(commandType.Name, "dispatch.type", "command");
 
-            var twoParamHandlerType = typeof(ICommandHandler<,>).MakeGenericType(commandType, typeof(CommandResult));
-            var oneParamHandlerType = typeof(ICommandHandler<>).MakeGenericType(commandType);
-
-            var handlerType = ServiceProvider.GetService(twoParamHandlerType) != null
-                ? twoParamHandlerType
-                : oneParamHandlerType;
-
-            var handler = ServiceProvider.GetRequiredService(handlerType);
+            var (handler, handlerType) = ResolveCommandHandler(commandType);
 
             var executeMethod = handlerType.GetMethod("ExecuteAsync")
                 ?? throw new InvalidOperationException($"ExecuteAsync method not found on handler type {handlerType.Name}");
 
-            var task = executeMethod.Invoke(handler, [command, cancellationToken]) as Task<CommandResult>
-                ?? throw new InvalidOperationException($"Handler ExecuteAsync method did not return expected Task<CommandResult>");
+            var taskObj = executeMethod.Invoke(handler, [command, cancellationToken])
+                ?? throw new InvalidOperationException($"Handler ExecuteAsync returned null for {commandType.Name}");
 
-            var result = await task;
+            // Await the task — the concrete return type may be CommandResult, DataResult<T>, etc.
+            await (Task)taskObj;
+
+            var resultProperty = taskObj.GetType().GetProperty("Result");
+            var result = resultProperty?.GetValue(taskObj) as RequestResult
+                ?? throw new InvalidOperationException(
+                    $"Handler for {commandType.Name} did not return a RequestResult");
 
             Logger.LogInformation("Command dispatched successfully: {CommandType}", commandType.Name);
-            return result;
+
+            // If the result is already a CommandResult, return it directly;
+            // otherwise wrap any RequestResult (e.g. DataResult<T>) into a CommandResult.
+            return result as CommandResult
+                ?? new CommandResult(result.IsSuccess, result.ErrorMessage);
         }
         catch (Exception ex)
         {
@@ -154,13 +164,38 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     }
 
     /// <summary>
+    /// Resolves a command handler from DI using the startup-built registry.
+    /// Tries all registered handler interface types for the command type.
+    /// </summary>
+    private (object handler, Type handlerInterfaceType) ResolveCommandHandler(Type commandType)
+    {
+        var interfaceTypes = HandlerRegistry.GetHandlerInterfaceTypes(commandType);
+
+        if (interfaceTypes != null)
+        {
+            foreach (var candidateType in interfaceTypes)
+            {
+                var handler = ServiceProvider.GetService(candidateType);
+                if (handler != null)
+                    return (handler, candidateType);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"No command handler has been registered for '{commandType.FullName}'. "
+            + $"Ensure a class implementing ICommandHandler<{commandType.Name}> or "
+            + $"ICommandHandler<{commandType.Name}, TResult> exists and its assembly "
+            + $"is included in AddRequestHandlers().");
+    }
+
+    /// <summary>
     /// Dispatches a context-aware query with HTTP context, returning a DataResult.
     /// </summary>
     /// <typeparam name="TResult">The data type returned by the query.</typeparam>
     /// <param name="query">The query to dispatch.</param>
     /// <param name="httpRequest">The HTTP request context.</param>
     /// <returns>A DataResult containing the queried data or error information.</returns>
-    public virtual async Task<DataResult<TResult>> DispatchQueryAsync<TResult>(IContextAwareQuery<TContext, TResult> query, HttpRequest? httpRequest)
+    public async Task<DataResult<TResult>> DispatchQueryAsync<TResult>(IContextAwareQuery<TContext, TResult> query, HttpRequest? httpRequest)
     {
         Logger.LogInformation("Dispatching query: {QueryType}", query.GetType().Name);
 
@@ -178,7 +213,7 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// <typeparam name="TResult">The data type returned by the query.</typeparam>
     /// <param name="query">The query to dispatch.</param>
     /// <returns>A DataResult containing the queried data or error information.</returns>
-    public virtual async Task<DataResult<TResult>> DispatchQueryAsync<TResult>(IQuery<TResult> query)
+    public async Task<DataResult<TResult>> DispatchQueryAsync<TResult>(IQuery<TResult> query)
     {
         var cancellationToken = CreateCancellationToken();
         try
@@ -222,5 +257,5 @@ public class Dispatcher<TContext> : IDispatcher<TContext>
     /// Creates a new cancellation token for dispatch operations.
     /// </summary>
     /// <returns>A new CancellationToken instance.</returns>
-    protected CancellationToken CreateCancellationToken() => new CancellationTokenSource().Token;
+    private CancellationToken CreateCancellationToken() => new CancellationTokenSource().Token;
 }

--- a/FinanceBackEnd/CQRSDispatch/Extensions/ServiceCollectionExtensions.cs
+++ b/FinanceBackEnd/CQRSDispatch/Extensions/ServiceCollectionExtensions.cs
@@ -21,11 +21,15 @@ public static class ServiceCollectionExtensions
         IEnumerable<Assembly> assemblies,
         ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
     {
+        var registry = new CommandHandlerTypeRegistry();
+
         foreach (var assembly in assemblies)
         {
-            RegisterCommandHandlers(services, assembly, serviceLifetime);
+            RegisterCommandHandlers(services, assembly, serviceLifetime, registry);
             RegisterQueryHandlers(services, assembly, serviceLifetime);
         }
+
+        services.AddSingleton(registry);
 
         return services;
     }
@@ -36,7 +40,7 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The service collection to register handlers to.</param>
     /// <param name="assembly">The assembly to scan for command handlers.</param>
     /// <param name="serviceLifetime">The service lifetime for the handlers.</param>
-    private static void RegisterCommandHandlers(IServiceCollection services, Assembly assembly, ServiceLifetime serviceLifetime)
+    private static void RegisterCommandHandlers(IServiceCollection services, Assembly assembly, ServiceLifetime serviceLifetime, CommandHandlerTypeRegistry registry)
     {
         // Register ICommandHandler<TCommand, TResult>
         var commandHandlerTypes = assembly.GetTypes()
@@ -53,12 +57,11 @@ public static class ServiceCollectionExtensions
             {
                 var genericArguments = handlerInterface.GetGenericArguments();
                 var commandType = genericArguments[0];
-                // var resultType = genericArguments[1];
 
-                // Validate that the command type implements ICommand
                 if (typeof(ICommand).IsAssignableFrom(commandType))
                 {
                     RegisterService(services, handlerInterface, handlerType, serviceLifetime);
+                    registry.Register(commandType, handlerInterface);
                 }
             }
         }
@@ -82,6 +85,7 @@ public static class ServiceCollectionExtensions
                 if (typeof(ICommand).IsAssignableFrom(commandType))
                 {
                     RegisterService(services, handlerInterface, handlerType, serviceLifetime);
+                    registry.Register(commandType, handlerInterface);
                 }
             }
         }


### PR DESCRIPTION
# Why
Partial effort toward #42 — The command dispatcher was resolving handlers at runtime by probing `GetService()` for multiple candidate types, which was fragile and could silently fall back to the wrong handler. This replaces that with an explicit registry built once at startup.

## What is the solution?
- Introduced `CommandHandlerTypeRegistry`: a `ConcurrentDictionary`-backed singleton that maps each command type to its registered handler interface types, populated during `AddRequestHandlers()`.
- `Dispatcher` now injects `CommandHandlerTypeRegistry` and uses `ResolveCommandHandler()` — a private method that looks up the registry and throws a clear, actionable error if no handler is found.
- Fixed `DispatchCommandAsync` result handling: the task is now properly awaited and `Result` is extracted via reflection, so handlers returning `DataResult<T>` are correctly unwrapped and wrapped into a `CommandResult` if needed.
- `Dispatcher<TContext>` sealed and all `protected`/`virtual` members made `private` since the class was never intended to be subclassed.
- Added bash and PowerShell helper scripts to rebuild and restart only the backend Docker service in the local shared stack without a full compose restart.

## What areas of the site does it impact?
- **CQRSDispatch** (`CQRSDispatch/Dispatcher.cs`, `CQRSDispatch/CommandHandlerTypeRegistry.cs`, `CQRSDispatch/Extensions/ServiceCollectionExtensions.cs`): handler resolution is now registry-driven; no runtime probing.
- **Local dev tooling** (`.bin/bash/rebuild-shared-backend-local.sh`, `.bin/powershell/rebuild-shared-backend-local.ps1`): new scripts for faster backend rebuilds in local Docker.

## Test scenarios

```gherkin
Scenario: Command with a registered handler is dispatched correctly
  Given a command type with a registered ICommandHandler implementation
  When the dispatcher receives that command
  Then the correct handler is resolved from the registry
  And the command is executed successfully

Scenario: Command with no registered handler produces a clear error
  Given a command type with no registered handler
  When the dispatcher receives that command
  Then an InvalidOperationException is thrown
  And the message names the unresolved command type and hints at the fix

Scenario: Handler returning DataResult is wrapped into CommandResult
  Given a command handler that returns DataResult<T>
  When the command is dispatched via DispatchCommandAsync
  Then the result is successfully cast to CommandResult without throwing
```
