### PR TITLE
Add CSharp unit tests workflow

### DIFF
--- a/.github/workflows/backend-api-unit-tests.yml
+++ b/.github/workflows/backend-api-unit-tests.yml
@@ -1,0 +1,48 @@
+name: "Backend API Unit Tests / C#"
+
+on:
+  push:
+    paths:
+      - 'FinanceBackEnd/**'
+  pull_request:
+    paths:
+      - 'FinanceBackEnd/**'
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Debug repository info
+      run: |
+        echo "Repository: ${{ github.repository }}"
+        echo "Event: ${{ github.event_name }}"
+        echo "Ref: ${{ github.ref }}"
+        echo "SHA: ${{ github.sha }}"
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
+    - name: Restore NuGet packages
+      run: |
+        dotnet restore FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj
+
+    - name: Run unit tests
+      run: |
+        dotnet test FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj --configuration Release --no-restore --logger "trx;LogFileName=backend-api-unit-tests.trx"


### PR DESCRIPTION
# Why
Backend changes currently do not have a dedicated GitHub Actions workflow that executes the C# unit test suite. This PR adds that coverage so backend changes are validated automatically in CI on pull requests and on pushes.

## What is the solution?
- Added a new GitHub Actions workflow for backend unit tests under `.github/workflows/backend-api-unit-tests.yml`.
- Scoped the workflow to changes under `FinanceBackEnd/**`.
- Configured the workflow to:
  - checkout the repository
  - setup .NET 9
  - cache NuGet packages
  - restore `FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj`
  - run `dotnet test` in `Release` configuration with TRX logging enabled
- Enabled the workflow for both `pull_request` and `push` events.

## What areas of the site does it impact?
This impacts backend CI only. No API runtime behavior, application logic, database behavior, or frontend functionality is changed.
