### PR TITLE
Credit card service command refactoring

### DIFF
--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardCommandController.cs
@@ -1,27 +1,68 @@
 using CQRSDispatch.Interfaces;
 using Finance.Api.Controllers.Base;
+using Finance.Api.Controllers.Requests;
 using Finance.Application.Auth;
-using Finance.Application.Legacy.Commands.CreditCards;
 using Finance.Application.Legacy.Dtos.CreditCards;
 using Finance.Application.Legacy.Mapping;
+using Finance.Application.Services;
+using Finance.Application.Services.CreditCards;
 using Finance.Domain.Models.CreditCards;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Finance.Api.Controllers.Commands;
 
 [Route("api/credit-cards")]
-public class CreditCardCommandController(IMappingService mapper, IDispatcher<FinanceDispatchContext> dispatcher)
+public class CreditCardCommandController(
+    IMappingService mapper,
+    IDispatcher<FinanceDispatchContext> dispatcher,
+    CreditCardService creditCardService)
     : ApiBaseCommandController<CreditCard?, Guid, CreditCardDto>(mapper, dispatcher)
 {
     [HttpPost]
-    public async Task<IActionResult> Create(CreateCreditCardCommand command)
-    => await ExecuteAsync(command);
+    public async Task<IActionResult> Create(CreateCreditCardRequest request)
+    {
+        var result = await creditCardService.Create(request, Request);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
+        return Ok(MappingService.Map<CreditCardDto>(result.Data));
+    }
 
     [HttpPut]
-    public async Task<IActionResult> Update(UpdateCreditCardCommand command)
-        => await ExecuteAsync(command);
+    public async Task<IActionResult> Update(UpdateCreditCardRequest request)
+    {
+        var result = await creditCardService.Update(request, Request);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
+        return Ok(MappingService.Map<CreditCardDto>(result.Data));
+    }
 
     [HttpDelete]
-    public async Task<IActionResult> Delete(DeleteCreditCardCommand request)
-        => await ExecuteAsync(request);
+    public async Task<IActionResult> Delete(DeleteCreditCardRequest request)
+    {
+        var result = await creditCardService.Delete(request, Request);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
+        return Ok();
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpPost("{resourceId}/owner/{userId}")]
+    public async Task<IActionResult> SetOwner(SetCreditCardOwnerRequest request)
+    {
+        var result = await creditCardService.SetOwner(request.ResourceId, Request);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
+        return Ok();
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpDelete("{resourceId}/owner/{userId}")]
+    public async Task<IActionResult> DeleteOwner(DeleteCreditCardOwnerRequest request)
+    {
+        var result = await creditCardService.DeleteOwner(request.ResourceId, Request);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
+        return Ok();
+    }
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Requests/DeleteCreditCardOwnerRequest.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Requests/DeleteCreditCardOwnerRequest.cs
@@ -1,0 +1,6 @@
+using Finance.Api.Controllers.Requests.Base;
+
+namespace Finance.Api.Controllers.Requests;
+
+public class DeleteCreditCardOwnerRequest(Guid resourceId, Guid userId)
+    : BaseResourceOwnerRequest(resourceId, userId);

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Requests/SetCreditCardOwnerRequest.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Requests/SetCreditCardOwnerRequest.cs
@@ -1,0 +1,6 @@
+using Finance.Api.Controllers.Requests.Base;
+
+namespace Finance.Api.Controllers.Requests;
+
+public class SetCreditCardOwnerRequest(Guid resourceId, Guid userId)
+    : BaseResourceOwnerRequest(resourceId, userId);

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardPermissionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardPermissionsCommand.cs
@@ -1,0 +1,18 @@
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class CreateCreditCardPermissionsCommand : CreateResourcePermissionsCommand<CreditCard, Guid, CreditCardPermissions>;
+
+public class CreateCreditCardPermissionsCommandHandler(FinanceDbContext dbContext)
+    : CreateResourcePermissionsCommandHandler<CreateCreditCardPermissionsCommand, CreditCard, Guid, CreditCardPermissions>(dbContext)
+{
+    protected override async Task<CreditCard?> QuerySource(
+        CreateCreditCardPermissionsCommand request, CancellationToken cancellationToken)
+        => await DbContext.CreditCard
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.Id == request.ResourceId, cancellationToken);
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardOwnerCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardOwnerCommand.cs
@@ -1,0 +1,12 @@
+using Finance.Application.Commands.Base;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class DeleteCreditCardOwnerCommand
+    : DeleteEntityOwnerCommand<CreditCard, Guid, CreditCardPermissions>;
+
+public class DeleteCreditCardOwnerCommandHandler(FinanceDbContext dbContext)
+    : DeleteEntityOwnerCommandHandler<DeleteCreditCardOwnerCommand, CreditCard, Guid, CreditCardPermissions>(dbContext);

--- a/FinanceBackEnd/src/Finance.Application/Extensions/ServiceExtensions.cs
+++ b/FinanceBackEnd/src/Finance.Application/Extensions/ServiceExtensions.cs
@@ -33,6 +33,7 @@ public static class SagaServiceExtensions
         services.AddScoped<CurrencyExchangeRateService>();
         services.AddScoped<DebitService>();
         services.AddScoped<DebitOriginService>();
+        services.AddScoped<CreditCardService>();
 
         RegisterScopedService<IdentityService>(services);
 

--- a/FinanceBackEnd/src/Finance.Application/Services/CreditCardService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/CreditCardService.cs
@@ -1,0 +1,109 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Services.CreditCards;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using FinanceBackEnd.Finance.Domain.Enums;
+using Finance.Persistence;
+using Microsoft.AspNetCore.Http;
+
+namespace Finance.Application.Services;
+
+public class CreditCardService(
+    IDispatcher<FinanceDispatchContext> dispatcher,
+    FinanceDbContext dbContext)
+{
+    public async Task<DataResult<CreditCard>> Create(CreateCreditCardRequest request, HttpRequest? httpRequest = null)
+    {
+        await using var tx = await dbContext.Database.BeginTransactionAsync();
+        try
+        {
+            var result = await dispatcher.DispatchAsync(
+                new Finance.Application.Legacy.Commands.CreditCards.CreateCreditCardCommand
+                {
+                    BankId = request.BankId,
+                    Name = request.Name,
+                    Deactivated = request.Deactivated,
+                });
+
+            if (!result.IsSuccess)
+            {
+                await tx.RollbackAsync();
+                return result;
+            }
+
+            await dispatcher.DispatchAsync(
+                new CreateCreditCardPermissionsCommand
+                {
+                    ResourceId = result.Data!.Id,
+                    PermissionLevels = [PermissionLevelEnum.Owner],
+                },
+                httpRequest);
+
+            await tx.CommitAsync();
+            return result;
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync();
+            return DataResult<CreditCard>.Failure(ex.Message);
+        }
+    }
+
+    public async Task<DataResult<CreditCard>> Update(UpdateCreditCardRequest request, HttpRequest? httpRequest = null)
+        => await dispatcher.DispatchAsync(
+            new Finance.Application.Legacy.Commands.CreditCards.UpdateCreditCardCommand
+            {
+                Id = request.Id,
+                BankId = request.BankId,
+                Name = request.Name,
+                Deactivated = request.Deactivated,
+            });
+
+    public async Task<CommandResult> Delete(DeleteCreditCardRequest request, HttpRequest? httpRequest = null)
+    {
+        await using var tx = await dbContext.Database.BeginTransactionAsync();
+        try
+        {
+            var deleteResult = await dispatcher.DispatchCommandAsync(
+                new Finance.Application.Legacy.Commands.CreditCards.DeleteCreditCardCommand { Ids = request.Ids });
+
+            if (!deleteResult.IsSuccess)
+            {
+                await tx.RollbackAsync();
+                return deleteResult;
+            }
+
+            foreach (var id in request.Ids)
+            {
+                await dispatcher.DispatchAsync(
+                    new DeleteCreditCardOwnerCommand { EntityId = id },
+                    httpRequest);
+            }
+
+            await tx.CommitAsync();
+            return CommandResult.Success();
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync();
+            return CommandResult.Failure(ex.Message);
+        }
+    }
+
+    public async Task<DataResult<CreditCardPermissions>> SetOwner(Guid resourceId, HttpRequest? httpRequest = null)
+        => await dispatcher.DispatchAsync(
+            new CreateCreditCardPermissionsCommand
+            {
+                ResourceId = resourceId,
+                PermissionLevels = [PermissionLevelEnum.Owner],
+            },
+            httpRequest);
+
+    public async Task<CommandResult> DeleteOwner(Guid resourceId, HttpRequest? httpRequest = null)
+        => await dispatcher.DispatchAsync(
+            new DeleteCreditCardOwnerCommand { EntityId = resourceId },
+            httpRequest);
+}

--- a/FinanceBackEnd/src/Finance.Application/Services/CreditCards/CreditCardRequests.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/CreditCards/CreditCardRequests.cs
@@ -1,0 +1,7 @@
+namespace Finance.Application.Services.CreditCards;
+
+public sealed record CreateCreditCardRequest(Guid BankId, string Name, bool Deactivated);
+
+public sealed record UpdateCreditCardRequest(Guid Id, Guid BankId, string Name, bool Deactivated);
+
+public sealed record DeleteCreditCardRequest(Guid[] Ids);

--- a/FinanceBackEnd/src/Finance.Application/_Legacy/Commands/CreditCards/CreateCreditCardCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/_Legacy/Commands/CreditCards/CreateCreditCardCommand.cs
@@ -42,7 +42,7 @@ public class CreateCreditCardCommandHandler : BaseCommandHandler<CreateCreditCar
     }
 }
 
-public class CreateCreditCardCommand : ICommand
+public class CreateCreditCardCommand : ICommand<DataResult<CreditCard>>
 {
     [Required]
     public Guid BankId { get; set; }

--- a/FinanceBackEnd/src/Finance.Application/_Legacy/Commands/CreditCards/UpdateCreditCardCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/_Legacy/Commands/CreditCards/UpdateCreditCardCommand.cs
@@ -43,7 +43,7 @@ public class UpdateCreditCardCommandHandler : BaseCommandHandler<UpdateCreditCar
     }
 }
 
-public class UpdateCreditCardCommand : ICommand
+public class UpdateCreditCardCommand : ICommand<DataResult<CreditCard>>
 {
     [Required]
     public Guid Id { get; set; }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardPermissionsCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardPermissionsCommandHandlerTests.cs
@@ -1,0 +1,164 @@
+using Finance.Application.Auth;
+using Finance.Application.Commands.CreditCards;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Finance.Persistence;
+using FinanceBackEnd.Finance.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class CreateCreditCardPermissionsCommandHandlerTests : IDisposable
+{
+    private readonly FinanceDbContext _dbContext;
+
+    public CreateCreditCardPermissionsCommandHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task CreatePermissions_CreditCardAndUserFoundByClaimId_ReturnsPermissions()
+    {
+        const string userIdClaim = "auth0|test-user";
+        var creditCardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var user = new User
+        {
+            Id = userId,
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = userIdClaim }],
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.CreditCard.AddAsync(new CreditCard { Id = creditCardId });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new CreateCreditCardPermissionsCommand
+        {
+            ResourceId = creditCardId,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        };
+        command.SetContext(new FinanceDispatchContext { UserIdClaim = userIdClaim });
+
+        var handler = new CreateCreditCardPermissionsCommandHandler(_dbContext);
+
+        var result = await handler.ExecuteAsync(command);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(creditCardId, result.Data.ResourceId);
+        Assert.Equal(userId, result.Data.UserId);
+        Assert.Contains(PermissionLevelEnum.Owner, result.Data.PermissionLevels);
+    }
+
+    [Fact]
+    public async Task CreatePermissions_ExplicitUserId_FindsUserByIdAndReturnsPermissions()
+    {
+        var creditCardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        await _dbContext.User.AddAsync(new User { Id = userId, Username = "u", FirstName = "F", LastName = "L" });
+        await _dbContext.CreditCard.AddAsync(new CreditCard { Id = creditCardId });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new CreateCreditCardPermissionsCommand
+        {
+            ResourceId = creditCardId,
+            UserId = userId,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        };
+
+        var handler = new CreateCreditCardPermissionsCommandHandler(_dbContext);
+
+        var result = await handler.ExecuteAsync(command);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(userId, result.Data.UserId);
+    }
+
+    [Fact]
+    public async Task CreatePermissions_CreditCardNotFound_ReturnsFailure()
+    {
+        var command = new CreateCreditCardPermissionsCommand
+        {
+            ResourceId = Guid.NewGuid(),
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        };
+
+        var handler = new CreateCreditCardPermissionsCommandHandler(_dbContext);
+
+        var result = await handler.ExecuteAsync(command);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Resource not found", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task CreatePermissions_UserNotFound_ReturnsFailure()
+    {
+        var creditCardId = Guid.NewGuid();
+        await _dbContext.CreditCard.AddAsync(new CreditCard { Id = creditCardId });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new CreateCreditCardPermissionsCommand
+        {
+            ResourceId = creditCardId,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        };
+        command.SetContext(new FinanceDispatchContext { UserIdClaim = "auth0|unknown" });
+
+        var handler = new CreateCreditCardPermissionsCommandHandler(_dbContext);
+
+        var result = await handler.ExecuteAsync(command);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User not found", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task CreatePermissions_PersistsPermissionRecord()
+    {
+        const string userIdClaim = "auth0|persist-test";
+        var creditCardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        await _dbContext.User.AddAsync(new User
+        {
+            Id = userId,
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = userIdClaim }],
+        });
+        await _dbContext.CreditCard.AddAsync(new CreditCard { Id = creditCardId });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new CreateCreditCardPermissionsCommand
+        {
+            ResourceId = creditCardId,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        };
+        command.SetContext(new FinanceDispatchContext { UserIdClaim = userIdClaim });
+
+        var handler = new CreateCreditCardPermissionsCommandHandler(_dbContext);
+        await handler.ExecuteAsync(command);
+
+        var saved = await _dbContext.CreditCardPermissions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.ResourceId == creditCardId && p.UserId == userId);
+
+        Assert.NotNull(saved);
+        Assert.Contains(PermissionLevelEnum.Owner, saved.PermissionLevels);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/DeleteCreditCardOwnerCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/DeleteCreditCardOwnerCommandHandlerTests.cs
@@ -1,0 +1,136 @@
+using Finance.Application.Auth;
+using Finance.Application.Commands.CreditCards;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Finance.Persistence;
+using FinanceBackEnd.Finance.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class DeleteCreditCardOwnerCommandHandlerTests : IDisposable
+{
+    private readonly FinanceDbContext _dbContext;
+
+    public DeleteCreditCardOwnerCommandHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task DeleteOwner_MatchingPermissionsExist_DeletesAndReturnsSuccess()
+    {
+        var creditCardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var user = new User
+        {
+            Id = userId,
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = "IdentityNotFound" }],
+        };
+        var creditCard = new CreditCard { Id = creditCardId };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.CreditCard.AddAsync(creditCard);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Set<CreditCardPermissions>().Add(new CreditCardPermissions
+        {
+            ResourceId = creditCardId,
+            UserId = userId,
+            Resource = creditCard,
+            User = user,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new DeleteCreditCardOwnerCommand { EntityId = creditCardId };
+        command.SetContext(new FinanceDispatchContext { UserInfo = user });
+
+        var handler = new DeleteCreditCardOwnerCommandHandler(_dbContext);
+
+        var result = await handler.ExecuteAsync(command);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(_dbContext.Set<CreditCardPermissions>().IgnoreQueryFilters().ToList());
+    }
+
+    [Fact]
+    public async Task DeleteOwner_NoMatchingPermissions_ReturnsSuccess()
+    {
+        var command = new DeleteCreditCardOwnerCommand { EntityId = Guid.NewGuid() };
+        command.SetContext(new FinanceDispatchContext());
+
+        var handler = new DeleteCreditCardOwnerCommandHandler(_dbContext);
+
+        var result = await handler.ExecuteAsync(command);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task DeleteOwner_OnlyDeletesPermissionsForMatchingEntityAndUser()
+    {
+        var creditCardIdA = Guid.NewGuid();
+        var creditCardIdB = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+
+        var user = new User { Id = userId, Username = "u", FirstName = "F", LastName = "L", Identities = [new Identity { SourceId = "IdentityNotFound" }] };
+        var otherUser = new User { Id = otherUserId, Username = "v", FirstName = "G", LastName = "H" };
+        var cardA = new CreditCard { Id = creditCardIdA };
+        var cardB = new CreditCard { Id = creditCardIdB };
+
+        await _dbContext.User.AddRangeAsync(user, otherUser);
+        await _dbContext.CreditCard.AddRangeAsync(cardA, cardB);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Set<CreditCardPermissions>().AddRange(
+            new CreditCardPermissions
+            {
+                ResourceId = creditCardIdA,
+                UserId = userId,
+                Resource = cardA,
+                User = user,
+                PermissionLevels = [PermissionLevelEnum.Owner],
+            },
+            new CreditCardPermissions
+            {
+                ResourceId = creditCardIdB,
+                UserId = userId,
+                Resource = cardB,
+                User = user,
+                PermissionLevels = [PermissionLevelEnum.Owner],
+            },
+            new CreditCardPermissions
+            {
+                ResourceId = creditCardIdA,
+                UserId = otherUserId,
+                Resource = cardA,
+                User = otherUser,
+                PermissionLevels = [PermissionLevelEnum.Owner],
+            });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new DeleteCreditCardOwnerCommand { EntityId = creditCardIdA };
+        command.SetContext(new FinanceDispatchContext { UserInfo = user });
+
+        var handler = new DeleteCreditCardOwnerCommandHandler(_dbContext);
+        await handler.ExecuteAsync(command);
+
+        var remaining = _dbContext.Set<CreditCardPermissions>().IgnoreQueryFilters().ToList();
+        Assert.Equal(2, remaining.Count);
+        Assert.DoesNotContain(remaining, p => p.ResourceId == creditCardIdA && p.UserId == userId);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/CreditCards/CreditCardServiceTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/CreditCards/CreditCardServiceTests.cs
@@ -1,0 +1,395 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Services;
+using Finance.Application.Services.CreditCards;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+using FinanceBackEnd.Finance.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using CreateCreditCardCommand = Finance.Application.Legacy.Commands.CreditCards.CreateCreditCardCommand;
+using DeleteCreditCardCommand = Finance.Application.Legacy.Commands.CreditCards.DeleteCreditCardCommand;
+using UpdateCreditCardCommand = Finance.Application.Legacy.Commands.CreditCards.UpdateCreditCardCommand;
+
+namespace Finance.Application.Tests.Services.CreditCards;
+
+public class CreditCardServiceTests : IDisposable
+{
+    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
+    private readonly FinanceDbContext _dbContext;
+    private readonly CreditCardService _sut;
+
+    public CreditCardServiceTests()
+    {
+        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
+
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+        _sut = new CreditCardService(_dispatcher.Object, _dbContext);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    #region Create
+
+    [Fact]
+    public async Task Create_WhenDispatchSucceeds_ReturnsSuccess()
+    {
+        var creditCard = new CreditCard { Id = Guid.NewGuid() };
+        var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Success(creditCard));
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
+
+        var result = await _sut.Create(request);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(creditCard, result.Data);
+    }
+
+    [Fact]
+    public async Task Create_DispatchesCommandWithCorrectProperties()
+    {
+        var bankId = Guid.NewGuid();
+        var request = new CreateCreditCardRequest(bankId, "Visa Gold", true);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Success(new CreditCard()));
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
+
+        await _sut.Create(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCard>>(
+            It.Is<CreateCreditCardCommand>(c =>
+                c.BankId == bankId &&
+                c.Name == request.Name &&
+                c.Deactivated == request.Deactivated)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_DispatchesPermissionsCommandWithOwnerLevel()
+    {
+        var creditCard = new CreditCard { Id = Guid.NewGuid() };
+        var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Success(creditCard));
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
+
+        await _sut.Create(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(
+            It.Is<CreateCreditCardPermissionsCommand>(c =>
+                c.ResourceId == creditCard.Id &&
+                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
+            It.IsAny<HttpRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WhenDispatchFails_ReturnsFailure()
+    {
+        var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Failure("dispatch error"));
+
+        var result = await _sut.Create(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("dispatch error", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Create_WhenDispatchFails_DoesNotDispatchPermissions()
+    {
+        var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Failure("dispatch error"));
+
+        await _sut.Create(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(
+            It.IsAny<CreateCreditCardPermissionsCommand>(),
+            It.IsAny<HttpRequest?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_WhenDispatchThrows_ReturnsFailure()
+    {
+        var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .Throws(new Exception("unexpected error"));
+
+        var result = await _sut.Create(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("unexpected error", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region Update
+
+    [Fact]
+    public async Task Update_WhenDispatchSucceeds_ReturnsSuccess()
+    {
+        var creditCard = new CreditCard { Id = Guid.NewGuid() };
+        var request = new UpdateCreditCardRequest(creditCard.Id, Guid.NewGuid(), "Updated Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<UpdateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Success(creditCard));
+
+        var result = await _sut.Update(request);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(creditCard, result.Data);
+    }
+
+    [Fact]
+    public async Task Update_DispatchesCommandWithCorrectProperties()
+    {
+        var id = Guid.NewGuid();
+        var bankId = Guid.NewGuid();
+        var request = new UpdateCreditCardRequest(id, bankId, "Mastercard Platinum", true);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<UpdateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Success(new CreditCard()));
+
+        await _sut.Update(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCard>>(
+            It.Is<UpdateCreditCardCommand>(c =>
+                c.Id == id &&
+                c.BankId == bankId &&
+                c.Name == request.Name &&
+                c.Deactivated == request.Deactivated)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Update_WhenDispatchFails_ReturnsFailure()
+    {
+        var request = new UpdateCreditCardRequest(Guid.NewGuid(), Guid.NewGuid(), "Card", false);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<UpdateCreditCardCommand>()))
+            .ReturnsAsync(DataResult<CreditCard>.Failure("not found"));
+
+        var result = await _sut.Update(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("not found", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region Delete
+
+    [Fact]
+    public async Task Delete_WhenDispatchSucceeds_ReturnsSuccess()
+    {
+        var ids = new[] { Guid.NewGuid() };
+        var request = new DeleteCreditCardRequest(ids);
+
+        _dispatcher
+            .Setup(d => d.DispatchCommandAsync(It.IsAny<DeleteCreditCardCommand>()))
+            .ReturnsAsync(CommandResult.Success());
+        _dispatcher
+            .Setup(d => d.DispatchAsync<CommandResult>(It.IsAny<DeleteCreditCardOwnerCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(CommandResult.Success());
+
+        var result = await _sut.Delete(request);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Delete_DeletesOwnerForEachId()
+    {
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        var request = new DeleteCreditCardRequest(ids);
+
+        _dispatcher
+            .Setup(d => d.DispatchCommandAsync(It.IsAny<DeleteCreditCardCommand>()))
+            .ReturnsAsync(CommandResult.Success());
+        _dispatcher
+            .Setup(d => d.DispatchAsync<CommandResult>(It.IsAny<DeleteCreditCardOwnerCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(CommandResult.Success());
+
+        await _sut.Delete(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<CommandResult>(
+            It.IsAny<DeleteCreditCardOwnerCommand>(),
+            It.IsAny<HttpRequest?>()),
+            Times.Exactly(ids.Length));
+    }
+
+    [Fact]
+    public async Task Delete_DeletesOwnerWithCorrectEntityId()
+    {
+        var id = Guid.NewGuid();
+        var request = new DeleteCreditCardRequest([id]);
+
+        _dispatcher
+            .Setup(d => d.DispatchCommandAsync(It.IsAny<DeleteCreditCardCommand>()))
+            .ReturnsAsync(CommandResult.Success());
+        _dispatcher
+            .Setup(d => d.DispatchAsync<CommandResult>(It.IsAny<DeleteCreditCardOwnerCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(CommandResult.Success());
+
+        await _sut.Delete(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<CommandResult>(
+            It.Is<DeleteCreditCardOwnerCommand>(c => c.EntityId == id),
+            It.IsAny<HttpRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_WhenDeleteDispatchFails_ReturnsFailure()
+    {
+        var request = new DeleteCreditCardRequest([Guid.NewGuid()]);
+
+        _dispatcher
+            .Setup(d => d.DispatchCommandAsync(It.IsAny<DeleteCreditCardCommand>()))
+            .ReturnsAsync(CommandResult.Failure("delete error"));
+
+        var result = await _sut.Delete(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("delete error", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Delete_WhenDeleteDispatchFails_DoesNotDispatchOwnerDelete()
+    {
+        var request = new DeleteCreditCardRequest([Guid.NewGuid()]);
+
+        _dispatcher
+            .Setup(d => d.DispatchCommandAsync(It.IsAny<DeleteCreditCardCommand>()))
+            .ReturnsAsync(CommandResult.Failure("delete error"));
+
+        await _sut.Delete(request);
+
+        _dispatcher.Verify(d => d.DispatchAsync<CommandResult>(
+            It.IsAny<DeleteCreditCardOwnerCommand>(),
+            It.IsAny<HttpRequest?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_WhenThrows_ReturnsFailure()
+    {
+        var request = new DeleteCreditCardRequest([Guid.NewGuid()]);
+
+        _dispatcher
+            .Setup(d => d.DispatchCommandAsync(It.IsAny<DeleteCreditCardCommand>()))
+            .Throws(new Exception("unexpected"));
+
+        var result = await _sut.Delete(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("unexpected", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region SetOwner
+
+    [Fact]
+    public async Task SetOwner_DispatchesCreatePermissionsCommandWithOwnerLevel()
+    {
+        var resourceId = Guid.NewGuid();
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
+
+        await _sut.SetOwner(resourceId);
+
+        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(
+            It.Is<CreateCreditCardPermissionsCommand>(c =>
+                c.ResourceId == resourceId &&
+                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
+            It.IsAny<HttpRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SetOwner_ReturnsDispatchResult()
+    {
+        var permissions = new CreditCardPermissions();
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<CreditCardPermissions>.Success(permissions));
+
+        var result = await _sut.SetOwner(Guid.NewGuid());
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(permissions, result.Data);
+    }
+
+    #endregion
+
+    #region DeleteOwner
+
+    [Fact]
+    public async Task DeleteOwner_DispatchesDeleteOwnerCommandWithCorrectId()
+    {
+        var resourceId = Guid.NewGuid();
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<CommandResult>(It.IsAny<DeleteCreditCardOwnerCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(CommandResult.Success());
+
+        await _sut.DeleteOwner(resourceId);
+
+        _dispatcher.Verify(d => d.DispatchAsync<CommandResult>(
+            It.Is<DeleteCreditCardOwnerCommand>(c => c.EntityId == resourceId),
+            It.IsAny<HttpRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteOwner_ReturnsDispatchResult()
+    {
+        _dispatcher
+            .Setup(d => d.DispatchAsync<CommandResult>(It.IsAny<DeleteCreditCardOwnerCommand>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(CommandResult.Success());
+
+        var result = await _sut.DeleteOwner(Guid.NewGuid());
+
+        Assert.True(result.IsSuccess);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
# Why
Fixes #58.

`CreditCard` was dispatching commands directly from the controller with no service layer and no ownership management. Creating a credit card never assigned the calling user as owner, and there were no `SetOwner`/`DeleteOwner` endpoints.

This introduces `CreditCardService` following the simplified orchestration pattern established by `DebitService` and `DebitOriginService` (see `docs/architecture/orchestration-simplification.md`).

## What is the solution?

### New command handlers
- Created `Finance.Application/Commands/CreditCards/CreateCreditCardPermissionsCommand.cs` — extends the shared `CreateResourcePermissionsCommandHandler` base; `QuerySource` calls `.IgnoreQueryFilters()` to locate the card regardless of the current user's ownership filter.
- Created `Finance.Application/Commands/CreditCards/DeleteCreditCardOwnerCommand.cs` — removes a single owner permission record via the shared `DeleteEntityOwnerCommandHandler` base.
- Both legacy commands (`CreateCreditCardCommand`, `UpdateCreditCardCommand`) upgraded from `ICommand` to `ICommand<DataResult<CreditCard>>` so the typed dispatcher overload can infer the return type without ambiguity.

### `CreditCardService` introduced
- Created `Finance.Application/Services/CreditCardService.cs` as a plain primary-constructor service registered via `services.AddScoped<CreditCardService>()` in `ServiceExtensions`.
- `Create` — wraps in a transaction: dispatches `CreateCreditCardCommand`, on success dispatches `CreateCreditCardPermissionsCommand` with `Owner` level, then commits. Rolls back and returns `Failure` on any error.
- `Update` — single `DispatchAsync` call, no transaction needed.
- `Delete` — wraps in a transaction: dispatches `DeleteCreditCardCommand`, then dispatches `DeleteCreditCardOwnerCommand` for each deleted id, then commits. Rolls back on failure.
- `SetOwner` — single `DispatchAsync` for `CreateCreditCardPermissionsCommand` with `Owner` level.
- `DeleteOwner` — single `DispatchAsync` for `DeleteCreditCardOwnerCommand`.
- Created `Finance.Application/Services/CreditCards/CreditCardRequests.cs` with `sealed record` types: `CreateCreditCardRequest`, `UpdateCreditCardRequest`, `DeleteCreditCardRequest`.

### Controller updates
- `CreditCardCommandController` — injected `CreditCardService`; replaced raw command dispatch with service calls; added `SetOwner` (Admin-only) and `DeleteOwner` (Admin-only) endpoints.
- Added `Finance.Api/Controllers/Requests/SetCreditCardOwnerRequest.cs` and `DeleteCreditCardOwnerRequest.cs` (both extend `BaseResourceOwnerRequest`).

### Unit tests added
Full unit test coverage under `tests/Finance.Application.Tests/`:

**Command handlers:**
- `CreateCreditCardPermissionsCommandHandlerTests` — claim-based user lookup, explicit `UserId` lookup, card not found, user not found, persists record to DB.
- `DeleteCreditCardOwnerCommandHandlerTests` — deletes matching permission, no matching permissions (graceful), only deletes the specific entity+user combination leaving unrelated records intact.

**Service:**
- `CreditCardServiceTests` — `Create`/`Update`/`Delete`/`SetOwner`/`DeleteOwner` — success and failure dispatch paths, correct property propagation, permissions not dispatched on failure, owner delete skipped on delete failure, per-id owner-delete count.

## What areas of the site does it impact?
- **CreditCard API endpoints** (`POST`, `PUT`, `DELETE`) — same external behavior with new ownership assignment on create.
- **New endpoints** — `POST /api/credit-cards/{resourceId}/owner/{userId}` and `DELETE /api/credit-cards/{resourceId}/owner/{userId}` (Admin-only).
- No frontend changes. No database schema changes.

## Test scenarios

```gherkin
Scenario: Create a credit card
  Given a valid CreateCreditCardRequest (BankId, Name, Deactivated)
  When POST /api/credit-cards is called
  Then a new CreditCard entity is persisted
  And the calling user is assigned Owner permissions on that credit card

Scenario: Update a credit card
  Given an existing CreditCard id and valid update fields
  When PUT /api/credit-cards is called
  Then the credit card is updated with the new values

Scenario: Delete credit cards
  Given one or more existing CreditCard ids
  When DELETE /api/credit-cards is called
  Then each card is removed
  And the associated owner permission records are removed

Scenario: Assign owner to a credit card
  Given an existing CreditCard id and a target userId
  When POST /api/credit-cards/{resourceId}/owner/{userId} is called by an Admin
  Then a CreditCardPermissions record with Owner level is created for that user

Scenario: Remove owner from a credit card
  Given an existing CreditCard id
  When DELETE /api/credit-cards/{resourceId}/owner/{userId} is called by an Admin
  Then the matching CreditCardPermissions record is removed
```
