### PR TITLE
fix: base command handlers implement ICommandHandler<TCommand, CommandResult>

### DIFF
--- a/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseActivateCommandHandler.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseActivateCommandHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Finance.Application.Commands.Base;
 
-public abstract class BaseActivateCommandHandler<TCommand, TValidator, TEntity, TId>(FinanceDbContext dbContext) : ICommandHandler<TCommand>
+public abstract class BaseActivateCommandHandler<TCommand, TValidator, TEntity, TId>(FinanceDbContext dbContext) : ICommandHandler<TCommand, CommandResult>
     where TCommand : BatchUpdateBaseCommand<TId>
     where TValidator : BatchUpdateBaseCommandValidator<TCommand, TId>
     where TEntity : Entity<TId>

--- a/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseDeactivateCommandHandler.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseDeactivateCommandHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Finance.Application.Commands.Base;
 
-public abstract class BaseDeactivateCommandHandler<TCommand, TValidator, TEntity, TId>(FinanceDbContext dbContext) : ICommandHandler<TCommand>
+public abstract class BaseDeactivateCommandHandler<TCommand, TValidator, TEntity, TId>(FinanceDbContext dbContext) : ICommandHandler<TCommand, CommandResult>
     where TCommand : BatchUpdateBaseCommand<TId>
     where TValidator : BatchUpdateBaseCommandValidator<TCommand, TId>
     where TEntity : Entity<TId>

--- a/FinanceBackEnd/src/Finance.Application/Commands/_Base/DeleteEntityCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/_Base/DeleteEntityCommand.cs
@@ -8,7 +8,7 @@ namespace Finance.Application.Commands.Base;
 public abstract class DeleteEntityCommand<TId>() : BatchUpdateBaseCommand<TId>();
 
 public abstract class DeleteEntityCommandHandler<TEntity, TKey, TCommand, TValidator>(IRepository<TEntity, TKey> repository)
-    : ICommandHandler<TCommand>
+    : ICommandHandler<TCommand, CommandResult>
     where TCommand : DeleteEntityCommand<TKey>
     where TEntity : Entity<TKey>
     where TValidator : DeleteEntityCommandValidator<TCommand, TKey>, new()


### PR DESCRIPTION
# Why
Base command handlers (BaseActivateCommandHandler, BaseDeactivateCommandHandler, DeleteEntityCommandHandler) were implementing ICommandHandler<TCommand> instead of ICommandHandler<TCommand, CommandResult>, causing a type mismatch with callers that depend on the CommandResult return type.

## What is the solution?
Updated the class signatures of all three affected base handlers to implement the correct ICommandHandler<TCommand, CommandResult> interface variant.

## What areas of the site does it impact?
Backend command handling pipeline. Any concrete activate, deactivate, or delete command handlers that inherit from these base classes are affected.

## Test scenarios

```gherkin
Scenario: Activate command handler resolves with CommandResult
  Given a command handler that inherits from BaseActivateCommandHandler
  When the command is dispatched
  Then it resolves with a CommandResult

Scenario: Deactivate command handler resolves with CommandResult
  Given a command handler that inherits from BaseDeactivateCommandHandler
  When the command is dispatched
  Then it resolves with a CommandResult

Scenario: Delete command handler resolves with CommandResult
  Given a command handler that inherits from DeleteEntityCommandHandler
  When the command is dispatched
  Then it resolves with a CommandResult
```

## Other Notes
Closes #80