### PR TITLE
fix: add health check endpoints and improve startup reliability

### DIFF
--- a/.bin/powershell/rebuild-shared-backend-local.ps1
+++ b/.bin/powershell/rebuild-shared-backend-local.ps1
@@ -28,4 +28,32 @@ if ($exitCode -ne 0) {
 }
 
 Write-Host ""
-Write-Host "Backend service rebuilt and restarted successfully."
+Write-Host "Waiting for backend to be healthy (max 120s)..."
+$timeout = 120
+$elapsed = 0
+while ($elapsed -lt $timeout) {
+    $health = docker inspect --format='{{.State.Health.Status}}' "$projectShared-backend-1" 2>$null
+    if ($health -eq "healthy") {
+        Write-Host "Backend is healthy!"
+        break
+    }
+    if ($health -eq "unhealthy") {
+        Write-Host "Backend is unhealthy. Showing logs..."
+        docker compose -p $projectShared -f $sharedCompose logs backend --tail=50
+        Write-Host ""
+        Write-Host "To see live logs: docker compose -p $projectShared -f $sharedCompose logs -f backend"
+        exit 1
+    }
+    Write-Host "Backend status: $health - waiting... ($elapsed/$timeout seconds)"
+    Start-Sleep -Seconds 5
+    $elapsed += 5
+}
+
+if ($elapsed -ge $timeout) {
+    Write-Host "WARNING: Backend health check timed out. Showing logs..."
+    docker compose -p $projectShared -f $sharedCompose logs backend --tail=50
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Backend service rebuilt and is healthy."

--- a/.bin/powershell/start-finances-frontend-local.ps1
+++ b/.bin/powershell/start-finances-frontend-local.ps1
@@ -5,7 +5,7 @@ if (-not $dockerProcess) {
     exit 1
 }
 
-$financesCompose = Join-Path $PSScriptRoot "..\.infra\local\finances\docker-compose.yaml"
+$financesCompose = Join-Path $PSScriptRoot "..\..\.infra\local\finances\docker-compose.yaml"
 
 Write-Host "Checking compose files:"
 Write-Host "  Finances: $financesCompose"
@@ -33,9 +33,32 @@ if ($exitFinances -ne 0) {
 
 Write-Host ""
 if ($exitFinances -eq 0) {
+    Write-Host "Waiting for finances frontend to be healthy (max 60s)..."
+    $timeout = 60
+    $elapsed = 0
+    while ($elapsed -lt $timeout) {
+        $health = docker inspect --format='{{.State.Health.Status}}' "$projectFinances-frontend-1" 2>$null
+        if ($health -eq "healthy") {
+            Write-Host "Frontend is healthy!"
+            break
+        }
+        if ($health -eq "unhealthy") {
+            Write-Host "Frontend is unhealthy. Showing logs..."
+            docker compose -p $projectFinances -f $financesCompose logs frontend --tail=50
+            break
+        }
+        Write-Host "Frontend status: $health - waiting... ($elapsed/$timeout seconds)"
+        Start-Sleep -Seconds 5
+        $elapsed += 5
+    }
+    if ($elapsed -ge $timeout) {
+        Write-Host "WARNING: Frontend health check timed out. Showing logs..."
+        docker compose -p $projectFinances -f $financesCompose logs frontend --tail=50
+    }
+
+    Write-Host ""
     Write-Host "All services started successfully!"
     Write-Host "Frontend: http://localhost:5100"
-    Write-Host "Redis: localhost:6379"
     Write-Host ""
     Write-Host "To stop: docker compose -p $projectFinances stop"
 }

--- a/.infra/local/finances/docker-compose.yaml
+++ b/.infra/local/finances/docker-compose.yaml
@@ -11,8 +11,8 @@ services:
       - "5100:5100"
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5100/auth/login" ]
-      interval: 60s
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5100/health" ]
+      interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s

--- a/.infra/local/funds/docker-compose.yaml
+++ b/.infra/local/funds/docker-compose.yaml
@@ -19,6 +19,12 @@ services:
       - "5200:5200"
     command: ["sh", "-c", "npm run preview -- --port=5200 --host=0.0.0.0"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5200/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
 networks:
   default:

--- a/.infra/local/shared/docker-compose.yaml
+++ b/.infra/local/shared/docker-compose.yaml
@@ -89,11 +89,11 @@ services:
       jaeger:
         condition: service_started  # Jaeger is optional; tracing is disabled if unreachable
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/swagger/index.html"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
 
 volumes:
   redis-data:

--- a/FinanceBackEnd/src/Finance.Api/Core/Config/ConfigExtensions.cs
+++ b/FinanceBackEnd/src/Finance.Api/Core/Config/ConfigExtensions.cs
@@ -51,6 +51,8 @@ public static class ConfigExtensions
 
         // Make sure API Explorer is enabled for controller discovery
         services.AddEndpointsApiExplorer();
+
+        services.AddHealthChecks();
     }
 
     public static void ConfigureDataBase(this IServiceCollection services, WebApplicationBuilder builder)
@@ -123,6 +125,9 @@ public static class ConfigExtensions
 
         // Configure controllers
         app.MapControllers();
+
+        // Health check endpoint (no auth required — used by Docker and load balancers)
+        app.MapHealthChecks("/health");
 
         // Configure Swagger and API reference for both development and production
         SwaggerConfig.ConfigureOpenApiUI(app);

--- a/FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { Agent } from "https";
 import serverLogger from "@/utils/logger.server";
+import { buildAxiosConfig } from "./base/axiosConfig";
 import { BanksQuery } from "./queries/BanksQuery";
 import { CreditCardQuery } from "./queries/CreditCardQuery";
 import { CreditCardStatementQuery } from "./queries/CreditCardStatementQuery";
@@ -78,13 +79,7 @@ export class BackendClient {
 
     async get<TFilter>(endpoint: string, filters?: TFilter) {
         try {
-            const response = await axios.get(endpoint, {
-                params: filters ?? {},
-                httpsAgent: this.HttpsAgent,
-                headers: {
-                    Authorization: `Bearer ${this.AccessToken}`,
-                },
-            });
+            const response = await axios.get(endpoint, buildAxiosConfig(this.HttpsAgent, this.AccessToken, filters ?? {}));
 
             return response.data;
         } catch (error) {

--- a/FinanceFrontEnd/FinanceApp/app/data/base/BasePaginatedQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/base/BasePaginatedQuery.ts
@@ -30,13 +30,7 @@ export class BasePaginatedQuery extends BaseQuery {
         this.getPaginatedEndpoint instanceof BackendUrl
           ? this.getPaginatedEndpoint.toRaw()
           : String(this.getPaginatedEndpoint);
-      const response = await axios.get(endpointUrl, {
-        params: filters,
-        httpsAgent: this.httpsAgent,
-        headers: {
-          Authorization: `Bearer ${this.accessToken}`,
-        },
-      });
+      const response = await axios.get(endpointUrl, this.axiosConfig(filters));
 
       return response.data;
     } catch (error) {

--- a/FinanceFrontEnd/FinanceApp/app/data/base/BaseQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/base/BaseQuery.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { Agent } from 'https';
 import serverLogger from '@/utils/logger.server';
 import { BackendUrl } from '@/utils/BackendUrl';
+import { buildAxiosConfig } from './axiosConfig';
 
 export interface QueryEndpoints {
   get: BackendUrl | string;
@@ -18,15 +19,13 @@ export class BaseQuery {
     this.accessToken = accessToken;
   }
 
+  protected axiosConfig(params?: object) {
+    return buildAxiosConfig(this.httpsAgent, this.accessToken, params);
+  }
+
   async get<TFilter>(filters?: TFilter) {
     try {
-      const config = {
-        params: filters ?? {},
-        httpsAgent: this.httpsAgent,
-        headers: {
-          Authorization: `Bearer ${this.accessToken}`,
-        },
-      };
+      const config = this.axiosConfig(filters ?? {});
       const endpointUrl =
         this.getEndpoint instanceof BackendUrl
           ? this.getEndpoint.toRaw()

--- a/FinanceFrontEnd/FinanceApp/app/data/base/axiosConfig.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/base/axiosConfig.ts
@@ -1,0 +1,12 @@
+import { Agent } from 'https';
+
+export function buildAxiosConfig(httpsAgent: Agent, accessToken: string, params?: object) {
+  return {
+    params: params ?? {},
+    httpsAgent,
+    timeout: 10_000,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+}

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/CreditCardStatementQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/CreditCardStatementQuery.ts
@@ -13,13 +13,7 @@ export class CreditCardStatementQuery extends BaseQuery {
 
   async getLatest() {
     try {
-      const config = {
-        httpsAgent: this.httpsAgent,
-        headers: {
-          Authorization: `Bearer ${this.accessToken}`,
-        },
-      };
-      const response = await axios.get(urls.creditCardStatements.latest.toRaw(), config);
+      const response = await axios.get(urls.creditCardStatements.latest.toRaw(), this.axiosConfig());
       return response.data;
     } catch (error) {
       serverLogger.error('Error fetching latest statements:', error);

--- a/FinanceFrontEnd/FinanceApp/app/entry.server.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/entry.server.tsx
@@ -64,7 +64,7 @@ function handleBotRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve, _) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
       <ServerRouter context={remixContext} url={request.url} />,

--- a/FinanceFrontEnd/FinanceApp/app/entry.server.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/entry.server.tsx
@@ -87,7 +87,12 @@ function handleBotRequest(
         },
         onShellError(error: unknown) {
           SafeLogger.error('[Bot Request] Shell Error:', error);
-          reject(error);
+          resolve(
+            new Response('<!DOCTYPE html><html><body><h1>Server Error</h1></body></html>', {
+              status: 500,
+              headers: { 'Content-Type': 'text/html' },
+            })
+          );
         },
         onError(error: unknown) {
           SafeLogger.error('[Bot Request] Render Error:', error);
@@ -109,7 +114,7 @@ function handleBrowserRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
       <ServerRouter context={remixContext} url={request.url} />,
@@ -131,7 +136,13 @@ function handleBrowserRequest(
           pipe(body);
         },
         onShellError(error: unknown) {
-          reject(error);
+          SafeLogger.error('[Browser Request] Shell Error:', error);
+          resolve(
+            new Response('<!DOCTYPE html><html><body><h1>Server Error</h1></body></html>', {
+              status: 500,
+              headers: { 'Content-Type': 'text/html' },
+            })
+          );
         },
         onError(error: unknown) {
           responseStatusCode = HttpStatusConstants.INTERNAL_SERVER_ERROR;

--- a/FinanceFrontEnd/FinanceApp/app/entry.server.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/entry.server.tsx
@@ -64,7 +64,7 @@ function handleBotRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  return new Promise((resolve, _) => {
+  return new Promise((resolve) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
       <ServerRouter context={remixContext} url={request.url} />,

--- a/FinanceFrontEnd/FinanceApp/app/routes/health.ts
+++ b/FinanceFrontEnd/FinanceApp/app/routes/health.ts
@@ -1,0 +1,10 @@
+/**
+ * Simple health check endpoint for Docker and load balancers.
+ * Does NOT touch Redis or Auth0 — must stay dependency-free so it responds
+ * immediately even while the app is still warming up.
+ */
+export const loader = () =>
+  new Response('OK', {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });

--- a/FinanceFrontEnd/FinanceApp/app/services/auth/auth.server.ts
+++ b/FinanceFrontEnd/FinanceApp/app/services/auth/auth.server.ts
@@ -22,10 +22,14 @@ const JWKS = createRemoteJWKSet(
 );
 
 export async function verifyIdToken(idToken: string) {
-    const { payload } = await jwtVerify(idToken, JWKS, {
+    const verifyPromise = jwtVerify(idToken, JWKS, {
         issuer: `https://${AuthConstants.DOMAIN}/`,
         audience: AuthConstants.CLIENT_ID,
     });
+    const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('JWKS verification timed out')), 5000)
+    );
+    const { payload } = await Promise.race([verifyPromise, timeoutPromise]);
     return payload;
 }
 


### PR DESCRIPTION
# Why

Services lacked dedicated `/health` endpoints, so Docker health checks were pointing at the Swagger UI (`/swagger/index.html`) or the auth login page (`/auth/login`) — both slow to initialise and meaningless as liveness indicators. The funds service had no healthcheck at all. Local startup scripts had no way to confirm a service was actually ready, and would exit immediately after `docker compose up` returned. Additionally, the frontend SSR server would reject promises on shell-render errors (producing unhandled promise rejections) and JWKS token verification had no timeout, leaving it able to hang indefinitely on a network issue.

## What is the solution?

- **Backend API** (`ConfigExtensions.cs`): registered `services.AddHealthChecks()` and mapped `/health` with `app.MapHealthChecks("/health")` — no auth required, used by Docker and load-balancers.
- **Frontend health route** (`app/routes/health.ts`): new React Router route that returns `200 OK` for Docker health probes.
- **Docker health checks** (`.infra/local/`): updated all three `docker-compose.yaml` files to target the `/health` endpoints, tightened intervals (10 s / 5 s), and added a missing healthcheck block to the funds service.
- **Startup scripts** (`.bin/powershell/`): added polling loops that inspect Docker's own health status and wait up to 60–120 s before reporting success or printing logs on failure. Also fixed an incorrect relative path for the finances compose file.
- **Axios config extraction** (`data/base/axiosConfig.ts`): introduced `buildAxiosConfig()` helper to centralise `httpsAgent` + `Authorization` header logic; updated `BaseQuery`, `BasePaginatedQuery`, `CreditCardStatementQuery`, and `BackendClient` to use it.
- **SSR error handling** (`entry.server.tsx`): `onShellError` callbacks in both `handleBotRequest` and `handleBrowserRequest` now resolve with a proper `500` HTML response instead of calling `reject(error)`.
- **Auth timeout** (`auth.server.ts`): JWKS verification is now raced against a 5-second timeout promise so a stalled JWKS endpoint cannot block the request indefinitely.

## What areas of the site does it impact?

- **Infrastructure / local dev environment**: Docker health checks and startup scripts
- **Backend API**: new `/health` endpoint (all environments)
- **Frontend (FinanceApp)**: new health route, improved SSR resilience, centralised axios config, auth timeout guard
- No database schema changes; no breaking API changes

## Test scenarios

```gherkin
Scenario: Backend health check endpoint responds
  Given the backend API is running
  When a GET request is made to /health
  Then the response status is 200

Scenario: Frontend health check endpoint responds
  Given the frontend server is running
  When a GET request is made to /health
  Then the response status is 200

Scenario: Startup script waits for healthy backend
  Given the shared backend docker-compose is running
  When rebuild-shared-backend-local.ps1 is executed
  Then the script polls Docker health status every 5 s
  And exits with code 0 once the backend container reports healthy
  And exits with code 1 and prints logs if the container reports unhealthy

Scenario: SSR shell render error returns 500 instead of unhandled rejection
  Given a browser request triggers a React shell render error
  When onShellError is called
  Then the promise resolves with a 500 HTML response
  And no unhandled promise rejection is emitted

Scenario: JWKS verification times out gracefully
  Given the JWKS endpoint is unreachable
  When verifyIdToken is called
  Then the call rejects with 'JWKS verification timed out' after 5 s
```

## Other Notes

Closes #82
