### PR TITLE
feat: funds page server-side loader with URL-driven filter state

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import { useLoaderData, useLocation, useNavigate } from 'react-router';
 import dayjs from 'dayjs';
 import urls from '@/utils/urls';
-import CommonUtils from '@/utils/common';
 import BankCurrencySelector from '@/components/ui/utils/BankCurrencySelector';
 import PaginatedTable, { Column, Row } from '@/components/ui/utils/PaginatedTable';
 import { InputType } from '@/components/ui/utils/InputType';
-import { toNumber } from '@/utils/common';
+import CommonUtils, { toNumber } from '@/utils/common';
 import { cn } from '@/lib/utils';
 import type { FundRecord } from '@/types/fund';
 
@@ -15,8 +14,6 @@ interface PickerData {
   id: string;
   name: string;
 }
-
-interface FundRow extends FundRecord, Omit<Row, 'id'> {}
 
 interface LoaderData {
   banks: PickerData[];

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useLocation, useNavigate } from 'react-router';
 import dayjs from 'dayjs';
 import urls from '@/utils/urls';
 import BankCurrencySelector from '@/components/ui/utils/BankCurrencySelector';
-import PaginatedTable, { Column, Row } from '@/components/ui/utils/PaginatedTable';
+import PaginatedTable, { Column } from '@/components/ui/utils/PaginatedTable';
 import { InputType } from '@/components/ui/utils/InputType';
 import CommonUtils, { toNumber } from '@/utils/common';
 import { cn } from '@/lib/utils';

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
-import { useLoaderData } from 'react-router';
+import React from 'react';
+import { useLoaderData, useLocation, useNavigate } from 'react-router';
 import dayjs from 'dayjs';
 import urls from '@/utils/urls';
+import CommonUtils from '@/utils/common';
 import BankCurrencySelector from '@/components/ui/utils/BankCurrencySelector';
-import PaginatedTable, { Column } from '@/components/ui/utils/PaginatedTable';
+import PaginatedTable, { Column, Row } from '@/components/ui/utils/PaginatedTable';
 import { InputType } from '@/components/ui/utils/InputType';
 import { toNumber } from '@/utils/common';
 import { cn } from '@/lib/utils';
+import type { FundRecord } from '@/types/fund';
 
 // Define types for the props and states
 interface PickerData {
@@ -14,41 +16,43 @@ interface PickerData {
   name: string;
 }
 
+interface FundRow extends FundRecord, Omit<Row, 'id'> {}
+
 interface LoaderData {
   banks: PickerData[];
   currencies: PickerData[];
+  data: FundRecord[];
+  bankId: string;
+  currencyId: string;
 }
 
 const dateFormat = 'DD/MM/YYYY';
 
-const buildFundsEndpoint = (bankId: string, currencyId: string) => {
-  return urls.funds.paginated.with({
-    BankId: bankId,
-    CurrencyId: currencyId,
-    Page: 1,
-    PageSize: 10,
-  });
-};
-
 const Funds: React.FC = () => {
-  const { banks, currencies } = useLoaderData<LoaderData>();
-  const [selectedBankId, setSelectedBankId] = useState<string>(banks[0].id);
-  const [selectedCurrencyId, setSelectedCurrencyId] = useState<string>(currencies[0].id);
-  const [fundsEndpoint, setFundsEndpoint] = useState(
-    buildFundsEndpoint(selectedBankId, selectedCurrencyId)
-  );
-  const [reloadTable, setReloadTable] = useState<boolean>(true);
+  const { banks, currencies, data, bankId, currencyId } = useLoaderData<LoaderData>();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  // Removed updateFundsEndpoint helper to keep effect dependencies stable.
+  const reload = ({
+    currentBankId,
+    currentCurrencyId,
+  }: {
+    currentBankId?: string;
+    currentCurrencyId?: string;
+  }) => {
+    const params = CommonUtils.Params({
+      bankId: currentBankId ?? bankId,
+      currencyId: currentCurrencyId ?? currencyId,
+    });
+    navigate(`${location.pathname}?${params}`);
+  };
 
   const onBankPickerChange = (picker: { value: string }) => {
-    const newBankId = selectedBankId !== picker.value ? picker.value : selectedBankId;
-    setSelectedBankId(newBankId);
+    reload({ currentBankId: picker.value });
   };
 
   const onCurrencyPickerChange = (picker: { value: string }) => {
-    const newCurrencyId = selectedCurrencyId !== picker.value ? picker.value : selectedCurrencyId;
-    setSelectedCurrencyId(newCurrencyId);
+    reload({ currentCurrencyId: picker.value });
   };
 
   const valueConditionalClass = {
@@ -72,13 +76,7 @@ const Funds: React.FC = () => {
       placeholder: 'Fecha',
       type: InputType.DateTime,
       editable: {
-        defaultValue: () => {
-          const rowSelector = document.querySelector('.bank-table-data-row > td > span');
-
-          if (!rowSelector?.textContent) return dayjs().format(dateFormat);
-
-          return dayjs(rowSelector.textContent, `${dateFormat}`).format(dateFormat);
-        },
+        defaultValue: () => dayjs().format(dateFormat),
       },
       datetime: {
         timeFormat: 'HH:mm',
@@ -101,7 +99,7 @@ const Funds: React.FC = () => {
       endpoint: urls.banks.endpoint,
       mapper: {
         id: 'id',
-        label: 'name',
+        label: (record) => (record as unknown as FundRecord).bank.name,
       },
     },
     {
@@ -113,7 +111,7 @@ const Funds: React.FC = () => {
       endpoint: urls.currencies.endpoint,
       mapper: {
         id: 'id',
-        label: 'name',
+        label: (record) => (record as unknown as FundRecord).currency.name,
       },
     },
     {
@@ -148,46 +146,43 @@ const Funds: React.FC = () => {
     },
   ];
 
-  // Update the endpoint whenever selectedBankId or selectedCurrencyId changes
-  React.useEffect(() => {
-    if (selectedBankId && selectedCurrencyId) {
-      setFundsEndpoint(buildFundsEndpoint(selectedBankId, selectedCurrencyId));
-      setReloadTable(true);
-    }
-  }, [selectedBankId, selectedCurrencyId]);
+  const paginatedData = Array.isArray(data)
+    ? {
+        items: data,
+        totalPages: 1,
+      }
+    : data;
 
   return (
     <div className={cn(['py-10', 'px-40'])}>
       <BankCurrencySelector
         banks={banks}
         currencies={currencies}
-        bankId={selectedBankId}
-        currencyId={selectedCurrencyId}
+        bankId={bankId}
+        currencyId={currencyId}
         onBankChange={onBankPickerChange}
         onCurrencyChange={onCurrencyPickerChange}
       />
-      {!fundsEndpoint && <div className="text-center">Cargando datos</div>}
-      {fundsEndpoint && (
-        <PaginatedTable
-          name={'funds-table'}
-          url={fundsEndpoint}
-          reloadData={reloadTable}
-          columns={TableColumns}
-          admin={{
-            endpoint: urls.funds.endpoint,
-            key: [
-              {
-                id: 'BankId',
-                value: selectedBankId,
-              },
-              {
-                id: 'CurrencyId',
-                value: selectedCurrencyId,
-              },
-            ],
-          }}
-        />
-      )}
+      <PaginatedTable
+        name={'funds-table'}
+        columns={TableColumns}
+        data={paginatedData}
+        onAdd={() => reload({})}
+        onDelete={() => reload({})}
+        admin={{
+          endpoint: urls.funds.endpoint,
+          key: [
+            {
+              id: 'BankId',
+              value: bankId,
+            },
+            {
+              id: 'CurrencyId',
+              value: currencyId,
+            },
+          ],
+        }}
+      />
     </div>
   );
 };

--- a/FinanceFrontEnd/FinanceApp/app/routes/funds.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/funds.tsx
@@ -1,25 +1,63 @@
-import { getBackendClient } from "@/data/getBackendClient";
-import Funds from "@/components/ui/Funds";
-import { LoaderFunctionArgs } from "react-router";
-import { requireAuth } from "@/services/auth/session.server";
+import { getBackendClient } from '@/data/getBackendClient';
+import Funds from '@/components/ui/Funds';
+import { LoaderFunctionArgs } from 'react-router';
+import { requireAuth } from '@/services/auth/session.server';
+import urls from '@/utils/urls';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const user = await requireAuth(request);
+  const user = await requireAuth(request);
 
-    if (!user.accessToken) {
-        throw new Error("No access token available");
-    }
+  if (!user.accessToken) {
+    throw new Error('No access token available');
+  }
 
-    const client = await getBackendClient(user.accessToken!);
+  const requestUrl = new URL(request.url);
+  const page = Number(requestUrl.searchParams.get('page') ?? DEFAULT_PAGE);
+  const pageSize = Number(requestUrl.searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE);
+  let selectedBankId = requestUrl.searchParams.get('bankId') ?? undefined;
+  let selectedCurrencyId = requestUrl.searchParams.get('currencyId') ?? undefined;
 
-    const banks = await client.GetBanksQuery().get();
+  const client = await getBackendClient(user.accessToken!);
 
-    const currencies = await client.GetCurrenciesQuery().get();
+  const getDataPromise = (bankId: string, currencyId: string) => {
+    const dataUrl = urls.funds.paginated
+      .with({
+        Page: page,
+        PageSize: pageSize,
+        BankId: bankId,
+        CurrencyId: currencyId,
+      })
+      .toRaw();
+    return client.get(dataUrl);
+  };
 
-    return {
-        banks,
-        currencies,
-    };
+  const queries = [await client.GetBanksQuery().get(), await client.GetCurrenciesQuery().get()];
+
+  if (selectedBankId && selectedCurrencyId) {
+    queries.push(getDataPromise(selectedBankId, selectedCurrencyId));
+  }
+
+  const results = await Promise.all(queries);
+  const banks = results[0];
+  const currencies = results[1];
+  let data = results[2] ?? null;
+
+  if (!data && banks?.length > 0 && currencies?.length > 0) {
+    selectedBankId ??= banks[0].id;
+    selectedCurrencyId ??= currencies[0].id;
+    data = await getDataPromise(selectedBankId!, selectedCurrencyId!);
+  }
+
+  return {
+    banks,
+    currencies,
+    data: data ?? [],
+    bankId: selectedBankId,
+    currencyId: selectedCurrencyId,
+  };
 };
 
 export const meta = () => {

--- a/FinanceFrontEnd/FinanceApp/app/types/fund.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/fund.ts
@@ -1,0 +1,15 @@
+import type { BankData, CurrencyData } from './income';
+
+export interface FundRecord {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  timeStamp: string;
+  deactivated: boolean;
+  amount: number;
+  bankId: string;
+  currencyId: string;
+  dailyUse: boolean;
+  bank: BankData;
+  currency: CurrencyData;
+}


### PR DESCRIPTION
# Why
Migrate the Funds page from a client-side state-driven approach (useState hooks + client-triggered API calls through PaginatedTable) to a React Router server-side loader pattern with URL query-param-driven filter state. This aligns the Funds page with the standard data-loading pattern used elsewhere in the app, improves initial page load (data arrives with the route), and makes bank/currency filter state bookmarkable and shareable via the URL.

## What is the solution?
- Added a new `FundRecord` TypeScript interface in `app/types/fund.ts` to type fund data returned from the API.
- Refactored the route loader in `app/routes/funds.tsx` to parse `bankId`, `currencyId`, `page`, and `pageSize` from URL search params and fetch fund data server-side using `Promise.all` for parallel requests. Default bank/currency are resolved server-side when no params are present.
- Refactored the `Funds` component in `app/components/ui/Funds/index.tsx` to consume `data`, `bankId`, and `currencyId` directly from `useLoaderData`. Replaced `useState` hooks with `useNavigate`/`useLocation` so that changing the bank or currency selector updates the URL, triggering a fresh loader execution. Add/delete callbacks also navigate to reload.
- Simplified column label mappers to use the typed `FundRecord.bank.name` and `FundRecord.currency.name` fields.
- Removed the `defaultValue` DOM-query hack for date columns.

## What areas of the site does it impact?
- **Funds page** (`/funds` route) — data loading, filter selectors, and CRUD table behaviour.
- No other routes or shared components are changed.

## Test scenarios

```gherkin
Scenario: Initial page load shows fund data for default bank and currency
  Given the user navigates to /funds with no query params
  When the page loads
  Then the loader resolves the first bank and first currency as defaults
  And fund records for those defaults are displayed in the table

Scenario: Changing the bank selector reloads data
  Given the Funds page is loaded
  When the user selects a different bank from the bank picker
  Then the URL is updated with the new bankId query param
  And the loader fetches fund records for the selected bank and current currency
  And the table displays the refreshed fund records

Scenario: Changing the currency selector reloads data
  Given the Funds page is loaded
  When the user selects a different currency from the currency picker
  Then the URL is updated with the new currencyId query param
  And the loader fetches fund records for the current bank and selected currency
  And the table displays the refreshed fund records

Scenario: Adding a fund record refreshes the table
  Given the Funds page is loaded with existing fund records
  When the user adds a new fund record via the table admin controls
  Then the onAdd callback navigates to the same URL
  And the loader re-fetches and the new record appears in the table

Scenario: Deleting a fund record refreshes the table
  Given the Funds page is loaded with existing fund records
  When the user deletes a fund record via the table admin controls
  Then the onDelete callback navigates to the same URL
  And the loader re-fetches and the deleted record is removed from the table
```

## Other Notes
Closes #84