### PR TITLE
feat: add edit credit card statement and transactions feature

### DIFF
--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardMovementCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardMovementCommandController.cs
@@ -19,6 +19,10 @@ public class CreditCardTransactionCommandController(IMappingService mapper, IDis
     public async Task<IActionResult> Create(CreateCreditCardTransactionCommand request)
         => await ExecuteAsync(request);
 
+    [HttpPut]
+    public async Task<IActionResult> Update(UpdateCreditCardTransactionCommand request)
+        => await ExecuteAsync(request);
+
     [HttpDelete]
     public async Task<IActionResult> Delete(DeleteCreditCardTransactionCommand request)
         => await ExecuteAsync(request);

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardTransactionCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardTransactionCommand.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.SpecialTypes;
+using Finance.Persistence;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class UpdateCreditCardTransactionCommandHandler(
+    IRepository<CreditCardTransaction, Guid> transactionRepository,
+    FinanceDbContext db)
+    : BaseUpdateCommandHandler<CreditCardTransaction, Guid, UpdateCreditCardTransactionCommand>(
+        transactionRepository, db)
+{
+    protected override Task<CreditCardTransaction> UpdateRecord(
+        UpdateCreditCardTransactionCommand command,
+        CreditCardTransaction record,
+        CancellationToken cancellationToken)
+    {
+        record.Timestamp = command.Timestamp;
+        record.Concept = command.Concept;
+        record.Amount = command.Amount;
+        return Task.FromResult(record);
+    }
+}
+
+public class UpdateCreditCardTransactionCommand : BaseUpdateCommand<CreditCardTransaction, Guid>
+{
+    [Required]
+    public DateTime Timestamp { get; set; }
+    [Required]
+    [StringLength(500)]
+    public string Concept { get; set; } = string.Empty;
+    [Required]
+    public Money Amount { get; set; } = 0;
+}
+
+public class UpdateCreditCardTransactionCommandValidator
+    : BaseUpdateCommandValidator<UpdateCreditCardTransactionCommand, CreditCardTransaction, Guid>
+{
+    public UpdateCreditCardTransactionCommandValidator(
+        IRepository<CreditCardTransaction, Guid> repository)
+        : base(repository)
+    {
+    }
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/utils/Modal';
 import urls from '@/utils/urls';
 import type { CreditCard, CreditCardStatement, CreditCardTransaction } from '@/types/creditCard';
+import EditStatementModal from './EditStatementModal';
 
 const formatDate = (dateStr: string) => {
   if (!dateStr) return '-';
@@ -222,6 +223,7 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
   const [transactions, setTransactions] = useState<CreditCardTransaction[]>([]);
   const [loading, setLoading] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
 
   const fetchStatements = useCallback(async () => {
     try {
@@ -316,6 +318,16 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
           >
             Nuevo Resúmen
           </Button>
+          {statements.length > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-primary text-primary hover:bg-primary/10"
+              onClick={() => setShowEditModal(true)}
+            >
+              Editar Resúmen
+            </Button>
+          )}
         </div>
       </div>
       <Separator className="my-5" />
@@ -338,6 +350,19 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
         creditCardId={card.id}
         onCreated={fetchStatements}
       />
+
+      {statements.length > 0 && (
+        <EditStatementModal
+          show={showEditModal}
+          onHide={() => setShowEditModal(false)}
+          statement={statements[statementIndex]}
+          transactions={transactions}
+          onSaved={() => {
+            fetchStatements();
+            fetchTransactions();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
@@ -1,0 +1,289 @@
+import { useState, useEffect } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/shadcn/table';
+import { Button } from '@/components/ui/shadcn/button';
+import { Input } from '@/components/ui/shadcn/input';
+import { Label } from '@/components/ui/shadcn/label';
+import { Separator } from '@/components/ui/shadcn/separator';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalBody,
+  ModalFooter,
+} from '@/components/ui/utils/Modal';
+import urls from '@/utils/urls';
+import type { CreditCardStatement, CreditCardTransaction } from '@/types/creditCard';
+
+interface DraftTransaction {
+  id?: string;
+  timestamp: string;
+  concept: string;
+  amount: string;
+  isDeleted: boolean;
+  isModified: boolean;
+}
+
+export default function EditStatementModal({
+  show,
+  onHide,
+  statement,
+  transactions,
+  onSaved,
+}: {
+  show: boolean;
+  onHide: () => void;
+  statement: CreditCardStatement;
+  transactions: CreditCardTransaction[];
+  onSaved: () => void;
+}) {
+  const [closureDate, setClosureDate] = useState('');
+  const [expiringDate, setExpiringDate] = useState('');
+  const [draftTxs, setDraftTxs] = useState<DraftTransaction[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (show) {
+      setClosureDate(statement.closureDate.slice(0, 10));
+      setExpiringDate(statement.expiringDate.slice(0, 10));
+      setDraftTxs(
+        transactions.map((tx) => ({
+          id: tx.id,
+          timestamp: tx.timestamp.slice(0, 10),
+          concept: tx.concept,
+          amount: String(tx.amount),
+          isDeleted: false,
+          isModified: false,
+        }))
+      );
+    }
+  }, [show, statement, transactions]);
+
+  const updateTx = (
+    index: number,
+    field: keyof Pick<DraftTransaction, 'timestamp' | 'concept' | 'amount'>,
+    value: string
+  ) => {
+    setDraftTxs((prev) =>
+      prev.map((tx, i) => (i === index ? { ...tx, [field]: value, isModified: true } : tx))
+    );
+  };
+
+  const deleteTx = (index: number) => {
+    setDraftTxs((prev) =>
+      prev.map((tx, i) => (i === index ? { ...tx, isDeleted: true } : tx))
+    );
+  };
+
+  const addRow = () => {
+    setDraftTxs((prev) => [
+      ...prev,
+      {
+        timestamp: new Date().toISOString().slice(0, 10),
+        concept: '',
+        amount: '0',
+        isDeleted: false,
+        isModified: false,
+      },
+    ]);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const origClosure = statement.closureDate.slice(0, 10);
+      const origExpiring = statement.expiringDate.slice(0, 10);
+      if (closureDate !== origClosure || expiringDate !== origExpiring) {
+        const res = await fetch(String(urls.creditCardStatements.endpoint), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            id: statement.id,
+            creditCardId: statement.creditCardId,
+            closureDate: new Date(closureDate).toISOString(),
+            expiringDate: new Date(expiringDate).toISOString(),
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      for (const tx of draftTxs.filter((t) => t.isDeleted && t.id !== undefined)) {
+        const res = await fetch(String(urls.creditCardTransactions.endpoint), {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: tx.id }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      for (const tx of draftTxs.filter((t) => !t.isDeleted && t.id === undefined)) {
+        const res = await fetch(String(urls.creditCardTransactions.endpoint), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            creditCardId: statement.creditCardId,
+            timestamp: new Date(tx.timestamp).toISOString(),
+            concept: tx.concept,
+            amount: Number(tx.amount),
+            transactionType: 0,
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      for (const tx of draftTxs.filter(
+        (t) => !t.isDeleted && t.id !== undefined && t.isModified
+      )) {
+        const res = await fetch(String(urls.creditCardTransactions.endpoint), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            id: tx.id,
+            timestamp: new Date(tx.timestamp).toISOString(),
+            concept: tx.concept,
+            amount: Number(tx.amount),
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      onSaved();
+      onHide();
+    } catch (err) {
+      alert(`Error al guardar: ${err}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const visibleTxs = draftTxs.filter((t) => !t.isDeleted);
+
+  return (
+    <Modal show={show} onHide={onHide} size="4xl">
+      <form onSubmit={handleSave}>
+        <ModalHeader closeButton>
+          <ModalTitle>
+            <h3 className="text-lg font-medium">Editar Resúmen</h3>
+          </ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="edit-closure-date" className="block mb-2">
+                  Fecha de Cierre
+                </Label>
+                <Input
+                  id="edit-closure-date"
+                  type="date"
+                  required
+                  value={closureDate}
+                  onChange={(e) => setClosureDate(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-expiring-date" className="block mb-2">
+                  Fecha de Vencimiento
+                </Label>
+                <Input
+                  id="edit-expiring-date"
+                  type="date"
+                  required
+                  value={expiringDate}
+                  onChange={(e) => setExpiringDate(e.target.value)}
+                />
+              </div>
+            </div>
+            <Separator />
+            <div>
+              <p className="text-sm font-medium mb-3">Movimientos</p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-36">Fecha</TableHead>
+                    <TableHead>Concepto</TableHead>
+                    <TableHead className="w-28 text-right">Monto</TableHead>
+                    <TableHead className="w-10"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visibleTxs.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center text-muted-foreground">
+                        Sin movimientos
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    visibleTxs.map((tx) => {
+                      const realIndex = draftTxs.indexOf(tx);
+                      return (
+                        <TableRow key={tx.id ?? `new-${realIndex}`}>
+                          <TableCell>
+                            <Input
+                              type="date"
+                              value={tx.timestamp}
+                              onChange={(e) => updateTx(realIndex, 'timestamp', e.target.value)}
+                              className="h-8 text-sm"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              value={tx.concept}
+                              onChange={(e) => updateTx(realIndex, 'concept', e.target.value)}
+                              className="h-8 text-sm"
+                              placeholder="Concepto"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              type="number"
+                              step="0.01"
+                              value={tx.amount}
+                              onChange={(e) => updateTx(realIndex, 'amount', e.target.value)}
+                              className="h-8 text-sm text-right"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => deleteTx(realIndex)}
+                              className="text-destructive hover:text-destructive h-8 w-8 p-0"
+                            >
+                              ×
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })
+                  )}
+                </TableBody>
+              </Table>
+              <Button type="button" variant="outline" size="sm" className="mt-2" onClick={addRow}>
+                + Agregar fila
+              </Button>
+            </div>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <div className="flex justify-end space-x-2 mt-6">
+            <Button type="button" variant="outline" onClick={onHide}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Guardando...' : 'Guardar'}
+            </Button>
+          </div>
+        </ModalFooter>
+      </form>
+    </Modal>
+  );
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Modal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Modal.tsx
@@ -5,6 +5,17 @@ type ModalProps = {
     onHide?: () => void;
     show?: boolean;
     children?: React.ReactNode;
+    size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+};
+
+const sizeClass: Record<NonNullable<ModalProps['size']>, string> = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl',
+    '4xl': 'max-w-4xl',
 };
 
 const ModalContext = createContext<{ onHide?: () => void }>({});
@@ -13,6 +24,7 @@ export const Modal: React.FC<ModalProps> = ({
     children,
     show = false,
     onHide,
+    size = 'md',
 }) => {
     return (
         <ModalContext.Provider value={{ onHide }}>
@@ -45,7 +57,7 @@ export const Modal: React.FC<ModalProps> = ({
                                 leaveFrom="opacity-100 scale-100"
                                 leaveTo="opacity-0 scale-95"
                             >
-                                <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                                <Dialog.Panel className={`w-full ${sizeClass[size]} transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all`}>
                                     {children}
                                 </Dialog.Panel>
                             </Transition.Child>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Modal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Modal.tsx
@@ -57,7 +57,7 @@ export const Modal: React.FC<ModalProps> = ({
                                 leaveFrom="opacity-100 scale-100"
                                 leaveTo="opacity-0 scale-95"
                             >
-                                <Dialog.Panel className={`w-full ${sizeClass[size]} transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all`}>
+                                <Dialog.Panel className={`w-full ${sizeClass[size]} transform overflow-hidden rounded-2xl bg-background text-foreground p-6 text-left align-middle shadow-xl transition-all border border-border`}>
                                     {children}
                                 </Dialog.Panel>
                             </Transition.Child>
@@ -86,7 +86,7 @@ export const ModalHeader: React.FC<ModalHeaderProps> = ({
                 <button
                     aria-label="close"
                     onClick={onHide}
-                    className="ml-4 text-gray-500 hover:text-gray-700"
+                    className="ml-4 text-muted-foreground hover:text-foreground"
                 >
                     ×
                 </button>


### PR DESCRIPTION
# Why
The credit card detail view only allowed creating new statements and transactions but had no way to modify or delete existing ones. This feature adds a full edit flow so users can update statement dates and manage transactions inline.

## What is the solution?
- Added `UpdateCreditCardTransactionCommand` (command, handler, validator) in the Application layer following the existing CQRS pattern, mirroring `CreateCreditCardTransactionCommand`.
- Exposed a new `[HttpPut]` action in `CreditCardTransactionCommandController` that dispatches the update command.
- Created `EditStatementModal` — a React component that loads the current statement dates and all related transactions into a draft state; it then submits deletions, creations, and modifications in sequence on save.
- Integrated `EditStatementModal` into `CreditCardDetail`, rendered behind a conditional *Editar Resumen* button (visible only when at least one statement exists).
- Generalized the `Modal` utility component with a `size` prop (`sm` to `4xl`) so the edit modal can render at a wider size.

## What areas of the site does it impact?
- **Backend — Application layer**: new `UpdateCreditCardTransactionCommand` in `Finance.Application/Commands/CreditCards`
- **Backend — API layer**: updated `CreditCardMovementCommandController` with a PUT endpoint
- **Frontend — CreditCards module**: new `EditStatementModal` component and updated `CreditCardDetail`
- **Frontend — shared utils**: `Modal` component extended with `size` prop (non-breaking, defaults to `md`)

## Test scenarios

```gherkin
Scenario: Edit button is hidden when no statements exist
  Given a credit card with no statements
  When the user views the credit card detail
  Then the "Editar Resumen" button is not visible

Scenario: Open edit modal
  Given a credit card with at least one statement and some transactions
  When the user clicks "Editar Resumen"
  Then the edit modal opens pre-populated with the current statement dates and transactions

Scenario: Modify a transaction and save
  Given the edit modal is open with existing transactions
  When the user changes the concept of a transaction and clicks Save
  Then a PUT request is sent for that transaction
  And the parent view refreshes with the updated data

Scenario: Delete a transaction and save
  Given the edit modal is open with existing transactions
  When the user marks a transaction as deleted and clicks Save
  Then a DELETE request is sent for that transaction
  And the transaction no longer appears in the list

Scenario: Add a new transaction and save
  Given the edit modal is open
  When the user adds a new row, fills in the fields, and clicks Save
  Then a POST request is sent for the new transaction
  And the new transaction appears in the list

Scenario: Edit statement dates and save
  Given the edit modal is open
  When the user changes the closure or expiring date and clicks Save
  Then a PUT request is sent for the statement with the new dates
```

## Other Notes
Closes #86
