### PR TITLE
fix: GetCurrentIncomesQuery returns wrong income per bank — GroupBy does not preserve OrderByDescending

### DIFF
--- a/FinanceBackEnd/src/Finance.Application/Queries/Summary/GetCurrentIncomesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/Summary/GetCurrentIncomesQuery.cs
@@ -36,9 +36,8 @@ public class GetCurrentIncomesQueryHandler(FinanceDbContext db, IRepository<Inco
 
         var data = await query
             .Where(q => q.TimeStamp >= dateFilter)
-            .OrderByDescending(i => i.TimeStamp)
             .GroupBy(g => new { g.BankId, g.CurrencyId })
-            .Select(g => g.First())
+            .Select(g => g.OrderByDescending(i => i.TimeStamp).First())
             .ToListAsync(cancellationToken);
 
         return DataResult<List<Income>>.Success(data);


### PR DESCRIPTION
# Why

`GetCurrentIncomesQueryHandler` was applying `OrderByDescending(i => i.TimeStamp)` **before** `GroupBy`, then calling `g.First()` inside each group. SQL `GROUP BY` does not propagate outer query ordering into groups, so the income record selected for each `(BankId, CurrencyId)` pair was arbitrary — not the most recent one.

## What is the solution?

Moved `OrderByDescending` inside the `Select` projection so it is evaluated **within** each group before `First()` is called:

\\\csharp
// Before (broken)
.OrderByDescending(i => i.TimeStamp)
.GroupBy(g => new { g.BankId, g.CurrencyId })
.Select(g => g.First())

// After (fixed)
.GroupBy(g => new { g.BankId, g.CurrencyId })
.Select(g => g.OrderByDescending(i => i.TimeStamp).First())
\\\

EF Core translates the inner ordering into a subquery that correctly picks the row with the maximum `TimeStamp` per group.

## What areas of the site does it impact?

- **Summary queries** — the Summary endpoint that uses `GetCurrentIncomesQuery` to display the current income per bank/currency.
- **Finance.Application** — `Queries/Summary/GetCurrentIncomesQuery.cs`

## Test scenarios

\\\gherkin
Scenario: Returns the latest income entry per bank
  Given multiple income entries exist for the same BankId and CurrencyId with different timestamps
  When GetCurrentIncomesQuery is executed
  Then the returned income for each (BankId, CurrencyId) group should be the one with the most recent TimeStamp

Scenario: Returns the latest income entry per bank filtered by BankId
  Given multiple income entries exist for a specific BankId with different timestamps
  When GetCurrentIncomesQuery is executed with that BankId filter
  Then only the most recent income for that BankId is returned

Scenario: Returns the latest income entry per bank filtered by CurrencyId
  Given multiple income entries exist for a specific CurrencyId with different timestamps
  When GetCurrentIncomesQuery is executed with that CurrencyId filter
  Then only the most recent income for that CurrencyId is returned
\\\

## Other Notes

Closes #88