### PR TITLE
fix: investments NaN in numeric columns, file upload 415 error, table not reloading after upload

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
@@ -10,7 +10,7 @@ type InvestmentField = {
 };
 
 function Movements() {
-  const [reloadData, setReloadData] = useState<boolean>(false);
+  const [reloadData, setReloadData] = useState<number>(0);
 
   const AppModuleTypeEnumFundsId = 3;
 
@@ -33,21 +33,24 @@ function Movements() {
     },
     class: 'text-end',
     editable: true,
-    mapper: (field: unknown) => {
+    mapper: (record: unknown) => {
+      const field = (record as Record<string, unknown>)[columnId];
       const num = typeof field === 'number' ? field : Number(String(field));
       return Number.isFinite(num) ? parseFloat(num.toFixed(2)) : num;
     },
     conditionalClass: [
       {
         class: 'text-success fw-bold',
-        eval: (field: unknown) => {
+        eval: (record: unknown) => {
+          const field = (record as Record<string, unknown>)[columnId];
           const num = typeof field === 'number' ? field : Number(String(field));
           return Number(num) > 0;
         },
       },
       {
         class: 'text-danger fw-bold',
-        eval: (field: unknown) => {
+        eval: (record: unknown) => {
+          const field = (record as Record<string, unknown>)[columnId];
           const num = typeof field === 'number' ? field : Number(String(field));
           return Number(num) < 0;
         },
@@ -110,7 +113,7 @@ function Movements() {
               url={IOLInvestmentsUploadEndpoint}
               extensions={['.xls', '.xlsx']}
               onSuccess={() => {
-                setReloadData(true);
+                setReloadData((n) => n + 1);
               }}
             />
             <hr className="py-1" />

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
@@ -100,7 +100,7 @@ export interface PaginatedTableProps<T extends Row = Row> {
   onFetch?: (data: unknown) => void;
   onAdd?: (data: unknown) => void;
   onDelete?: (data: unknown) => void;
-  reloadData?: boolean;
+  reloadData?: number;
 }
 
 function PaginatedTable<T extends Row = Row>({
@@ -112,7 +112,7 @@ function PaginatedTable<T extends Row = Row>({
   columns,
   onAdd,
   onDelete,
-  // onFetch and reloadData intentionally unused in this component
+  reloadData,
 }: PaginatedTableProps<T>) {
   const [tableData, setTableData] = useState<Data<T>>({
     items: [],
@@ -127,6 +127,10 @@ function PaginatedTable<T extends Row = Row>({
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [loading, setLoading] = useState(!url ? false : true);
   const [reloadFlag, setReloadFlag] = useState(!url ? false : true);
+
+  useEffect(() => {
+    if (reloadData) setReloadFlag(true);
+  }, [reloadData]); // reloadData is a counter; any increment triggers a reload
 
   const pageSize = rowCount ?? 10;
   const adminRowId = `${name}-edit-row`;

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Uploader.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Uploader.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef } from 'react';
-import { useFetcher } from 'react-router';
 import type { BackendUrl } from '@/utils/BackendUrl';
 import { Toast, ToastContainer, ToastHeader, ToastBody } from '@/components/ui/utils/Toast';
 import ActionButton, { ButtonType } from '@/components/ui/utils/ActionButton';
@@ -13,56 +12,58 @@ interface UploaderProps {
 }
 
 const Uploader = ({ url, extensions, onSuccess, onError }: UploaderProps) => {
-  const [showToast, setShowToast] = useState<boolean>(false); // State for controlling toast visibility
-  const [toastMessage, setToastMessage] = useState<string>(''); // Message for the toast
-  const [toastType, setToastType] = useState<'success' | 'error'>('success'); // Toast type
-  type UploadResponse = {
-    success?: boolean;
-    error?: string;
-    [key: string]: unknown;
-  } | null;
-  const fetcher = useFetcher<UploadResponse>();
+  const [showToast, setShowToast] = useState<boolean>(false);
+  const [toastMessage, setToastMessage] = useState<string>('');
+  const [toastType, setToastType] = useState<'success' | 'error'>('success');
+  const [uploading, setUploading] = useState<boolean>(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const uploadFile = () => {
+  const uploadFile = async () => {
     const fileInput = fileInputRef.current;
     const file = fileInput?.files?.[0];
 
-    if (file) {
-      const formData = new FormData();
-      formData.append('file', file);
-
-      SafeLogger.log('URL', url);
-
-      fetcher.submit(formData, {
-        method: 'post',
-        action: String(url), // URL for the upload action
-        encType: 'multipart/form-data',
-      });
-    } else {
+    if (!file) {
       setToastMessage('No file selected.');
       setToastType('error');
-      setShowToast(true); // Show the toast
+      setShowToast(true);
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    SafeLogger.log('URL', url);
+
+    setUploading(true);
+    try {
+      const response = await fetch(String(url), {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (response.ok) {
+        if (fileInputRef.current) fileInputRef.current.value = '';
+        setToastMessage('File uploaded successfully!');
+        setToastType('success');
+        setShowToast(true);
+        if (onSuccess) onSuccess();
+      } else {
+        const errorText = await response.text().catch(() => 'File upload failed.');
+        setToastMessage(errorText || 'File upload failed.');
+        setToastType('error');
+        setShowToast(true);
+        if (onError) onError();
+      }
+    } catch (error) {
+      SafeLogger.error('Upload error:', error);
+      setToastMessage('File upload failed.');
+      setToastType('error');
+      setShowToast(true);
+      if (onError) onError();
+    } finally {
+      setUploading(false);
     }
   };
-
-  if (fetcher.state === 'submitting') {
-    setToastMessage('');
-  }
-
-  if (fetcher.data && fetcher.data.success) {
-    fileInputRef.current!.value = '';
-    if (onSuccess) onSuccess();
-    setToastMessage('File uploaded successfully!');
-    setToastType('success');
-    setShowToast(true); // Show success toast
-  } else if (fetcher.data && fetcher.data.error) {
-    setToastMessage(fetcher.data.error ?? String(fetcher.data));
-    if (onError) onError();
-    setToastMessage(fetcher.data.error || 'File upload failed.');
-    setToastType('error');
-    setShowToast(true); // Show error toast
-  }
 
   return (
     <>
@@ -78,12 +79,10 @@ const Uploader = ({ url, extensions, onSuccess, onError }: UploaderProps) => {
               aria-label="Subir"
             />
             <ActionButton
-              text={'Subir'}
-              //variant={OUTLINE_VARIANT.WARNING}
+              text={uploading ? 'Subiendo...' : 'Subir'}
               type={ButtonType.None}
-              //classes={["btn", "btn-outline-secondary"]}
               action={uploadFile}
-              disabled={false}
+              disabled={uploading}
             />
           </div>
         </form>

--- a/FinanceFrontEnd/FinanceApp/app/routes/api.proxy.ts
+++ b/FinanceFrontEnd/FinanceApp/app/routes/api.proxy.ts
@@ -164,17 +164,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   try {
-    // Get the request body for POST/PUT/DELETE operations
-    const body = await request.text();
-    
+    const incomingContentType = request.headers.get('Content-Type') ?? '';
+    const isMultipart = incomingContentType.includes('multipart/form-data');
+
+    const body: BodyInit | undefined = isMultipart
+      ? await request.arrayBuffer()
+      : (await request.text()) || undefined;
+
+    const forwardHeaders: HeadersInit = {
+      Authorization: `Bearer ${accessToken}`,
+      ...(isMultipart
+        ? { 'Content-Type': incomingContentType }
+        : { 'Content-Type': 'application/json' }),
+    };
+
     // Fetch from external API
     const apiResponse = await fetch(endpoint, {
       method: request.method,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: body || undefined,
+      headers: forwardHeaders,
+      body,
     });
 
     if (!apiResponse.ok) {


### PR DESCRIPTION
# Why

The Investments page had four related bugs:

1. **NaN in numeric columns** — The `numericColumn` column-definition helper passed the full row record to its `mapper` and `eval` callbacks instead of the individual cell value. Every numeric conversion (`Number(record)`) produced `NaN`, making quantity, price, and variation columns unreadable.

2. **File upload fails with a flash error** — `Uploader.tsx` used React Router's `useFetcher` to submit the form. `useFetcher` cannot POST to an absolute external URL (the backend proxy is at `/api/proxy?path=…`), so the request was silently dropped. The component also mutated state (`setToastMessage`, `setToastType`, `setShowToast`) directly during rendering while reading `fetcher.data`, violating React's render-purity rules and causing an immediate error flash.

3. **Proxy returns 415 Unsupported Media Type** — `api.proxy.ts` unconditionally set `Content-Type: application/json` on every forwarded request. When a multipart file upload arrived the backend correctly rejected it with 415 because the boundary information was lost.

4. **Table does not reload after upload** — `PaginatedTable` accepted a `reloadData` boolean prop, but the prop was never wired to the internal `reloadFlag` state (the destructuring comment read "intentionally unused"). A successful upload therefore never triggered a data refresh.

## What is the solution?

- **NaN fix (`Investments/index.tsx`):** Changed `mapper` and `eval` callback signatures from `(field: unknown)` to `(record: unknown)` and extracted the target field via `(record as Record<string, unknown>)[columnId]` before converting to a number.

- **Upload fix (`Uploader.tsx`):** Replaced `useFetcher` with a direct `fetch(String(url), { method: 'POST', body: formData })` call inside an `async` handler. All state mutations (`setToastMessage`, etc.) are now performed after `await`, removing every render-time side-effect. Added an `uploading` boolean state to disable the button and show "Subiendo…" while the request is in flight.

- **Proxy fix (`api.proxy.ts`):** The action handler now reads the incoming `Content-Type` header. When `multipart/form-data` is detected, the body is read as `arrayBuffer()` and the original header (including its boundary parameter) is forwarded as-is. Non-multipart requests keep the `application/json` path unchanged.

- **Reload fix (`PaginatedTable.tsx`):** Changed `reloadData` prop type from `boolean` to `number`. Added a `useEffect` that calls `setReloadFlag(true)` whenever `reloadData` changes. In `Investments/index.tsx`, the state was correspondingly changed from `boolean` to a `number` counter so that `setReloadData(n => n + 1)` works for repeated uploads.

## What areas of the site does it impact?

- **Investments page** — numeric column display, file uploader, post-upload table refresh
- **`PaginatedTable`** — generic component used across multiple pages; the `reloadData` prop change is additive (it was previously unused)
- **`api.proxy.ts`** — server-side proxy used by every API call in the app; the multipart path is new, the existing JSON path is unchanged

## Test scenarios

```gherkin
Scenario: Numeric columns display correctly on the Investments page
  Given the user is on the Investments page
  When the table data loads
  Then all numeric columns (quantity, price, variation) show formatted numbers
  And no cell displays "NaN"

Scenario: Uploading a valid .xlsx file succeeds
  Given the user is on the Investments page
  When the user selects a valid .xlsx file and clicks "Subir"
  Then a success toast appears with the message "File uploaded successfully!"
  And the table refreshes automatically

Scenario: Uploading triggers a full table reload
  Given a successful file upload just completed
  When the upload success callback fires
  Then PaginatedTable fetches fresh data from the backend
  And newly uploaded rows appear in the table

Scenario: Uploading an unsupported file type shows an error
  Given the user selects a file with an extension other than .xls or .xlsx
  When the user clicks "Subir"
  Then an error toast is shown
  And no request is sent to the backend
```

## Other Notes

Closes #91