### PR TITLE
feat: auto-create ownership permissions in FinanceDbContext on SaveChanges

### DIFF
--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/DebitCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/DebitCommandController.cs
@@ -36,7 +36,7 @@ public abstract class DebitCommandController(
     [Route("upload")]
     protected async Task<IActionResult> Upload(IFormFile file, string appModuleId, [DefaultValue("Local")] string dateKind, FrequencyEnum frequency)
     {
-        await ExecuteAsync(new UploadDebitsFileCommand(file, appModuleId, EnumHelper.Parse<DateTimeKind>(dateKind), frequency));
+        await Dispatcher.DispatchCommandAsync(new UploadDebitsFileCommand(file, appModuleId, EnumHelper.Parse<DateTimeKind>(dateKind), frequency));
         return Ok();
     }
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/IOLInvestmentCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/IOLInvestmentCommandController.cs
@@ -33,7 +33,7 @@ public class IOLInvestmentCommandController(
     [HttpPost("upload")]
     public async Task<IActionResult> Upload(IFormFile file)
     {
-        await ExecuteAsync(new UploadIOLInvestmentsCommand(file));
+        await Dispatcher.DispatchCommandAsync(new UploadIOLInvestmentsCommand(file));
         return Ok();
     }
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/MovementCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/MovementCommandController.cs
@@ -36,7 +36,7 @@ public class MovementCommandController(
     [Route("upload")]
     public async Task<IActionResult> Upload(IFormFile file, Guid appModuleId, Guid bankId, [DefaultValue("Local")] string dateKind)
     {
-        await ExecuteAsync(new UploadMovementsFileCommand(file, appModuleId, bankId, EnumHelper.Parse<DateTimeKind>(dateKind)));
+        await Dispatcher.DispatchCommandAsync(new UploadMovementsFileCommand(file, appModuleId, bankId, EnumHelper.Parse<DateTimeKind>(dateKind)));
         return Ok();
     }
 }

--- a/FinanceBackEnd/src/Finance.Application/Commands/CurrencyExchangeRates/CreateCurrencyExchangeRateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CurrencyExchangeRates/CreateCurrencyExchangeRateCommand.cs
@@ -5,7 +5,6 @@ using Finance.Application.Commands.Base;
 using Finance.Application.Repositories;
 using Finance.Domain.Models.Currencies;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 
 namespace Finance.Application.Commands.CurrencyExchangeRates;
 
@@ -23,8 +22,7 @@ public class CreateCurrencyExchangeRateCommand : IContextAwareCommand<FinanceDis
 public class CreateCurrencyExchangeRateCommandHandler(
     FinanceDbContext db,
     IRepository<Currency, Guid> currencyRepository,
-    IRepository<CurrencyExchangeRate, Guid> currencyExchangeRateRepository,
-    IDispatcher<FinanceDispatchContext> dispatcher)
+    IRepository<CurrencyExchangeRate, Guid> currencyExchangeRateRepository)
     : BaseCommandHandler<CreateCurrencyExchangeRateCommand, CurrencyExchangeRate>(db)
 {
     public override async Task<DataResult<CurrencyExchangeRate>> ExecuteAsync(
@@ -46,14 +44,6 @@ public class CreateCurrencyExchangeRateCommandHandler(
         };
 
         await currencyExchangeRateRepository.AddAsync(newRate, cancellationToken);
-
-        await dispatcher.DispatchAsync(
-            new CreateCurrencyExchangeRatePermissionsCommand
-            {
-                ResourceId = newRate.Id,
-                PermissionLevels = [PermissionLevelEnum.Owner],
-            },
-            command.Context.HttpRequest);
 
         return DataResult<CurrencyExchangeRate>.Success(newRate);
     }

--- a/FinanceBackEnd/src/Finance.Application/Commands/Debits/CreateDebitCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/Debits/CreateDebitCommand.cs
@@ -7,7 +7,6 @@ using Finance.Application.Commands.DebitOrigins;
 using Finance.Application.Repositories;
 using Finance.Domain.Models.Debits;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 
 namespace Finance.Application.Commands.Debits;
 
@@ -60,14 +59,6 @@ public class CreateDebitCommandHandler(
         };
 
         await _debitRepository.AddAsync(debit, cancellationToken);
-
-        await _dispatcher.DispatchAsync(
-            new CreateDebitPermissionsCommand
-            {
-                ResourceId = debit.Id,
-                PermissionLevels = [PermissionLevelEnum.Owner],
-            },
-            command.Context.HttpRequest);
 
         return DataResult<Debit>.Success(debit);
     }

--- a/FinanceBackEnd/src/Finance.Application/Commands/Funds/CreateFundCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/Funds/CreateFundCommand.cs
@@ -1,6 +1,4 @@
 using CQRSDispatch;
-using CQRSDispatch.Interfaces;
-using Finance.Application.Auth;
 using Finance.Application.Commands.Base;
 using Finance.Application.Commands.Funds.Base;
 using Finance.Application.Repositories;
@@ -8,29 +6,27 @@ using Finance.Domain.Models.Banks;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Funds;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 
 namespace Finance.Application.Commands.Funds;
+
+public class CreateFundCommand : UpsertFundBaseCommand;
 
 public class CreateFundCommandHandler : BaseCommandHandler<CreateFundCommand, Fund>
 {
     private readonly IRepository<Bank, Guid> _bankRepository;
     private readonly IRepository<Currency, Guid> _currencyRepository;
     private readonly IRepository<Fund, Guid> _fundRepository;
-    private readonly IDispatcher<FinanceDispatchContext> _dispatcher;
 
     public CreateFundCommandHandler(
         FinanceDbContext db,
         IRepository<Bank, Guid> bankRepository,
         IRepository<Currency, Guid> currencyRepository,
-        IRepository<Fund, Guid> fundRepository,
-        IDispatcher<FinanceDispatchContext> dispatcher)
+        IRepository<Fund, Guid> fundRepository)
         : base(db)
     {
         _bankRepository = bankRepository;
         _currencyRepository = currencyRepository;
         _fundRepository = fundRepository;
-        _dispatcher = dispatcher;
     }
 
     public override async Task<DataResult<Fund>> ExecuteAsync(CreateFundCommand command, CancellationToken cancellationToken)
@@ -55,18 +51,8 @@ public class CreateFundCommandHandler : BaseCommandHandler<CreateFundCommand, Fu
 
         await _fundRepository.AddAsync(newFund, cancellationToken);
 
-        var ownershipCommand = new CreateFundPermissionsCommand
-        {
-            ResourceId = newFund.Id,
-            PermissionLevels = [PermissionLevelEnum.Owner]
-        };
-
-        await _dispatcher.DispatchAsync(ownershipCommand, command.Context.HttpRequest);
-
         return DataResult<Fund>.Success(newFund);
     }
 }
-
-public class CreateFundCommand : UpsertFundBaseCommand;
 
 public class CreateFundCommandValidator : UpsertFundBaseCommandValidator<CreateFundCommand>;

--- a/FinanceBackEnd/src/Finance.Application/Commands/Incomes/CreateIncomeCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/Incomes/CreateIncomeCommand.cs
@@ -8,16 +8,24 @@ using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Incomes;
 using Finance.Domain.SpecialTypes;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 
 namespace Finance.Application.Commands.Incomes;
+
+public class CreateIncomeCommand : IContextAwareCommand<FinanceDispatchContext, DataResult<Income>>
+{
+    public virtual Guid BankId { get; set; }
+    public virtual Guid CurrencyId { get; set; }
+    required public DateTime? TimeStamp { get; set; }
+    required public Money Amount { get; set; }
+    internal FinanceDispatchContext Context { get; private set; } = new();
+    public void SetContext(FinanceDispatchContext context) => Context = context;
+}
 
 public class CreateIncomeCommandHandler(
     FinanceDbContext db,
     IRepository<Bank, Guid> bankRepository,
     IRepository<Currency, Guid> currencyRepository,
-    IRepository<Income, Guid> incomeRepository,
-    IDispatcher<FinanceDispatchContext> dispatcher)
+    IRepository<Income, Guid> incomeRepository)
     : BaseCommandHandler<CreateIncomeCommand, Income>(db)
 {
     public override async Task<DataResult<Income>> ExecuteAsync(CreateIncomeCommand command, CancellationToken cancellationToken)
@@ -39,24 +47,6 @@ public class CreateIncomeCommandHandler(
 
         await incomeRepository.AddAsync(newIncome, cancellationToken);
 
-        await dispatcher.DispatchAsync(
-            new CreateIncomePermissionsCommand
-            {
-                ResourceId = newIncome.Id,
-                PermissionLevels = [PermissionLevelEnum.Owner],
-            },
-            command.Context.HttpRequest);
-
         return DataResult<Income>.Success(newIncome);
     }
-}
-
-public class CreateIncomeCommand : IContextAwareCommand<FinanceDispatchContext, DataResult<Income>>
-{
-    public virtual Guid BankId { get; set; }
-    public virtual Guid CurrencyId { get; set; }
-    required public DateTime? TimeStamp { get; set; }
-    required public Money Amount { get; set; }
-    internal FinanceDispatchContext Context { get; private set; } = new();
-    public void SetContext(FinanceDispatchContext context) => Context = context;
 }

--- a/FinanceBackEnd/src/Finance.Application/Commands/Subscriptions/CreateSubscriptionCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/Subscriptions/CreateSubscriptionCommand.cs
@@ -1,13 +1,10 @@
 using CQRSDispatch;
-using CQRSDispatch.Interfaces;
-using Finance.Application.Auth;
 using Finance.Application.Commands.Base;
 using Finance.Application.Commands.Subscriptions.Base;
 using Finance.Application.Repositories;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Subscriptions;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 
 namespace Finance.Application.Commands.Subscriptions;
 
@@ -16,13 +13,11 @@ public class CreateSubscriptionCommand : UpsertSubscriptionBaseCommand;
 public class CreateSubscriptionCommandHandler(
     FinanceDbContext db,
     IRepository<Subscription, Guid> subscriptionRepository,
-    IRepository<Currency, Guid> currencyRepository,
-    IDispatcher<FinanceDispatchContext> dispatcher
+    IRepository<Currency, Guid> currencyRepository
 ) : BaseCommandHandler<CreateSubscriptionCommand, Subscription>(db)
 {
     private readonly IRepository<Subscription, Guid> _subscriptionRepository = subscriptionRepository;
     private readonly IRepository<Currency, Guid> _currencyRepository = currencyRepository;
-    private readonly IDispatcher<FinanceDispatchContext> _dispatcher = dispatcher;
 
     public override async Task<DataResult<Subscription>> ExecuteAsync(CreateSubscriptionCommand command, CancellationToken cancellationToken)
     {
@@ -38,14 +33,6 @@ public class CreateSubscriptionCommandHandler(
         subscription.Frequency = command.Frequency;
 
         await _subscriptionRepository.AddAsync(subscription, cancellationToken);
-
-        var ownershipCommand = new CreateSubscriptionOwnershipCommand
-        {
-            ResourceId = subscription.Id,
-            PermissionLevels = [PermissionLevelEnum.Owner]
-        };
-
-        await _dispatcher.DispatchAsync(ownershipCommand, command.Context.HttpRequest);
 
         return DataResult<Subscription>.Success(subscription);
     }

--- a/FinanceBackEnd/src/Finance.Application/Extensions/ServiceExtensions.cs
+++ b/FinanceBackEnd/src/Finance.Application/Extensions/ServiceExtensions.cs
@@ -12,10 +12,9 @@ public static class SagaServiceExtensions
 {
     public static IServiceCollection AddSagaServices(this IServiceCollection services)
     {
-        // TODO Copy RepositoryExtensions 
-        RegisterScopedService<CurrencyConversionService>(services);
+        services.RegisterScopedService<CurrencyConversionService>();
 
-        services.AddScoped<FundService>();
+        services.RegisterScopedService<FundService>();
 
         RegisterEntityService<
             User,
@@ -25,15 +24,16 @@ public static class SagaServiceExtensions
             DeleteUserSagaRequest
             >(services);
 
-        services.AddScoped<IncomeService>();
-        services.AddScoped<SubscriptionService>();
-        services.AddScoped<CurrencyExchangeRateService>();
-        services.AddScoped<DebitService>();
-        services.AddScoped<DebitOriginService>();
-        services.AddScoped<CreditCardService>();
-        services.AddScoped<MovementService>();
-
-        RegisterScopedService<IdentityService>(services);
+        services.RegisterScopedService<IncomeService>();
+        services.RegisterScopedService<SubscriptionService>();
+        services.RegisterScopedService<CurrencyExchangeRateService>();
+        services.RegisterScopedService<DebitService>();
+        services.RegisterScopedService<DebitOriginService>();
+        services.RegisterScopedService<CreditCardService>();
+        services.RegisterScopedService<MovementService>();
+        services.RegisterScopedService<IOLInvestmentService>();
+        services.RegisterScopedService<IOLInvestmentAssetService>();
+        services.RegisterScopedService<IdentityService>();
 
         return services;
     }
@@ -52,7 +52,7 @@ public static class SagaServiceExtensions
             TEntity>>(services);
     }
 
-    private static void RegisterScopedService<TService>(IServiceCollection services)
+    private static void RegisterScopedService<TService>(this IServiceCollection services)
         where TService : class
     {
         services.TryAddScoped<TService>();

--- a/FinanceBackEnd/src/Finance.Application/Services/CreditCardService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/CreditCardService.cs
@@ -41,14 +41,6 @@ public class CreditCardService(
                 return result;
             }
 
-            await dispatcher.DispatchAsync(
-                new CreateCreditCardPermissionsCommand
-                {
-                    ResourceId = result.Data!.Id,
-                    PermissionLevels = [PermissionLevelEnum.Owner],
-                },
-                httpRequest);
-
             await tx.CommitAsync();
             return result;
         }

--- a/FinanceBackEnd/src/Finance.Application/Services/DebitOriginService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/DebitOriginService.cs
@@ -5,8 +5,8 @@ using Finance.Application.Commands.DebitOrigins;
 using Finance.Application.Services.DebitOrigins;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Debits;
-using Finance.Persistence;
 using FinanceBackEnd.Finance.Domain.Enums;
+using Finance.Persistence;
 using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Services;
@@ -40,20 +40,6 @@ public class DebitOriginService(
             {
                 await tx.RollbackAsync();
                 return result;
-            }
-
-            var permResult = await dispatcher.DispatchAsync(
-                new CreateDebitOriginPermissionsCommand
-                {
-                    ResourceId = result.Data!.Id,
-                    PermissionLevels = [PermissionLevelEnum.Owner],
-                },
-                httpRequest);
-
-            if (!permResult.IsSuccess)
-            {
-                await tx.RollbackAsync();
-                return DataResult<DebitOrigin>.Failure(permResult.ErrorMessage ?? "Permission creation failed.");
             }
 
             await tx.CommitAsync();

--- a/FinanceBackEnd/src/Finance.Application/Services/IOLInvestmentAssetService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/IOLInvestmentAssetService.cs
@@ -42,14 +42,6 @@ public class IOLInvestmentAssetService(
                 return result;
             }
 
-            await dispatcher.DispatchAsync(
-                new CreateIOLInvestmentAssetPermissionsCommand
-                {
-                    ResourceId = result.Data!.Id,
-                    PermissionLevels = [PermissionLevelEnum.Owner],
-                },
-                httpRequest);
-
             await tx.CommitAsync();
             return result;
         }

--- a/FinanceBackEnd/src/Finance.Application/Services/IOLInvestmentService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/IOLInvestmentService.cs
@@ -50,14 +50,6 @@ public class IOLInvestmentService(
                 return result;
             }
 
-            await dispatcher.DispatchAsync(
-                new CreateIOLInvestmentPermissionsCommand
-                {
-                    ResourceId = result.Data!.Id,
-                    PermissionLevels = [PermissionLevelEnum.Owner],
-                },
-                httpRequest);
-
             await tx.CommitAsync();
             return result;
         }

--- a/FinanceBackEnd/src/Finance.Application/Services/MovementService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/MovementService.cs
@@ -45,14 +45,6 @@ public class MovementService(
                 return result;
             }
 
-            await dispatcher.DispatchAsync(
-                new CreateMovementPermissionsCommand
-                {
-                    ResourceId = result.Data!.Id,
-                    PermissionLevels = [PermissionLevelEnum.Owner],
-                },
-                httpRequest);
-
             await tx.CommitAsync();
             return result;
         }

--- a/FinanceBackEnd/src/Finance.Persistence/FinanceDbContext.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/FinanceDbContext.cs
@@ -16,6 +16,7 @@ using Finance.Domain.SpecialTypes;
 using Finance.Persistence.Configurations;
 using Finance.Persistence.Extensions;
 using Finance.Persistence.TypeConverters;
+using FinanceBackEnd.Finance.Domain.Enums;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
@@ -81,16 +82,82 @@ public class FinanceDbContext : DbContext
         base.OnModelCreating(modelBuilder);
     }
 
-    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    private static TPermission BuildOwnership<TResource, TId, TPermission>(TId id, Guid userId)
+        where TResource : IEntity
+        where TPermission : ResourcePermissions<TResource, TId>, new()
+        => new TPermission { ResourceId = id, UserId = userId, PermissionLevels = [PermissionLevelEnum.Owner] };
+
+    private static readonly Dictionary<Type, Func<Guid, Guid, object>> _permissionFactories = new()
     {
+        [typeof(CreditCard)] = BuildOwnership<CreditCard, Guid, CreditCardPermissions>,
+        [typeof(CurrencyExchangeRate)] = BuildOwnership<CurrencyExchangeRate, Guid, CurrencyExchangeRatePermissions>,
+        [typeof(Debit)] = BuildOwnership<Debit, Guid, DebitPermissions>,
+        [typeof(DebitOrigin)] = BuildOwnership<DebitOrigin, Guid, DebitOriginPermissions>,
+        [typeof(Fund)] = BuildOwnership<Fund, Guid, FundPermissions>,
+        [typeof(Income)] = BuildOwnership<Income, Guid, IncomePermissions>,
+        [typeof(IOLInvestment)] = BuildOwnership<IOLInvestment, Guid, IOLInvestmentPermissions>,
+        [typeof(IOLInvestmentAsset)] = BuildOwnership<IOLInvestmentAsset, Guid, IOLInvestmentAssetPermissions>,
+        [typeof(Movement)] = BuildOwnership<Movement, Guid, MovementPermissions>,
+        [typeof(Subscription)] = BuildOwnership<Subscription, Guid, SubscriptionPermissions>,
+    };
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await AutoCreateOwnershipPermissionsAsync(cancellationToken);
         SetAuditableDefaults();
-        return base.SaveChangesAsync(cancellationToken);
+        return await base.SaveChangesAsync(cancellationToken);
     }
 
     public override int SaveChanges()
     {
+        AutoCreateOwnershipPermissions();
         SetAuditableDefaults();
         return base.SaveChanges();
+    }
+
+    private async Task AutoCreateOwnershipPermissionsAsync(CancellationToken cancellationToken)
+    {
+        if (HttpContextAccessor?.HttpContext == null) return;
+
+        var addedOwned = ChangeTracker.Entries()
+            .Where(e => e.State == EntityState.Added && _permissionFactories.ContainsKey(e.Entity.GetType()))
+            .Select(e => (Type: e.Entity.GetType(), Id: (Guid)e.Property("Id").CurrentValue!))
+            .ToList();
+
+        if (addedOwned.Count == 0) return;
+
+        var user = await User
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .Include(u => u.Identities)
+            .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == CurrentUserId), cancellationToken);
+
+        if (user == null) return;
+
+        foreach (var (type, entityId) in addedOwned)
+            Add(_permissionFactories[type](entityId, user.Id));
+    }
+
+    private void AutoCreateOwnershipPermissions()
+    {
+        if (HttpContextAccessor?.HttpContext == null) return;
+
+        var addedOwned = ChangeTracker.Entries()
+            .Where(e => e.State == EntityState.Added && _permissionFactories.ContainsKey(e.Entity.GetType()))
+            .Select(e => (Type: e.Entity.GetType(), Id: (Guid)e.Property("Id").CurrentValue!))
+            .ToList();
+
+        if (addedOwned.Count == 0) return;
+
+        var user = User
+            .IgnoreQueryFilters()
+            .Include(u => u.Identities)
+            .FirstOrDefault(u => u.Identities.Any(i => i.SourceId == CurrentUserId));
+
+        if (user == null) return;
+
+        foreach (var (type, entityId) in addedOwned)
+            Add(_permissionFactories[type](entityId, user.Id));
     }
 
     private void SetAuditableDefaults()

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CurrencyExchangeRates/CreateCurrencyExchangeRateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CurrencyExchangeRates/CreateCurrencyExchangeRateCommandHandlerTests.cs
@@ -1,13 +1,7 @@
-using CQRSDispatch;
-using CQRSDispatch.Interfaces;
-using Finance.Application.Auth;
 using Finance.Application.Commands.CurrencyExchangeRates;
 using Finance.Application.Repositories;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Currencies;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -17,14 +11,12 @@ public class CreateCurrencyExchangeRateCommandHandlerTests : IDisposable
 {
     private readonly Mock<IRepository<Currency, Guid>> _currencyRepo;
     private readonly Mock<IRepository<CurrencyExchangeRate, Guid>> _rateRepo;
-    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
     private readonly FinanceDbContext _dbContext;
 
     public CreateCurrencyExchangeRateCommandHandlerTests()
     {
         _currencyRepo = new Mock<IRepository<Currency, Guid>>();
         _rateRepo = new Mock<IRepository<CurrencyExchangeRate, Guid>>();
-        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
 
         var options = new DbContextOptionsBuilder<FinanceDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -37,7 +29,7 @@ public class CreateCurrencyExchangeRateCommandHandlerTests : IDisposable
     public void Dispose() => _dbContext.Dispose();
 
     [Fact]
-    public async Task Create_HappyPath_AddsRateAndDispatchesPermissions()
+    public async Task Create_HappyPath_AddsRate()
     {
         var baseCurrency = new Currency { Id = Guid.NewGuid(), Name = "Peso", ShortName = "ARS" };
         var quoteCurrency = new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD" };
@@ -56,12 +48,8 @@ public class CreateCurrencyExchangeRateCommandHandlerTests : IDisposable
             .Setup(r => r.AddAsync(It.IsAny<CurrencyExchangeRate>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .Callback<CurrencyExchangeRate, CancellationToken, bool>((rate, _, _) => rate.Id = Guid.NewGuid())
             .Returns(Task.CompletedTask);
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CurrencyExchangeRatePermissions>>(
-                It.IsAny<CreateCurrencyExchangeRatePermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<CurrencyExchangeRatePermissions>.Success(new CurrencyExchangeRatePermissions()));
 
-        var handler = new CreateCurrencyExchangeRateCommandHandler(_dbContext, _currencyRepo.Object, _rateRepo.Object, _dispatcher.Object);
+        var handler = new CreateCurrencyExchangeRateCommandHandler(_dbContext, _currencyRepo.Object, _rateRepo.Object);
         var result = await handler.ExecuteAsync(command, default);
 
         Assert.True(result.IsSuccess);
@@ -71,12 +59,6 @@ public class CreateCurrencyExchangeRateCommandHandlerTests : IDisposable
         Assert.Equal(910m, (decimal)result.Data.SellRate);
 
         _rateRepo.Verify(r => r.AddAsync(It.IsAny<CurrencyExchangeRate>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CurrencyExchangeRatePermissions>>(
-            It.Is<CreateCurrencyExchangeRatePermissionsCommand>(c =>
-                c.ResourceId == result.Data.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
     }
 
     [Fact]
@@ -93,7 +75,7 @@ public class CreateCurrencyExchangeRateCommandHandlerTests : IDisposable
 
         _currencyRepo.Setup(r => r.GetByIdAsync(command.BaseCurrencyId, It.IsAny<CancellationToken>())).ReturnsAsync((Currency?)null);
 
-        var handler = new CreateCurrencyExchangeRateCommandHandler(_dbContext, _currencyRepo.Object, _rateRepo.Object, _dispatcher.Object);
+        var handler = new CreateCurrencyExchangeRateCommandHandler(_dbContext, _currencyRepo.Object, _rateRepo.Object);
         await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
     }
 
@@ -113,7 +95,7 @@ public class CreateCurrencyExchangeRateCommandHandlerTests : IDisposable
         _currencyRepo.Setup(r => r.GetByIdAsync(baseCurrency.Id, It.IsAny<CancellationToken>())).ReturnsAsync(baseCurrency);
         _currencyRepo.Setup(r => r.GetByIdAsync(command.QuoteCurrencyId, It.IsAny<CancellationToken>())).ReturnsAsync((Currency?)null);
 
-        var handler = new CreateCurrencyExchangeRateCommandHandler(_dbContext, _currencyRepo.Object, _rateRepo.Object, _dispatcher.Object);
+        var handler = new CreateCurrencyExchangeRateCommandHandler(_dbContext, _currencyRepo.Object, _rateRepo.Object);
         await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
     }
 }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Debits/CreateDebitCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Debits/CreateDebitCommandHandlerTests.cs
@@ -4,12 +4,10 @@ using Finance.Application.Auth;
 using Finance.Application.Commands.Debits;
 using Finance.Application.Commands.DebitOrigins;
 using Finance.Application.Repositories;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Debits;
 using Finance.Domain.Enums;
 using Finance.Domain.SpecialTypes;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -58,8 +56,6 @@ public class CreateDebitCommandHandlerTests : IDisposable
         var command = ValidCommand();
 
         _originRepo.Setup(r => r.GetByAsync(It.IsAny<Dictionary<string, object>>(), It.IsAny<CancellationToken>())).ReturnsAsync(origin);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<DebitPermissions>>(It.IsAny<CreateDebitPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<DebitPermissions>.Success(new DebitPermissions()));
 
         var result = await CreateHandler().ExecuteAsync(command, default);
 
@@ -74,8 +70,6 @@ public class CreateDebitCommandHandlerTests : IDisposable
     {
         var origin = new DebitOrigin { Id = Guid.NewGuid(), Name = "Rent" };
         _originRepo.Setup(r => r.GetByAsync(It.IsAny<Dictionary<string, object>>(), It.IsAny<CancellationToken>())).ReturnsAsync(origin);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<DebitPermissions>>(It.IsAny<CreateDebitPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<DebitPermissions>.Success(new DebitPermissions()));
 
         await CreateHandler().ExecuteAsync(ValidCommand(), default);
 
@@ -89,31 +83,13 @@ public class CreateDebitCommandHandlerTests : IDisposable
         var command = new CreateDebitCommand { AppModuleId = appModuleId, Origin = "  NewOrigin  ", Amount = new Money(100m) };
 
         _originRepo.Setup(r => r.GetByAsync(It.IsAny<Dictionary<string, object>>(), It.IsAny<CancellationToken>())).ReturnsAsync((DebitOrigin?)null);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
+        _dispatcher.Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOrigin>.Success(new DebitOrigin { Name = "NewOrigin" }));
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<DebitPermissions>>(It.IsAny<CreateDebitPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<DebitPermissions>.Success(new DebitPermissions()));
 
         await CreateHandler().ExecuteAsync(command, default);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<DebitOrigin>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.Is<CreateDebitOriginCommand>(c => c.Name == "NewOrigin" && c.AppModuleId == appModuleId),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task Create_ValidCommand_DispatchesPermissionsWithOwner()
-    {
-        var origin = new DebitOrigin { Id = Guid.NewGuid(), Name = "Rent" };
-        _originRepo.Setup(r => r.GetByAsync(It.IsAny<Dictionary<string, object>>(), It.IsAny<CancellationToken>())).ReturnsAsync(origin);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<DebitPermissions>>(It.IsAny<CreateDebitPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<DebitPermissions>.Success(new DebitPermissions()));
-
-        await CreateHandler().ExecuteAsync(ValidCommand(), default);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<DebitPermissions>>(
-            It.Is<CreateDebitPermissionsCommand>(c => c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
             It.IsAny<HttpRequest?>()),
             Times.Once);
     }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Funds/CreateFundCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Funds/CreateFundCommandHandlerTests.cs
@@ -1,16 +1,10 @@
-using CQRSDispatch;
-using CQRSDispatch.Interfaces;
-using Finance.Application.Auth;
 using Finance.Application.Commands.Funds;
 using Finance.Application.Repositories;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Banks;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Funds;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 using FluentValidation;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -21,7 +15,6 @@ public class CreateFundCommandHandlerTests : IDisposable
     private readonly Mock<IRepository<Fund, Guid>> _fundRepo;
     private readonly Mock<IRepository<Bank, Guid>> _bankRepo;
     private readonly Mock<IRepository<Currency, Guid>> _currencyRepo;
-    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
     private readonly FinanceDbContext _dbContext;
 
     public CreateFundCommandHandlerTests()
@@ -29,7 +22,6 @@ public class CreateFundCommandHandlerTests : IDisposable
         _fundRepo = new Mock<IRepository<Fund, Guid>>();
         _bankRepo = new Mock<IRepository<Bank, Guid>>();
         _currencyRepo = new Mock<IRepository<Currency, Guid>>();
-        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
 
         var options = new DbContextOptionsBuilder<FinanceDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -40,6 +32,9 @@ public class CreateFundCommandHandlerTests : IDisposable
     }
 
     public void Dispose() => _dbContext.Dispose();
+
+    private CreateFundCommandHandler CreateHandler() =>
+        new(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object);
 
     [Fact]
     public async Task Create_HappyPath_AddsFundAndReturnsSuccess()
@@ -61,13 +56,8 @@ public class CreateFundCommandHandlerTests : IDisposable
             .Setup(r => r.AddAsync(It.IsAny<Fund>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .Callback<Fund, CancellationToken, bool>((fund, _, _) => fund.Id = Guid.NewGuid())
             .Returns(Task.CompletedTask);
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<FundPermissions>>(It.IsAny<CreateFundPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<FundPermissions>.Success(new FundPermissions()));
 
-        var handler = new CreateFundCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object, _dispatcher.Object);
-
-        var result = await handler.ExecuteAsync(command, default);
+        var result = await CreateHandler().ExecuteAsync(command, default);
 
         Assert.True(result.IsSuccess);
         Assert.Equal(bank, result.Data.Bank);
@@ -76,12 +66,6 @@ public class CreateFundCommandHandlerTests : IDisposable
         Assert.True(result.Data.DailyUse);
 
         _fundRepo.Verify(r => r.AddAsync(It.IsAny<Fund>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<FundPermissions>>(
-            It.Is<CreateFundPermissionsCommand>(c =>
-                c.ResourceId == result.Data.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
     }
 
     [Fact]
@@ -97,9 +81,7 @@ public class CreateFundCommandHandlerTests : IDisposable
 
         _bankRepo.Setup(r => r.GetByIdAsync(command.BankId, It.IsAny<CancellationToken>())).ReturnsAsync((Bank?)null);
 
-        var handler = new CreateFundCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -117,9 +99,7 @@ public class CreateFundCommandHandlerTests : IDisposable
         _bankRepo.Setup(r => r.GetByIdAsync(bank.Id, It.IsAny<CancellationToken>())).ReturnsAsync(bank);
         _currencyRepo.Setup(r => r.GetByIdAsync(command.CurrencyId, It.IsAny<CancellationToken>())).ReturnsAsync((Currency?)null);
 
-        var handler = new CreateFundCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -133,9 +113,7 @@ public class CreateFundCommandHandlerTests : IDisposable
             Amount = 100m,
         };
 
-        var handler = new CreateFundCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<ValidationException>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<ValidationException>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -149,9 +127,7 @@ public class CreateFundCommandHandlerTests : IDisposable
             Amount = 100m,
         };
 
-        var handler = new CreateFundCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<ValidationException>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<ValidationException>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -165,8 +141,6 @@ public class CreateFundCommandHandlerTests : IDisposable
             Amount = 100m,
         };
 
-        var handler = new CreateFundCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _fundRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<ValidationException>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<ValidationException>(() => CreateHandler().ExecuteAsync(command, default));
     }
 }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Incomes/CreateIncomeCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Incomes/CreateIncomeCommandHandlerTests.cs
@@ -1,16 +1,10 @@
-using CQRSDispatch;
-using CQRSDispatch.Interfaces;
-using Finance.Application.Auth;
 using Finance.Application.Commands.Incomes;
 using Finance.Application.Repositories;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Banks;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Incomes;
 using Finance.Domain.SpecialTypes;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -21,7 +15,6 @@ public class CreateIncomeCommandHandlerTests : IDisposable
     private readonly Mock<IRepository<Income, Guid>> _incomeRepo;
     private readonly Mock<IRepository<Bank, Guid>> _bankRepo;
     private readonly Mock<IRepository<Currency, Guid>> _currencyRepo;
-    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
     private readonly FinanceDbContext _dbContext;
 
     public CreateIncomeCommandHandlerTests()
@@ -29,7 +22,6 @@ public class CreateIncomeCommandHandlerTests : IDisposable
         _incomeRepo = new Mock<IRepository<Income, Guid>>();
         _bankRepo = new Mock<IRepository<Bank, Guid>>();
         _currencyRepo = new Mock<IRepository<Currency, Guid>>();
-        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
 
         var options = new DbContextOptionsBuilder<FinanceDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -60,11 +52,8 @@ public class CreateIncomeCommandHandlerTests : IDisposable
             .Setup(r => r.AddAsync(It.IsAny<Income>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .Callback<Income, CancellationToken, bool>((income, _, _) => income.Id = Guid.NewGuid())
             .Returns(Task.CompletedTask);
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IncomePermissions>>(It.IsAny<CreateIncomePermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<IncomePermissions>.Success(new IncomePermissions()));
 
-        var handler = new CreateIncomeCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _incomeRepo.Object, _dispatcher.Object);
+        var handler = new CreateIncomeCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _incomeRepo.Object);
         var result = await handler.ExecuteAsync(command, default);
 
         Assert.True(result.IsSuccess);
@@ -73,12 +62,6 @@ public class CreateIncomeCommandHandlerTests : IDisposable
         Assert.Equal(100m, (decimal)result.Data.Amount);
 
         _incomeRepo.Verify(r => r.AddAsync(It.IsAny<Income>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IncomePermissions>>(
-            It.Is<CreateIncomePermissionsCommand>(c =>
-                c.ResourceId == result.Data.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
     }
 
     [Fact]
@@ -94,7 +77,7 @@ public class CreateIncomeCommandHandlerTests : IDisposable
 
         _bankRepo.Setup(r => r.GetByIdAsync(command.BankId, It.IsAny<CancellationToken>())).ReturnsAsync((Bank?)null);
 
-        var handler = new CreateIncomeCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _incomeRepo.Object, _dispatcher.Object);
+        var handler = new CreateIncomeCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _incomeRepo.Object);
         await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
     }
 
@@ -113,7 +96,7 @@ public class CreateIncomeCommandHandlerTests : IDisposable
         _bankRepo.Setup(r => r.GetByIdAsync(bank.Id, It.IsAny<CancellationToken>())).ReturnsAsync(bank);
         _currencyRepo.Setup(r => r.GetByIdAsync(command.CurrencyId, It.IsAny<CancellationToken>())).ReturnsAsync((Currency?)null);
 
-        var handler = new CreateIncomeCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _incomeRepo.Object, _dispatcher.Object);
+        var handler = new CreateIncomeCommandHandler(_dbContext, _bankRepo.Object, _currencyRepo.Object, _incomeRepo.Object);
         await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
     }
 }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Subscriptions/CreateSubscriptionCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/Subscriptions/CreateSubscriptionCommandHandlerTests.cs
@@ -1,16 +1,10 @@
-using CQRSDispatch;
-using CQRSDispatch.Interfaces;
-using Finance.Application.Auth;
 using Finance.Application.Commands.Subscriptions;
 using Finance.Application.Repositories;
 using Finance.Domain.Enums;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Subscriptions;
 using Finance.Persistence;
-using FinanceBackEnd.Finance.Domain.Enums;
 using FluentValidation;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -20,14 +14,12 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
 {
     private readonly Mock<IRepository<Subscription, Guid>> _subscriptionRepo;
     private readonly Mock<IRepository<Currency, Guid>> _currencyRepo;
-    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
     private readonly FinanceDbContext _dbContext;
 
     public CreateSubscriptionCommandHandlerTests()
     {
         _subscriptionRepo = new Mock<IRepository<Subscription, Guid>>();
         _currencyRepo = new Mock<IRepository<Currency, Guid>>();
-        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
 
         var options = new DbContextOptionsBuilder<FinanceDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -38,6 +30,9 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
     }
 
     public void Dispose() => _dbContext.Dispose();
+
+    private CreateSubscriptionCommandHandler CreateHandler() =>
+        new(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object);
 
     [Fact]
     public async Task Create_HappyPath_AddsCurrencyAndReturnsSuccess()
@@ -52,13 +47,8 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
         };
 
         _currencyRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(currency);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<SubscriptionPermissions>>(
-            It.IsAny<CreateSubscriptionOwnershipCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<SubscriptionPermissions>.Success(new SubscriptionPermissions()));
 
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        var result = await handler.ExecuteAsync(command, default);
+        var result = await CreateHandler().ExecuteAsync(command, default);
 
         Assert.True(result.IsSuccess);
         Assert.Equal("Netflix", result.Data.Name);
@@ -74,37 +64,10 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
         var command = new CreateSubscriptionCommand { CurrencyId = currency.Id, Name = "Netflix", Price = 9.99m };
 
         _currencyRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(currency);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<SubscriptionPermissions>>(
-            It.IsAny<CreateSubscriptionOwnershipCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<SubscriptionPermissions>.Success(new SubscriptionPermissions()));
 
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        await handler.ExecuteAsync(command, default);
+        await CreateHandler().ExecuteAsync(command, default);
 
         _subscriptionRepo.Verify(r => r.AddAsync(It.IsAny<Subscription>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task Create_HappyPath_DispatchesOwnershipCommandWithOwnerPermission()
-    {
-        var currency = new Currency { Id = Guid.NewGuid(), Name = "", ShortName = "" };
-        var command = new CreateSubscriptionCommand { CurrencyId = currency.Id, Name = "Netflix", Price = 9.99m };
-
-        _currencyRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(currency);
-        _dispatcher.Setup(d => d.DispatchAsync<DataResult<SubscriptionPermissions>>(
-            It.IsAny<CreateSubscriptionOwnershipCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<SubscriptionPermissions>.Success(new SubscriptionPermissions()));
-
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        await handler.ExecuteAsync(command, default);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<SubscriptionPermissions>>(
-            It.Is<CreateSubscriptionOwnershipCommand>(c =>
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
     }
 
     [Fact]
@@ -113,9 +76,7 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
         _currencyRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((Currency?)null);
         var command = new CreateSubscriptionCommand { CurrencyId = Guid.NewGuid(), Name = "Netflix", Price = 9.99m };
 
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<Exception>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -123,9 +84,7 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
     {
         var command = new CreateSubscriptionCommand { CurrencyId = Guid.NewGuid(), Name = "", Price = 9.99m };
 
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<ValidationException>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<ValidationException>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -133,9 +92,7 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
     {
         var command = new CreateSubscriptionCommand { CurrencyId = Guid.Empty, Name = "Netflix", Price = 9.99m };
 
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<ValidationException>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<ValidationException>(() => CreateHandler().ExecuteAsync(command, default));
     }
 
     [Fact]
@@ -143,8 +100,6 @@ public class CreateSubscriptionCommandHandlerTests : IDisposable
     {
         var command = new CreateSubscriptionCommand { CurrencyId = Guid.NewGuid(), Name = "Netflix", Price = -1m };
 
-        var handler = new CreateSubscriptionCommandHandler(_dbContext, _subscriptionRepo.Object, _currencyRepo.Object, _dispatcher.Object);
-
-        await Assert.ThrowsAsync<ValidationException>(() => handler.ExecuteAsync(command, default));
+        await Assert.ThrowsAsync<ValidationException>(() => CreateHandler().ExecuteAsync(command, default));
     }
 }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/CreditCards/CreditCardServiceTests.Create.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/CreditCards/CreditCardServiceTests.Create.cs
@@ -3,7 +3,6 @@ using Finance.Application.Commands.CreditCards;
 using Finance.Application.Services.CreditCards;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.CreditCards;
-using FinanceBackEnd.Finance.Domain.Enums;
 using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Tests.Services.CreditCards;
@@ -17,10 +16,10 @@ public partial class CreditCardServiceTests : IDisposable
         var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardCommand>()))
             .ReturnsAsync(DataResult<CreditCard>.Success(creditCard));
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
 
         var result = await _sut.Create(request);
@@ -36,42 +35,19 @@ public partial class CreditCardServiceTests : IDisposable
         var request = new CreateCreditCardRequest(bankId, "Visa Gold", true);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardCommand>()))
             .ReturnsAsync(DataResult<CreditCard>.Success(new CreditCard()));
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCard>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.Is<CreateCreditCardCommand>(c =>
                 c.BankId == bankId &&
                 c.Name == request.Name &&
                 c.Deactivated == request.Deactivated)),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task Create_DispatchesPermissionsCommandWithOwnerLevel()
-    {
-        var creditCard = new CreditCard { Id = Guid.NewGuid() };
-        var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
-
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
-            .ReturnsAsync(DataResult<CreditCard>.Success(creditCard));
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(It.IsAny<CreateCreditCardPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<CreditCardPermissions>.Success(new CreditCardPermissions()));
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(
-            It.Is<CreateCreditCardPermissionsCommand>(c =>
-                c.ResourceId == creditCard.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
             Times.Once);
     }
 
@@ -81,7 +57,7 @@ public partial class CreditCardServiceTests : IDisposable
         var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardCommand>()))
             .ReturnsAsync(DataResult<CreditCard>.Failure("dispatch error"));
 
         var result = await _sut.Create(request);
@@ -96,12 +72,12 @@ public partial class CreditCardServiceTests : IDisposable
         var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardCommand>()))
             .ReturnsAsync(DataResult<CreditCard>.Failure("dispatch error"));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<CreditCardPermissions>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.IsAny<CreateCreditCardPermissionsCommand>(),
             It.IsAny<HttpRequest?>()),
             Times.Never);
@@ -113,7 +89,7 @@ public partial class CreditCardServiceTests : IDisposable
         var request = new CreateCreditCardRequest(Guid.NewGuid(), "My Card", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<CreditCard>>(It.IsAny<CreateCreditCardCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateCreditCardCommand>()))
             .Throws(new Exception("unexpected error"));
 
         var result = await _sut.Create(request);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/DebitOrigins/DebitOriginServiceTests.Create.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/DebitOrigins/DebitOriginServiceTests.Create.cs
@@ -3,7 +3,6 @@ using Finance.Application.Commands.DebitOrigins;
 using Finance.Application.Services.DebitOrigins;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Debits;
-using FinanceBackEnd.Finance.Domain.Enums;
 using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Tests.Services.DebitOrigins;
@@ -17,10 +16,10 @@ public partial class DebitOriginServiceTests : IDisposable
         var request = new CreateDebitOriginRequest(Guid.NewGuid(), "Netflix", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOrigin>.Success(origin));
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOriginPermissions>>(It.IsAny<CreateDebitOriginPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOriginPermissions>.Success(new DebitOriginPermissions()));
 
         var result = await _sut.Create(request);
@@ -36,42 +35,19 @@ public partial class DebitOriginServiceTests : IDisposable
         var request = new CreateDebitOriginRequest(appModuleId, "Spotify", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOrigin>.Success(new DebitOrigin { Id = Guid.NewGuid() }));
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOriginPermissions>>(It.IsAny<CreateDebitOriginPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOriginPermissions>.Success(new DebitOriginPermissions()));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<DebitOrigin>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.Is<CreateDebitOriginCommand>(c =>
                 c.AppModuleId == appModuleId &&
                 c.Name == "Spotify" &&
                 c.Deactivated == false),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task Create_DispatchesPermissionsCommandWithOwnerLevel()
-    {
-        var originId = Guid.NewGuid();
-        var request = new CreateDebitOriginRequest(Guid.NewGuid(), "Netflix", false);
-
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<DebitOrigin>.Success(new DebitOrigin { Id = originId }));
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOriginPermissions>>(It.IsAny<CreateDebitOriginPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<DebitOriginPermissions>.Success(new DebitOriginPermissions()));
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<DebitOriginPermissions>>(
-            It.Is<CreateDebitOriginPermissionsCommand>(c =>
-                c.ResourceId == originId &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
             It.IsAny<HttpRequest?>()),
             Times.Once);
     }
@@ -82,7 +58,7 @@ public partial class DebitOriginServiceTests : IDisposable
         var request = new CreateDebitOriginRequest(Guid.NewGuid(), "Netflix", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOrigin>.Failure("create error"));
 
         var result = await _sut.Create(request);
@@ -97,12 +73,12 @@ public partial class DebitOriginServiceTests : IDisposable
         var request = new CreateDebitOriginRequest(Guid.NewGuid(), "Netflix", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<DebitOrigin>.Failure("create error"));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<DebitOriginPermissions>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.IsAny<CreateDebitOriginPermissionsCommand>(), It.IsAny<HttpRequest?>()),
             Times.Never);
     }
@@ -113,7 +89,7 @@ public partial class DebitOriginServiceTests : IDisposable
         var request = new CreateDebitOriginRequest(Guid.NewGuid(), "Netflix", false);
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<DebitOrigin>>(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateDebitOriginCommand>(), It.IsAny<HttpRequest?>()))
             .Throws(new Exception("unexpected error"));
 
         var result = await _sut.Create(request);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/IOLInvestmentAssets/IOLInvestmentAssetServiceTests.Create.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/IOLInvestmentAssets/IOLInvestmentAssetServiceTests.Create.cs
@@ -4,7 +4,6 @@ using Finance.Application.Services.IOLInvestmentAssets;
 using Finance.Domain.Enums;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.IOLInvestments;
-using FinanceBackEnd.Finance.Domain.Enums;
 using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Tests.Services.IOLInvestmentAssets;
@@ -21,10 +20,10 @@ public partial class IOLInvestmentAssetServiceTests
         var request = ACreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAsset>>(It.IsAny<CreateIOLInvestmentAssetCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentAssetCommand>()))
             .ReturnsAsync(DataResult<IOLInvestmentAsset>.Success(asset));
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAssetPermissions>>(It.IsAny<CreateIOLInvestmentAssetPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentAssetPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<IOLInvestmentAssetPermissions>.Success(new IOLInvestmentAssetPermissions()));
 
         var result = await _sut.Create(request);
@@ -40,15 +39,15 @@ public partial class IOLInvestmentAssetServiceTests
         var asset = new IOLInvestmentAsset { Id = Guid.NewGuid() };
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAsset>>(It.IsAny<CreateIOLInvestmentAssetCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentAssetCommand>()))
             .ReturnsAsync(DataResult<IOLInvestmentAsset>.Success(asset));
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAssetPermissions>>(It.IsAny<CreateIOLInvestmentAssetPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentAssetPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<IOLInvestmentAssetPermissions>.Success(new IOLInvestmentAssetPermissions()));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IOLInvestmentAsset>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.Is<CreateIOLInvestmentAssetCommand>(c =>
                 c.TypeId == request.TypeId &&
                 c.CurrencyId == request.CurrencyId &&
@@ -58,35 +57,12 @@ public partial class IOLInvestmentAssetServiceTests
     }
 
     [Fact]
-    public async Task Create_DispatchesPermissionsCommandWithOwnerLevel()
-    {
-        var asset = new IOLInvestmentAsset { Id = Guid.NewGuid() };
-        var request = ACreateRequest();
-
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAsset>>(It.IsAny<CreateIOLInvestmentAssetCommand>()))
-            .ReturnsAsync(DataResult<IOLInvestmentAsset>.Success(asset));
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAssetPermissions>>(It.IsAny<CreateIOLInvestmentAssetPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<IOLInvestmentAssetPermissions>.Success(new IOLInvestmentAssetPermissions()));
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IOLInvestmentAssetPermissions>>(
-            It.Is<CreateIOLInvestmentAssetPermissionsCommand>(c =>
-                c.ResourceId == asset.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
-    }
-
-    [Fact]
     public async Task Create_WhenCommandDispatchFails_ReturnsFailure()
     {
         var request = ACreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAsset>>(It.IsAny<CreateIOLInvestmentAssetCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentAssetCommand>()))
             .ReturnsAsync(DataResult<IOLInvestmentAsset>.Failure("create error"));
 
         var result = await _sut.Create(request);
@@ -101,12 +77,12 @@ public partial class IOLInvestmentAssetServiceTests
         var request = ACreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentAsset>>(It.IsAny<CreateIOLInvestmentAssetCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentAssetCommand>()))
             .ReturnsAsync(DataResult<IOLInvestmentAsset>.Failure("create error"));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IOLInvestmentAssetPermissions>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.IsAny<CreateIOLInvestmentAssetPermissionsCommand>(),
             It.IsAny<HttpRequest?>()),
             Times.Never);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/IOLInvestments/IOLInvestmentServiceTests.Create.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/IOLInvestments/IOLInvestmentServiceTests.Create.cs
@@ -2,10 +2,7 @@ using CQRSDispatch;
 using Finance.Application.Commands.IOLInvestments;
 using Finance.Application.Services.IOLInvestments;
 using Finance.Domain.Enums;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.IOLInvestments;
-using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Tests.Services.IOLInvestments;
 
@@ -21,11 +18,8 @@ public partial class IOLInvestmentServiceTests
         var request = ACreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestment>>(It.IsAny<CreateIOLInvestmentCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentCommand>()))
             .ReturnsAsync(DataResult<IOLInvestment>.Success(investment));
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentPermissions>>(It.IsAny<CreateIOLInvestmentPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<IOLInvestmentPermissions>.Success(new IOLInvestmentPermissions()));
 
         var result = await _sut.Create(request);
 
@@ -40,15 +34,12 @@ public partial class IOLInvestmentServiceTests
         var investment = new IOLInvestment { Id = Guid.NewGuid() };
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestment>>(It.IsAny<CreateIOLInvestmentCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentCommand>()))
             .ReturnsAsync(DataResult<IOLInvestment>.Success(investment));
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentPermissions>>(It.IsAny<CreateIOLInvestmentPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<IOLInvestmentPermissions>.Success(new IOLInvestmentPermissions()));
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IOLInvestment>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.Is<CreateIOLInvestmentCommand>(c =>
                 c.AssetSymbol == request.AssetSymbol &&
                 c.Alarms == request.Alarms &&
@@ -66,35 +57,12 @@ public partial class IOLInvestmentServiceTests
     }
 
     [Fact]
-    public async Task Create_DispatchesPermissionsCommandWithOwnerLevel()
-    {
-        var investment = new IOLInvestment { Id = Guid.NewGuid() };
-        var request = ACreateRequest();
-
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestment>>(It.IsAny<CreateIOLInvestmentCommand>()))
-            .ReturnsAsync(DataResult<IOLInvestment>.Success(investment));
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestmentPermissions>>(It.IsAny<CreateIOLInvestmentPermissionsCommand>(), It.IsAny<HttpRequest?>()))
-            .ReturnsAsync(DataResult<IOLInvestmentPermissions>.Success(new IOLInvestmentPermissions()));
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IOLInvestmentPermissions>>(
-            It.Is<CreateIOLInvestmentPermissionsCommand>(c =>
-                c.ResourceId == investment.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
-            Times.Once);
-    }
-
-    [Fact]
     public async Task Create_WhenDispatchFails_ReturnsFailure()
     {
         var request = ACreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestment>>(It.IsAny<CreateIOLInvestmentCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentCommand>()))
             .ReturnsAsync(DataResult<IOLInvestment>.Failure("dispatch error"));
 
         var result = await _sut.Create(request);
@@ -104,29 +72,12 @@ public partial class IOLInvestmentServiceTests
     }
 
     [Fact]
-    public async Task Create_WhenDispatchFails_DoesNotDispatchPermissions()
-    {
-        var request = ACreateRequest();
-
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestment>>(It.IsAny<CreateIOLInvestmentCommand>()))
-            .ReturnsAsync(DataResult<IOLInvestment>.Failure("dispatch error"));
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<IOLInvestmentPermissions>>(
-            It.IsAny<CreateIOLInvestmentPermissionsCommand>(),
-            It.IsAny<HttpRequest?>()),
-            Times.Never);
-    }
-
-    [Fact]
     public async Task Create_WhenDispatchThrows_ReturnsFailure()
     {
         var request = ACreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<IOLInvestment>>(It.IsAny<CreateIOLInvestmentCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateIOLInvestmentCommand>()))
             .Throws(new Exception("unexpected error"));
 
         var result = await _sut.Create(request);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/Movements/MovementServiceTests.Create.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/Movements/MovementServiceTests.Create.cs
@@ -1,11 +1,8 @@
 using CQRSDispatch;
 using Finance.Application.Commands.Movements;
 using Finance.Application.Services.Movements;
-using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Movements;
 using Finance.Domain.SpecialTypes;
-using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Tests.Services.Movements;
 
@@ -18,7 +15,6 @@ public partial class MovementServiceTests
         var request = BuildCreateRequest();
 
         SetupCreateMovementDispatch(DataResult<Movement>.Success(movement));
-        SetupCreatePermissionsDispatch();
 
         var result = await _sut.Create(request);
 
@@ -37,11 +33,10 @@ public partial class MovementServiceTests
         var request = new CreateMovementRequest(appModuleId, currencyId, timestamp, "Concept A", "Concept B", amount, total);
 
         SetupCreateMovementDispatch(DataResult<Movement>.Success(new Movement()));
-        SetupCreatePermissionsDispatch();
 
         await _sut.Create(request);
 
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<Movement>>(
+        _dispatcher.Verify(d => d.DispatchAsync(
             It.Is<CreateMovementCommand>(c =>
                 c.AppModuleId == appModuleId &&
                 c.CurrencyId == currencyId &&
@@ -50,25 +45,6 @@ public partial class MovementServiceTests
                 c.Concept2 == "Concept B" &&
                 c.Amount == amount &&
                 c.Total == total)),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task Create_DispatchesPermissionsCommandWithOwnerLevel()
-    {
-        var movement = new Movement { Id = Guid.NewGuid() };
-        var request = BuildCreateRequest();
-
-        SetupCreateMovementDispatch(DataResult<Movement>.Success(movement));
-        SetupCreatePermissionsDispatch();
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<MovementPermissions>>(
-            It.Is<CreateMovementPermissionsCommand>(c =>
-                c.ResourceId == movement.Id &&
-                c.PermissionLevels.Contains(PermissionLevelEnum.Owner)),
-            It.IsAny<HttpRequest?>()),
             Times.Once);
     }
 
@@ -86,27 +62,12 @@ public partial class MovementServiceTests
     }
 
     [Fact]
-    public async Task Create_WhenDispatchFails_DoesNotDispatchPermissions()
-    {
-        var request = BuildCreateRequest();
-
-        SetupCreateMovementDispatch(DataResult<Movement>.Failure("dispatch error"));
-
-        await _sut.Create(request);
-
-        _dispatcher.Verify(d => d.DispatchAsync<DataResult<MovementPermissions>>(
-            It.IsAny<CreateMovementPermissionsCommand>(),
-            It.IsAny<HttpRequest?>()),
-            Times.Never);
-    }
-
-    [Fact]
     public async Task Create_WhenDispatchThrows_ReturnsFailure()
     {
         var request = BuildCreateRequest();
 
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<Movement>>(It.IsAny<CreateMovementCommand>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateMovementCommand>()))
             .ThrowsAsync(new Exception("unexpected error"));
 
         var result = await _sut.Create(request);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Services/Movements/MovementServiceTests.Helpers.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Services/Movements/MovementServiceTests.Helpers.cs
@@ -16,15 +16,15 @@ public partial class MovementServiceTests
     private static UpdateMovementRequest BuildUpdateRequest(Guid id) =>
         new(id, DateTime.UtcNow, "Updated", null, new Money(500m), null);
 
-    private void SetupCreateMovementDispatch(DataResult<Movement> result) =>
-        _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<Movement>>(It.IsAny<CreateMovementCommand>()))
-            .ReturnsAsync(result);
-
     private void SetupCreatePermissionsDispatch() =>
         _dispatcher
-            .Setup(d => d.DispatchAsync<DataResult<MovementPermissions>>(It.IsAny<CreateMovementPermissionsCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateMovementPermissionsCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(DataResult<MovementPermissions>.Success(new MovementPermissions()));
+
+    private void SetupCreateMovementDispatch(DataResult<Movement> result) =>
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<CreateMovementCommand>()))
+            .ReturnsAsync(result);
 
     private void SetupDeleteMovementDispatch(CommandResult result) =>
         _dispatcher
@@ -33,6 +33,6 @@ public partial class MovementServiceTests
 
     private void SetupDeleteOwnerDispatch(CommandResult result) =>
         _dispatcher
-            .Setup(d => d.DispatchAsync<CommandResult>(It.IsAny<DeleteMovementOwnerCommand>(), It.IsAny<HttpRequest?>()))
+            .Setup(d => d.DispatchAsync(It.IsAny<DeleteMovementOwnerCommand>(), It.IsAny<HttpRequest?>()))
             .ReturnsAsync(result);
 }


### PR DESCRIPTION
# Why

Previously, each command handler and service method responsible for creating a resource (Income, Debit, Fund, CreditCard, Movement, Subscription, IOLInvestment, IOLInvestmentAsset, CurrencyExchangeRate, DebitOrigin) had to individually dispatch a `CreateXxxPermissionsCommand` via `IDispatcher` to persist an ownership permission record for the current user. This scattered permission-creation logic across many handlers and introduced a shared `IDispatcher` dependency everywhere.

## What is the solution?

Ownership permission creation is now centralized inside `FinanceDbContext.SaveChangesAsync` / `SaveChanges`. A static `_permissionFactories` dictionary maps each owned entity type to its permission builder. Before delegating to EF Core's base `SaveChanges`, the context inspects the change tracker for newly `Added` entities and automatically inserts the corresponding `ResourcePermissions` row with `PermissionLevelEnum.Owner` for the authenticated user.

Key implementation details:
- `AutoCreateOwnershipPermissionsAsync` (async) and `AutoCreateOwnershipPermissions` (sync) added to `FinanceDbContext`
- `IDispatcher<FinanceDispatchContext>` dependency removed from all Create command handlers and services
- `ServiceExtensions.cs` DI registrations updated accordingly
- Unit tests simplified: dispatcher mocks removed; `CreateHandler()` factory helpers introduced where beneficial

## What areas of the site does it impact?

- **Persistence layer** — `FinanceDbContext` (core change)
- **Application layer** — all Create command handlers (Income, Debit, Fund, CurrencyExchangeRate, Subscription) and services (CreditCardService, DebitOriginService, IOLInvestmentAssetService, IOLInvestmentService, MovementService)
- **API layer** — minor simplifications to DebitCommandController, IOLInvestmentCommandController, MovementCommandController
- **Test layer** — all corresponding unit test classes

## Test scenarios

```gherkin
Scenario: Creating an owned resource automatically creates an Owner permission
  Given an authenticated user
  When the user creates a new resource (e.g. Income, Fund, CreditCard)
  Then a ResourcePermissions record with PermissionLevelEnum.Owner is persisted for that user

Scenario: Command handler no longer requires IDispatcher
  Given a CreateXxxCommandHandler instance constructed without IDispatcher
  When ExecuteAsync is called with a valid command
  Then the resource is created and the handler returns a success result

Scenario: No permission created without an authenticated HTTP context
  Given no active HttpContext (e.g. background job or seeding)
  When SaveChanges is called with a new owned entity
  Then no ResourcePermissions record is inserted and no exception is thrown
```

## Other Notes

Closes #93