### PR TITLE
fix: replace per-page buttons with compact navigation controls in PaginationBar

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginationBar.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginationBar.tsx
@@ -1,50 +1,103 @@
 import React from "react";
-import ActionLink from "@/components/ui/utils/ActionLink";
+import {
+    ChevronsLeftIcon,
+    ChevronsRightIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon,
+} from "lucide-react";
+import {
+    Pagination,
+    PaginationContent,
+    PaginationItem,
+} from "@/components/ui/shadcn/pagination";
+import { buttonVariants } from "@/components/ui/shadcn/button";
+import { cn } from "@/lib/utils";
 
-/* TODO Fix the ammount of page pickers displayed on screen */
 const PaginationBar: React.FC<{
     page: number;
     totalPages: number;
     action: (page: number) => void;
 }> = ({ page, totalPages, action }) => {
-    const previousPageEnabled = page > 1;
-    const nextPageEnabled = page < totalPages;
+    const atFirst = page <= 1;
+    const atLast = page >= totalPages;
+
+    function handlePageInput(e: React.ChangeEvent<HTMLInputElement>) {
+        const value = parseInt(e.target.value, 10);
+        if (!isNaN(value) && value >= 1 && value <= totalPages) {
+            action(value);
+        }
+    }
+
+    const navBtn = (disabled: boolean) =>
+        cn(buttonVariants({ variant: "ghost", size: "icon" }), disabled && "pointer-events-none opacity-50");
 
     return (
-        <ul className="pagination">
-            <li
-                className={
-                    "page-item" + (!previousPageEnabled ? " disabled" : "")
-                }
-            >
-                <ActionLink
-                    text="Anterior"
-                    action={() => action(page - 1)}
-                    isEnabled={previousPageEnabled}
-                />
-            </li>
-            {Array.from({ length: totalPages }, (_, i) => {
-                const isActive = i === page - 1 ? " active" : "";
-                return (
-                    <li key={i} className="page-item">
-                        <button
-                            type="button"
-                            className={"page-link" + isActive}
-                            onClick={() => action(i)}
-                        >
-                            {i + 1}
-                        </button>
-                    </li>
-                );
-            })}
-            <li className={"page-item" + (!nextPageEnabled ? " disabled" : "")}>
-                <ActionLink
-                    text="Siguiente"
-                    action={() => action(page + 1)}
-                    isEnabled={nextPageEnabled}
-                />
-            </li>
-        </ul>
+        <Pagination>
+            <PaginationContent>
+                <PaginationItem>
+                    <button
+                        type="button"
+                        aria-label="Primera página"
+                        className={navBtn(atFirst)}
+                        disabled={atFirst}
+                        onClick={() => action(1)}
+                    >
+                        <ChevronsLeftIcon className="size-4" />
+                    </button>
+                </PaginationItem>
+
+                <PaginationItem>
+                    <button
+                        type="button"
+                        aria-label="Página anterior"
+                        className={navBtn(atFirst)}
+                        disabled={atFirst}
+                        onClick={() => action(page - 1)}
+                    >
+                        <ChevronLeftIcon className="size-4" />
+                    </button>
+                </PaginationItem>
+
+                <PaginationItem className="flex items-center gap-2 px-1">
+                    <input
+                        type="number"
+                        min={1}
+                        max={totalPages}
+                        value={page}
+                        onChange={handlePageInput}
+                        aria-label="Página"
+                        className="w-14 rounded-md border border-input bg-background px-2 py-1 text-center text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                    <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        de {totalPages}
+                    </span>
+                </PaginationItem>
+
+                <PaginationItem>
+                    <button
+                        type="button"
+                        aria-label="Página siguiente"
+                        className={navBtn(atLast)}
+                        disabled={atLast}
+                        onClick={() => action(page + 1)}
+                    >
+                        <ChevronRightIcon className="size-4" />
+                    </button>
+                </PaginationItem>
+
+                <PaginationItem>
+                    <button
+                        type="button"
+                        aria-label="Última página"
+                        className={navBtn(atLast)}
+                        disabled={atLast}
+                        onClick={() => action(totalPages)}
+                    >
+                        <ChevronsRightIcon className="size-4" />
+                    </button>
+                </PaginationItem>
+            </PaginationContent>
+        </Pagination>
     );
 };
 


### PR DESCRIPTION
# Why

`PaginationBar` rendered one button per page, causing severe UI overflow on lists with large page counts (a known issue flagged by a `TODO` comment in the original code). Additionally, the page button click handler incorrectly called `action(i)` using the 0-indexed loop variable instead of `action(i + 1)`, so clicking page 1 would trigger navigation to page 0 — a non-existent page.

## What is the solution?

Rewrote `PaginationBar` using the shadcn `Pagination` compound component with lucide-react icons. The new layout provides:

- **First / Last** page buttons (double-chevron icons)
- **Previous / Next** page buttons (single-chevron icons)
- A **numeric input** for direct page entry, replacing the overflowing per-page button list
- Correct disabled state via `atFirst` / `atLast` flags
- Accessible `aria-label` attributes on every navigation button

## What areas of the site does it impact?

Any view that uses the shared `PaginationBar` component — all paginated list screens across the FinanceApp frontend.

## Test scenarios

```gherkin
Scenario: Navigation buttons are disabled on the first page
  Given the user is on page 1 of a paginated list
  Then the first-page and previous-page buttons are disabled

Scenario: Navigation buttons are disabled on the last page
  Given the user is on the last page of a paginated list
  Then the last-page and next-page buttons are disabled

Scenario: Next page button advances one page
  Given the user is on page 2 of 5
  When the user clicks the next-page button
  Then the action is called with page 3

Scenario: Direct page input navigates to the entered page
  Given the user is on page 1 of 10
  When the user types 7 in the page input
  Then the action is called with page 7

Scenario: Direct page input ignores out-of-range values
  Given the user is on page 1 of 10
  When the user types 0 or 11 in the page input
  Then no navigation action is triggered

Scenario: First page button navigates to page 1
  Given the user is on page 4 of 10
  When the user clicks the first-page button
  Then the action is called with page 1

Scenario: Last page button navigates to the last page
  Given the user is on page 4 of 10
  When the user clicks the last-page button
  Then the action is called with page 10
```

## Other Notes

Closes #96
