### PR TITLE
docs: add copilot-instructions and local dev environment docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+# Project: Finanzas
+
+## Stack
+- **Backend**: .NET API — runs in Docker (`finances-shared-backend-1`), port 5000
+- **Frontend**: React Router v7 SSR (`FinanceFrontEnd/FinanceApp`) — port 5100
+- **Frontend (Funds)**: Vite SPA (`FinanceFrontEnd/FinanceFunds`) — port 5200
+- **Infra**: Postgres, Redis, Jaeger, Grafana in Docker via `.infra/local/shared/docker-compose.yaml`
+
+## Local dev
+- Frontend and backend can each run locally (terminal) or in Docker
+- Env file for local dev: `FinanceFrontEnd/FinanceApp/.env.development`
+- Known gotcha: `localhost` resolves to IPv6 on this machine — use `127.0.0.1` for `API_URL` when backend runs in Docker. Details in `.github/docs/local-dev-environment.md`
+
+## Docs (load when relevant)
+- `.github/docs/local-dev-environment.md` — run modes, IPv6 gotcha, env files, start script
+- `.github/docs/finance-query-filters.md` — EF ownership filters, test identity seeding

--- a/.github/docs/finance-query-filters.md
+++ b/.github/docs/finance-query-filters.md
@@ -1,0 +1,5 @@
+# EF Query Filters & Test Identity Seeding
+
+- `FinanceDbContext` applies global ownership filters to `Fund` and `Movement`.
+- In tests with no `HttpContextAccessor`, `CurrentUserId` defaults to `IdentityNotFound`.
+- Query tests must seed a `User` identity with `SourceId = IdentityNotFound` plus matching `FundPermissions` / `MovementPermissions` to make entities visible.

--- a/.github/docs/local-dev-environment.md
+++ b/.github/docs/local-dev-environment.md
@@ -1,0 +1,32 @@
+# Local Dev Environment
+
+## Running modes
+
+Both frontend and backend can run either way:
+- **Locally** (terminal): `dotnet run` / `npm run dev`
+- **In Docker**: via docker-compose stacks
+
+## Ports
+- Backend: `5000`
+- Frontend (`FinanceApp`): `5100`
+- Frontend (`FinanceFunds`): `5200`
+
+## Docker stacks
+- Infra (Postgres, Redis, Jaeger, Grafana) + Backend: `.infra/local/shared/docker-compose.yaml`
+- FinanceApp frontend container: `.infra/local/finances/docker-compose.yaml`
+- FinanceFunds frontend container: `.infra/local/funds/docker-compose.yaml`
+- Start script: `.bin/powershell/start-finances-local.ps1`
+
+## Env files
+- Frontend local dev: `FinanceFrontEnd/FinanceApp/.env.development`
+- Frontend Docker: `.infra/local/finances/.env` — uses `host.docker.internal:5000` for `API_URL`
+- Backend Docker: `.infra/local/shared/.env`
+
+## Key gotcha: localhost resolves to IPv6 on this machine
+
+`localhost` resolves to `::1` (IPv6), but Docker port bindings only reliably respond on `127.0.0.1` (IPv4).
+
+- When running the frontend locally (`npm run dev`) and the backend in Docker, SSR server-side fetches to `localhost:5000` will **hang/timeout**.
+- Fix: use `API_URL=http://127.0.0.1:5000` in `.env.development`.
+- Browser-side calls use `window.location.hostname` and are unaffected.
+- When both run in Docker this is not an issue — the frontend container uses `host.docker.internal:5000`.

--- a/.github/skills/gh-docs-pr/SKILL.md
+++ b/.github/skills/gh-docs-pr/SKILL.md
@@ -100,7 +100,6 @@ The PR body must follow the template structure from [.github/PULL_REQUEST_TEMPLA
 - **# Why** — what prompted the documentation change
 - **## What is the solution?** — what was written or updated and how it helps
 - **## What areas of the site does it impact?** — which modules, layers, or workflows the docs relate to
-- **## Test scenarios** — N/A for docs; note any examples or diagrams added
 - **## Other Notes** — `Closes #<issue-number>`
 
 ## Output


### PR DESCRIPTION
# Why
The project lacked documentation about its run modes, ports, environment configuration, and known platform-specific gotchas. GitHub Copilot had no persistent context about the project, causing it to re-discover the same facts on every session.

## What is the solution?
Added three new files:
- \.github/copilot-instructions.md\: minimal always-loaded Copilot context — stack overview, ports, run modes, and pointers to detailed docs
- \.github/docs/local-dev-environment.md\: full local dev reference — running modes (terminal vs Docker), docker-compose stacks, env files per scenario, and the Windows IPv6/IPv4 gotcha when mixing local frontend with Docker backend
- \.github/docs/finance-query-filters.md\: documents EF global ownership filter behaviour on Fund and Movement, and the test identity seeding required for query tests

## What areas of the site does it impact?
Developer tooling and onboarding only. No application code changed.

## Other Notes
Closes #98