### PR TITLE
fix: funds grid amount column always showing 0

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -149,12 +149,10 @@ const Funds: React.FC = () => {
 
   const paginatedData = Array.isArray(data)
     ? {
-        items: data,
-        totalPages: 1,
-      }
+      items: data,
+      totalPages: 1,
+    }
     : data;
-  
-  SafeLogger.log('Funds component loaded with data:', paginatedData);
 
   return (
     <div className={cn(['py-10', 'px-40'])}>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -8,7 +8,6 @@ import { InputType } from '@/components/ui/utils/InputType';
 import CommonUtils, { toNumber } from '@/utils/common';
 import { cn } from '@/lib/utils';
 import type { FundRecord } from '@/types/fund';
-import SafeLogger from '@/utils/SafeLogger';
 
 // Define types for the props and states
 interface PickerData {

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Funds/index.tsx
@@ -8,6 +8,7 @@ import { InputType } from '@/components/ui/utils/InputType';
 import CommonUtils, { toNumber } from '@/utils/common';
 import { cn } from '@/lib/utils';
 import type { FundRecord } from '@/types/fund';
+import SafeLogger from '@/utils/SafeLogger';
 
 // Define types for the props and states
 interface PickerData {
@@ -57,7 +58,10 @@ const Funds: React.FC = () => {
     eval: (field: unknown) => field != null && toNumber(field) > 0,
   };
 
-  const valueMapper = (field: unknown) => (field != null ? toNumber(field) : null);
+  const valueMapper = (record: unknown) => {
+    const amount = (record as FundRecord).amount;
+    return amount != null ? toNumber(amount) : null;
+  };
 
   const numericHeader = {
     classes: 'text-end',
@@ -149,6 +153,8 @@ const Funds: React.FC = () => {
         totalPages: 1,
       }
     : data;
+  
+  SafeLogger.log('Funds component loaded with data:', paginatedData);
 
   return (
     <div className={cn(['py-10', 'px-40'])}>


### PR DESCRIPTION
# Why
The Amount column in the Funds grid always rendered `0` regardless of the actual record value. The `valueMapper` function was defined as `(field: unknown) => toNumber(field)`, but `PaginatedTable` passes the **full record object** to mapper functions — not the individual field value. As a result, `toNumber(record)` always fell through to the default return value of `0`.

## What is the solution?
Updated `valueMapper` in the Funds component to correctly extract the `amount` field from the record object before calling `toNumber`:

```ts
const valueMapper = (record: unknown) => {
  const amount = (record as FundRecord).amount;
  return amount != null ? toNumber(amount) : null;
};
```

## What areas of the site does it impact?
- **Funds page** (`/funds`) — the Amount column in the funds grid now displays correct values.

## Test scenarios

```gherkin
Scenario: Funds grid displays correct amount values
  Given I have fund records with non-zero amounts
  When I navigate to the Funds page
  Then each row in the Amount column shows the correct value from the record

Scenario: Funds grid handles null amount gracefully
  Given I have a fund record where amount is null
  When I navigate to the Funds page
  Then the Amount column for that row renders empty rather than 0
```

## Other Notes
Closes #100