### PR TITLE
fix: use client timezone offset in IOL investment Excel upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ secrets.local.env
 !.bin
 
 **/*.log
+
+**/TestResults/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,4 @@
         "editor.defaultFormatter": "vscode.json-language-features"
     },
     "dotnet-test-explorer.testProjectPath": "FinanceBackEnd/tests/**/*.csproj",
-    "chat.tools.terminal.autoApprove": {
-        "dotnet build": true,
-        "ForceNoAlign": true,
-        "dotnet test": true
-    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,4 +10,9 @@
         "editor.defaultFormatter": "vscode.json-language-features"
     },
     "dotnet-test-explorer.testProjectPath": "FinanceBackEnd/tests/**/*.csproj",
+    "chat.tools.terminal.autoApprove": {
+        "dotnet build": true,
+        "ForceNoAlign": true,
+        "dotnet test": true
+    },
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/IOLInvestmentCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/IOLInvestmentCommandController.cs
@@ -31,9 +31,9 @@ public class IOLInvestmentCommandController(
         IOLInvestmentService>(mapper, dispatcher, iolInvestmentService)
 {
     [HttpPost("upload")]
-    public async Task<IActionResult> Upload(IFormFile file)
+    public async Task<IActionResult> Upload(IFormFile file, [FromQuery] short? timezoneOffset = null)
     {
-        await Dispatcher.DispatchCommandAsync(new UploadIOLInvestmentsCommand(file));
+        await Dispatcher.DispatchCommandAsync(new UploadIOLInvestmentsCommand(file, timezoneOffset));
         return Ok();
     }
 }

--- a/FinanceBackEnd/src/Finance.Api/Core/Config/ConfigExtensions.cs
+++ b/FinanceBackEnd/src/Finance.Api/Core/Config/ConfigExtensions.cs
@@ -8,6 +8,7 @@ using Finance.Application.Mapping;
 using Finance.Application.Repositories;
 using Finance.Domain.DataConverters;
 using Finance.Domain.JsonConverters;
+using Finance.Domain.Models.IOLInvestments;
 using Finance.Persistence;
 using Finance.Persistence.Telemetry;
 using Microsoft.EntityFrameworkCore;
@@ -36,7 +37,7 @@ public static class ConfigExtensions
 
         services.AddSagaServices();
 
-        services.AddScoped<IOLInvestmentExcelHelper>();
+        services.AddScoped<IExcelHelper<IOLInvestment>, IOLInvestmentExcelHelper>();
 
         services.AddDispatecherServices();
 

--- a/FinanceBackEnd/src/Finance.Application/Commands/IOLInvestments/UploadIOLInvestmentCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/IOLInvestments/UploadIOLInvestmentCommand.cs
@@ -18,7 +18,7 @@ public class UploadIOLInvestmentCommandHandler : BaseResponselessHandler<UploadI
     private readonly IRepository<IOLInvestment, Guid> _iolInvestment;
     private readonly IRepository<IOLInvestmentAsset, Guid> _iolInvestmentAsset;
     private readonly IRepository<IOLInvestmentAssetType, IOLInvestmentAssetTypeEnum> _iolInvestmentAssetType;
-    private readonly IOLInvestmentExcelHelper _iolInvestmentExcelHelper;
+    private readonly IExcelHelper<IOLInvestment> _iolInvestmentExcelHelper;
 
     public UploadIOLInvestmentCommandHandler(
         FinanceDbContext db,
@@ -26,7 +26,7 @@ public class UploadIOLInvestmentCommandHandler : BaseResponselessHandler<UploadI
         IRepository<IOLInvestment, Guid> iolInvestmentRepository,
         IRepository<IOLInvestmentAsset, Guid> iolInvestmentAssetRepository,
         IRepository<IOLInvestmentAssetType, IOLInvestmentAssetTypeEnum> iolInvestmentAssetTypeRepository,
-        IOLInvestmentExcelHelper iolInvestmentExcelHelper)
+        IExcelHelper<IOLInvestment> iolInvestmentExcelHelper)
         : base(db)
     {
         _iolInvestment = iolInvestmentRepository;
@@ -40,7 +40,7 @@ public class UploadIOLInvestmentCommandHandler : BaseResponselessHandler<UploadI
     {
         var files = command.File;
 
-        var newRecords = _iolInvestmentExcelHelper.Read(files, DateTimeKind.Utc).ToArray();
+        var newRecords = _iolInvestmentExcelHelper.Read(files, command.TimezoneOffset).ToArray();
 
         if (newRecords.Length > 0)
         {
@@ -104,10 +104,12 @@ public class UploadIOLInvestmentCommandHandler : BaseResponselessHandler<UploadI
 
 public class UploadIOLInvestmentsCommand : ICommand
 {
-    public UploadIOLInvestmentsCommand(IFormFile file)
+    public UploadIOLInvestmentsCommand(IFormFile file, short? timezoneOffset = null)
     {
         File = file;
+        TimezoneOffset = timezoneOffset;
     }
 
     public IFormFile File { get; set; }
+    public short? TimezoneOffset { get; set; }
 }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/DateTimeHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/DateTimeHelper.cs
@@ -27,7 +27,7 @@ public static class DateTimeHelper
     public static DateTime ParseDateTime(object? value, string format, IFormatProvider? formatProvider = null, DateTimeKind kind = DateTimeKind.Unspecified)
         => ParseNullDateTime(value, format, formatProvider, kind) ?? default;
 
-    internal static DateTime FromTimeZoneToUTC(DateTime currentDate, short offset)
+    public static DateTime FromTimeZoneToUTC(DateTime currentDate, short offset)
     {
         TimeSpan timeZoneOffset = TimeSpan.FromHours(offset);
 

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/IExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/IExcelHelper.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Http;
 
 public interface IExcelHelper<TResult>
 {
-    IEnumerable<TResult> Read(IEnumerable<IFormFile> files, DateTimeKind dateTimeKind = DateTimeKind.Unspecified);
+    IEnumerable<TResult> Read(IEnumerable<IFormFile> files, short? timezoneOffset = null);
 
-    IEnumerable<TResult> Read(IFormFile file, DateTimeKind dateTimeKind = DateTimeKind.Unspecified);
+    IEnumerable<TResult> Read(IFormFile file, short? timezoneOffset = null);
 }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/IOLInvestmentExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/IOLInvestmentExcelHelper.cs
@@ -9,10 +9,10 @@ using Microsoft.AspNetCore.Http;
 
 public class IOLInvestmentExcelHelper : IExcelHelper<IOLInvestment>
 {
-    public IEnumerable<IOLInvestment> Read(IEnumerable<IFormFile> files, DateTimeKind dateTimeKind = DateTimeKind.Unspecified)
-        => files.SelectMany(o => Read(o, dateTimeKind)).ToArray();
+    public IEnumerable<IOLInvestment> Read(IEnumerable<IFormFile> files, short? timezoneOffset = null)
+        => files.SelectMany(o => Read(o, timezoneOffset)).ToArray();
 
-    public IEnumerable<IOLInvestment> Read(IFormFile file, DateTimeKind dateTimeKind = DateTimeKind.Unspecified)
+    public IEnumerable<IOLInvestment> Read(IFormFile file, short? timezoneOffset = null)
     {
         var records = new List<IOLInvestment>();
 
@@ -35,9 +35,11 @@ public class IOLInvestmentExcelHelper : IExcelHelper<IOLInvestment>
                 Func<object, string> currencySymbolParser = ExtractCurrencySymbol;
 
                 var dateString = sheet.Rows[0][1].ToString();
-                var currentDate = DateTimeHelper.ParseDateTime(dateString, "d/M/yyyy HH:mm:ss", null, dateTimeKind);
+                var currentDate = DateTimeHelper.ParseDateTime(dateString, "d/M/yyyy HH:mm:ss");
                 if (currentDate.Ticks == DateTime.MinValue.Ticks) currentDate = DateTime.Now;
-                currentDate = DateTimeHelper.FromTimeZoneToUTC(currentDate, -3);
+                currentDate = timezoneOffset.HasValue
+                    ? DateTimeHelper.FromTimeZoneToUTC(currentDate, timezoneOffset.Value)
+                    : DateTime.SpecifyKind(currentDate, DateTimeKind.Local).ToUniversalTime();
 
                 var now = DateTime.UtcNow;
 

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/IOLInvestments/UploadIOLInvestmentCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/IOLInvestments/UploadIOLInvestmentCommandHandlerTests.cs
@@ -1,0 +1,249 @@
+using Finance.Application.Commands.IOLInvestments;
+using Finance.Application.Repositories;
+using Finance.Domain.Enums;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.Currencies;
+using Finance.Domain.Models.Identities;
+using Finance.Domain.Models.IOLInvestments;
+using Finance.Persistence;
+using FinanceBackEnd.Finance.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Commands.IOLInvestments;
+
+public class UploadIOLInvestmentCommandHandlerTests : IDisposable
+{
+    private readonly Mock<IRepository<Currency, Guid>> _currencyRepository;
+    private readonly Mock<IRepository<IOLInvestmentAssetType, IOLInvestmentAssetTypeEnum>> _iolInvestmentAssetTypeRepository;
+    private readonly Mock<IExcelHelper<IOLInvestment>> _excelHelper;
+    private readonly FinanceDbContext _dbContext;
+
+    public UploadIOLInvestmentCommandHandlerTests()
+    {
+        _currencyRepository = new Mock<IRepository<Currency, Guid>>();
+        _iolInvestmentAssetTypeRepository = new Mock<IRepository<IOLInvestmentAssetType, IOLInvestmentAssetTypeEnum>>();
+        _excelHelper = new Mock<IExcelHelper<IOLInvestment>>();
+
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        _dbContext = new FinanceDbContext(options, null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private UploadIOLInvestmentCommandHandler CreateHandler() =>
+        new(_dbContext, _currencyRepository.Object,
+            new IOLInvestmentRepository(_dbContext),
+            new IOLInvestmentAssetRepository(_dbContext),
+            _iolInvestmentAssetTypeRepository.Object,
+            _excelHelper.Object);
+
+    [Fact]
+    public async Task Upload_WhenHelperReturnsNoRecords_ReturnsFailure()
+    {
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), It.IsAny<short?>()))
+            .Returns(Array.Empty<IOLInvestment>());
+
+        var result = await CreateHandler().ExecuteAsync(
+            new UploadIOLInvestmentsCommand(StubFile()), default);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("No records found in the uploaded file.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Upload_PassesTimezoneOffsetToHelper()
+    {
+        var record = MakeRecord();
+        var currency = new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD" };
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), (short?)-3))
+            .Returns([record]);
+
+        _currencyRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currency);
+        _currencyRepository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currency);
+
+        _iolInvestmentAssetTypeRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IOLInvestmentAssetType?)null);
+
+        await CreateHandler().ExecuteAsync(
+            new UploadIOLInvestmentsCommand(StubFile(), timezoneOffset: -3), default);
+
+        _excelHelper.Verify(h => h.Read(It.IsAny<IFormFile>(), (short?)-3), Times.Once);
+    }
+
+    [Fact]
+    public async Task Upload_WhenNoTimezoneProvided_PassesNullToHelper()
+    {
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), (short?)null))
+            .Returns(Array.Empty<IOLInvestment>());
+
+        await CreateHandler().ExecuteAsync(
+            new UploadIOLInvestmentsCommand(StubFile()), default);
+
+        _excelHelper.Verify(h => h.Read(It.IsAny<IFormFile>(), (short?)null), Times.Once);
+    }
+
+    [Fact]
+    public async Task Upload_WhenRecordAlreadyExists_SkipsIt()
+    {
+        var record = MakeRecord("AAPL");
+        var user = await SeedUserAsync();
+
+        var existingCurrency = new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD" };
+        var existingAsset = new IOLInvestmentAsset { Id = Guid.NewGuid(), Symbol = "AAPL", Description = string.Empty, TypeId = IOLInvestmentAssetTypeEnum.Cedear, CurrencyId = existingCurrency.Id };
+        var existing = new IOLInvestment { Id = Guid.NewGuid(), Asset = existingAsset, AssetId = existingAsset.Id, TimeStamp = record.TimeStamp, CreatedAt = DateTime.UtcNow };
+        _dbContext.Currency.Add(existingCurrency);
+        _dbContext.IOLInvestmentAsset.Add(existingAsset);
+        _dbContext.IOLInvestment.Add(existing);
+        await _dbContext.SaveChangesAsync();
+        await GrantInvestmentAccessAsync(user, existing);
+
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), It.IsAny<short?>()))
+            .Returns([record]);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new UploadIOLInvestmentsCommand(StubFile()), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, await _dbContext.IOLInvestment.IgnoreQueryFilters().CountAsync());
+    }
+
+    [Fact]
+    public async Task Upload_WhenCurrencyNotFound_AndFallbackNotFound_SkipsRecord()
+    {
+        var record = MakeRecord("AAPL");
+
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), It.IsAny<short?>()))
+            .Returns([record]);
+
+        _currencyRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Currency?)null);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new UploadIOLInvestmentsCommand(StubFile()), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, await _dbContext.IOLInvestment.CountAsync());
+    }
+
+    [Fact]
+    public async Task Upload_WhenNewRecord_AddsToRepository()
+    {
+        var record = MakeRecord("MSFT");
+        var currency = new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD" };
+
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), It.IsAny<short?>()))
+            .Returns([record]);
+
+        _currencyRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currency);
+        _currencyRepository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currency);
+
+        _iolInvestmentAssetTypeRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IOLInvestmentAssetType?)null);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new UploadIOLInvestmentsCommand(StubFile()), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, await _dbContext.IOLInvestment.IgnoreQueryFilters().CountAsync());
+    }
+
+    [Fact]
+    public async Task Upload_WhenAssetAlreadyExists_ReusesIt()
+    {
+        var user = await SeedUserAsync();
+        var existingCurrency = new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD" };
+        var existingAsset = new IOLInvestmentAsset { Id = Guid.NewGuid(), Symbol = "GOOGL", Description = string.Empty, TypeId = IOLInvestmentAssetTypeEnum.Cedear, CurrencyId = existingCurrency.Id };
+        _dbContext.Currency.Add(existingCurrency);
+        _dbContext.IOLInvestmentAsset.Add(existingAsset);
+        await _dbContext.SaveChangesAsync();
+        await GrantAssetAccessAsync(user, existingAsset);
+
+        var record = MakeRecord("GOOGL");
+        _excelHelper.Setup(h => h.Read(It.IsAny<IFormFile>(), It.IsAny<short?>()))
+            .Returns([record]);
+
+        _currencyRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingCurrency);
+        _currencyRepository.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingCurrency);
+
+        _iolInvestmentAssetTypeRepository.Setup(r => r.GetByAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IOLInvestmentAssetType?)null);
+
+        await CreateHandler().ExecuteAsync(new UploadIOLInvestmentsCommand(StubFile()), default);
+
+        var saved = await _dbContext.IOLInvestment.IgnoreQueryFilters().Include(i => i.Asset).FirstAsync();
+        Assert.Equal(existingAsset.Id, saved.AssetId);
+    }
+
+    private static IFormFile StubFile() =>
+        new FormFile(new MemoryStream([0x00]), 0, 1, "file", "investments.xlsx");
+
+    private async Task<User> SeedUserAsync()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { Id = Guid.NewGuid(), SourceId = "IdentityNotFound" }],
+        };
+        _dbContext.User.Add(user);
+        await _dbContext.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task GrantInvestmentAccessAsync(User user, IOLInvestment investment)
+    {
+        _dbContext.IOLInvestmentPermissions.Add(new IOLInvestmentPermissions
+        {
+            Id = Guid.NewGuid(),
+            ResourceId = investment.Id,
+            UserId = user.Id,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task GrantAssetAccessAsync(User user, IOLInvestmentAsset asset)
+    {
+        _dbContext.IOLInvestmentAssetPermissions.Add(new IOLInvestmentAssetPermissions
+        {
+            Id = Guid.NewGuid(),
+            ResourceId = asset.Id,
+            UserId = user.Id,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private static IOLInvestment MakeRecord(string symbol = "AAPL", DateTime? timestamp = null)
+    {
+        var asset = new IOLInvestmentAsset
+        {
+            Id = Guid.NewGuid(),
+            Symbol = symbol,
+            Description = string.Empty,
+            Type = new IOLInvestmentAssetType { Id = IOLInvestmentAssetTypeEnum.Cedear, Name = "Cedear" },
+            Currency = Currency.Default(symbols: [CurrencySymbol.Default(symbol: "USD")]),
+        };
+        return new IOLInvestment
+        {
+            Id = Guid.NewGuid(),
+            Asset = asset,
+            TimeStamp = timestamp ?? new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc),
+            CreatedAt = DateTime.UtcNow,
+        };
+    }
+}
+

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/DateTimeHelperTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/DateTimeHelperTests.cs
@@ -1,0 +1,73 @@
+using Finance.Helpers;
+
+namespace Finance.Application.Tests.Helpers;
+
+public class DateTimeHelperTests
+{
+    [Fact]
+    public void ParseDateTime_ValidString_ReturnsParsedDate()
+    {
+        var result = DateTimeHelper.ParseDateTime("1/6/2025 12:30:00", "d/M/yyyy HH:mm:ss");
+
+        Assert.Equal(new DateTime(2025, 6, 1, 12, 30, 0), result);
+    }
+
+    [Fact]
+    public void ParseDateTime_InvalidString_ReturnsDefault()
+    {
+        var result = DateTimeHelper.ParseDateTime("not-a-date", "d/M/yyyy HH:mm:ss");
+
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void ParseDateTime_NullValue_ReturnsDefault()
+    {
+        var result = DateTimeHelper.ParseDateTime(null, "d/M/yyyy HH:mm:ss");
+
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void FromTimeZoneToUTC_NegativeOffset_AddsOffsetToConvertToUTC()
+    {
+        var localTime = new DateTime(2025, 6, 1, 12, 0, 0);
+
+        var result = DateTimeHelper.FromTimeZoneToUTC(localTime, -3);
+
+        Assert.Equal(new DateTime(2025, 6, 1, 15, 0, 0, DateTimeKind.Utc), result);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+    [Fact]
+    public void FromTimeZoneToUTC_PositiveOffset_SubtractsOffsetToConvertToUTC()
+    {
+        var localTime = new DateTime(2025, 6, 1, 12, 0, 0);
+
+        var result = DateTimeHelper.FromTimeZoneToUTC(localTime, 2);
+
+        Assert.Equal(new DateTime(2025, 6, 1, 10, 0, 0, DateTimeKind.Utc), result);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+    [Fact]
+    public void FromTimeZoneToUTC_IgnoresExistingKind_TreatsAsUnspecified()
+    {
+        var utcLabelled = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var result = DateTimeHelper.FromTimeZoneToUTC(utcLabelled, -3);
+
+        Assert.Equal(new DateTime(2025, 6, 1, 15, 0, 0, DateTimeKind.Utc), result);
+    }
+
+    [Fact]
+    public void FromTimeZoneToUTC_ZeroOffset_ReturnsSameTimeAsUTC()
+    {
+        var localTime = new DateTime(2025, 6, 1, 12, 0, 0);
+
+        var result = DateTimeHelper.FromTimeZoneToUTC(localTime, 0);
+
+        Assert.Equal(new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc), result);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import urls from '@/utils/urls';
 import Uploader from '@/components/ui/utils/Uploader';
 import PaginatedTable, { Column } from '@/components/ui/utils/PaginatedTable';
@@ -12,17 +12,12 @@ type InvestmentField = {
 function Movements() {
   const [reloadData, setReloadData] = useState<number>(0);
 
-  const AppModuleTypeEnumFundsId = 3;
-
   const IOLInvestmentsUploadEndpoint = urls.iolInvestments.upload.with({
-    DateKind: 'Local',
-    AppModuleId: AppModuleTypeEnumFundsId,
+    timezoneOffset: -new Date().getTimezoneOffset() / 60,
   });
   const iolInvestmentsEndpoint = urls.iolInvestments.paginated;
 
   const onFetchInvestmentsTable = () => {};
-
-  useEffect(() => {}, [AppModuleTypeEnumFundsId]);
 
   const numericColumn = (columnId: string, label: string): Column => ({
     id: columnId,


### PR DESCRIPTION
# Why

The IOL investment Excel upload endpoint hardcoded a timezone offset of `-3` (Argentina Standard Time) when parsing dates from uploaded files. This caused dates to be stored incorrectly for users in any timezone other than UTC-3, or when DST was in effect. Additionally, `IOLInvestmentExcelHelper` was injected and registered as a concrete type rather than through the `IExcelHelper<IOLInvestment>` interface.

## What is the solution?

- Added a `timezoneOffset` query parameter (`short?`) to the `POST /upload` endpoint in `IOLInvestmentCommandController` and to `UploadIOLInvestmentsCommand`.
- Changed `IExcelHelper<TResult>.Read()` signatures to accept `short? timezoneOffset` instead of `DateTimeKind`.
- Updated `IOLInvestmentExcelHelper` to use the supplied offset via `DateTimeHelper.FromTimeZoneToUTC`, falling back to `DateTime.SpecifyKind(..., Local).ToUniversalTime()` when not provided.
- Made `DateTimeHelper.FromTimeZoneToUTC` `public` so it can be called from tests and external helpers.
- Registered `IOLInvestmentExcelHelper` against `IExcelHelper<IOLInvestment>` in `ConfigExtensions` (was registered as concrete type).
- Updated the frontend `Investments` component to pass `-new Date().getTimezoneOffset() / 60` as the query parameter, removing the hardcoded `DateKind` and `AppModuleId` values.
- Added unit tests for `UploadIOLInvestmentCommandHandler` and `DateTimeHelper`.

## What areas of the site does it impact?

- **Backend — Application layer**: `UploadIOLInvestmentsCommand`, `IExcelHelper<T>`, `IOLInvestmentExcelHelper`, `DateTimeHelper`.
- **Backend — API layer**: `IOLInvestmentCommandController`, `ConfigExtensions` (DI registration).
- **Frontend — FinanceApp**: `Investments` upload component (`app/components/ui/Investments/index.tsx`).
- **Tests**: New unit tests for the command handler and `DateTimeHelper`.

## Test scenarios

```gherkin
Scenario: Upload IOL investment file with explicit timezone offset
  Given the client sends a POST to /upload with a valid Excel file
  And the query parameter timezoneOffset is -3
  Then dates parsed from the file are converted from UTC-3 to UTC correctly

Scenario: Upload IOL investment file without timezone offset
  Given the client sends a POST to /upload with a valid Excel file
  And no timezoneOffset query parameter is provided
  Then dates parsed from the file are treated as local time and converted to UTC

Scenario: Frontend passes browser timezone offset on upload
  Given the user is on the Investments page
  When they upload an IOL investment file
  Then the request includes timezoneOffset equal to the browser's UTC offset in hours
```

## Other Notes

Closes #102