### PR TITLE
feat: currency exchange rates page

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import urls from '@/utils/urls';
+import dayjs from 'dayjs';
+import CommonUtils from '@/utils/common';
+import Picker from '@/components/ui/utils/Picker';
+import { Label } from '@/components/ui/shadcn/label';
+import { useLoaderData, useLocation, useNavigate } from 'react-router';
+import { InputType } from '@/components/ui/utils/InputType';
+import PaginatedTable, {
+  Column,
+  ConditionalClass,
+  Row,
+} from '@/components/ui/utils/PaginatedTable';
+import { cn } from '@/lib/utils';
+import type { CurrencyExchangeRateRecord, CurrencyData } from '@/types/currencyExchangeRate';
+
+interface LoaderData {
+  currencies: CurrencyData[];
+  data: CurrencyExchangeRateRecord[] | { items: CurrencyExchangeRateRecord[]; totalPages: number };
+  baseCurrencyId: string;
+  quoteCurrencyId: string;
+}
+
+interface CurrencyExchangeRateRow extends CurrencyExchangeRateRecord, Omit<Row, 'id'> {}
+
+const dateFormat = 'DD/MM/YYYY';
+
+const CurrencyExchangeRates: React.FC = () => {
+  const { currencies, data, baseCurrencyId, quoteCurrencyId } = useLoaderData<LoaderData>();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const reload = ({
+    currentBaseCurrencyId,
+    currentQuoteCurrencyId,
+  }: {
+    currentBaseCurrencyId?: string;
+    currentQuoteCurrencyId?: string;
+  }) => {
+    const params = CommonUtils.Params({
+      baseCurrencyId: currentBaseCurrencyId ?? baseCurrencyId,
+      quoteCurrencyId: currentQuoteCurrencyId ?? quoteCurrencyId,
+    });
+    navigate(`${location.pathname}?${params}`);
+  };
+
+  const numericHeader = {
+    classes: 'text-end',
+    style: { width: '180px' },
+  };
+
+  const positiveValueClass: ConditionalClass = {
+    class: 'text-success fw-bold',
+    eval: (field: unknown) => field != null && Number(String(field)) > 0,
+  };
+
+  const TableColumns: Column<CurrencyExchangeRateRow>[] = [
+    {
+      id: 'timeStamp',
+      label: 'Fecha',
+      placeholder: 'Fecha',
+      type: InputType.DateTime,
+      editable: {
+        defaultValue: () => dayjs().format(dateFormat),
+      },
+      datetime: {
+        timeFormat: 'HH:mm',
+        timeIntervals: 15,
+        dateFormat: dateFormat,
+        placeholder: 'Seleccionar fecha',
+      },
+      header: {
+        style: { width: '160px' },
+      },
+    },
+    {
+      id: 'baseCurrency',
+      label: 'Moneda base',
+      placeholder: 'Seleccione moneda base',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.currencies.endpoint,
+      mapper: {
+        id: 'id',
+        label: (record) => record.baseCurrency.name,
+      },
+    },
+    {
+      id: 'quoteCurrency',
+      label: 'Moneda cotización',
+      placeholder: 'Seleccione moneda cotización',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.currencies.endpoint,
+      mapper: {
+        id: 'id',
+        label: (record) => record.quoteCurrency.name,
+      },
+    },
+    {
+      id: 'buyRate',
+      label: 'Compra',
+      placeholder: 'Compra',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: {
+        defaultValue: 0.0,
+      },
+      mapper: (record) => (record.buyRate != null ? Number(record.buyRate) : null),
+      conditionalClass: positiveValueClass,
+    },
+    {
+      id: 'sellRate',
+      label: 'Venta',
+      placeholder: 'Venta',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: {
+        defaultValue: 0.0,
+      },
+      mapper: (record) => (record.sellRate != null ? Number(record.sellRate) : null),
+      conditionalClass: positiveValueClass,
+    },
+  ];
+
+  const paginatedData = Array.isArray(data)
+    ? { items: data, totalPages: 1 }
+    : data;
+
+  return (
+    <div className={cn(['py-10', 'px-40'])}>
+      <div className="flex flex-row justify-center gap-10">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="base-currency-picker">Moneda base</Label>
+          <Picker
+            id="base-currency-picker"
+            placeholder="Moneda base..."
+            value={baseCurrencyId}
+            data={currencies}
+            mapper={{
+              id: 'id',
+              label: (record: unknown) => `${(record as CurrencyData).name}`,
+            }}
+            onChange={(picker: { value: string }) => reload({ currentBaseCurrencyId: picker.value })}
+            className="w-60"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="quote-currency-picker">Moneda cotización</Label>
+          <Picker
+            id="quote-currency-picker"
+            placeholder="Moneda cotización..."
+            value={quoteCurrencyId}
+            data={currencies}
+            mapper={{
+              id: 'id',
+              label: (record: unknown) => `${(record as CurrencyData).name}`,
+            }}
+            onChange={(picker: { value: string }) => reload({ currentQuoteCurrencyId: picker.value })}
+            className="w-60"
+          />
+        </div>
+      </div>
+      <hr className={cn('py-1', 'mb-5', 'mt-5')} />
+      <PaginatedTable<CurrencyExchangeRateRow>
+        name="currency-exchange-rates-table"
+        columns={TableColumns}
+        data={paginatedData}
+        onAdd={() => reload({})}
+        onDelete={() => reload({})}
+        admin={{
+          endpoint: urls.currencyExchangeRates.endpoint,
+          key: [
+            {
+              id: 'BaseCurrencyId',
+              value: baseCurrencyId,
+            },
+            {
+              id: 'QuoteCurrencyId',
+              value: quoteCurrencyId,
+            },
+          ],
+        }}
+      />
+    </div>
+  );
+};
+
+export default CurrencyExchangeRates;

--- a/FinanceFrontEnd/FinanceApp/app/routes/currency-exchange-rates.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/currency-exchange-rates.tsx
@@ -1,0 +1,68 @@
+import { LoaderFunctionArgs } from 'react-router';
+import { getBackendClient } from '@/data/getBackendClient';
+import urls from '@/utils/urls';
+import CurrencyExchangeRates from '@/components/ui/CurrencyExchangeRates';
+import { requireAuth } from '@/services/auth/session.server';
+import { CURRENCY_IDS } from '@/utils/currency.constants';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 100;
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const user = await requireAuth(request);
+
+  if (!user.accessToken) {
+    throw new Error('No access token available');
+  }
+
+  const url = new URL(request.url);
+  const page = Number(url.searchParams.get('page') ?? DEFAULT_PAGE);
+  const pageSize = Number(url.searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE);
+  let selectedBaseCurrencyId = url.searchParams.get('baseCurrencyId') ?? undefined;
+  let selectedQuoteCurrencyId = url.searchParams.get('quoteCurrencyId') ?? undefined;
+
+  const client = await getBackendClient(user.accessToken!);
+
+  const getDataPromise = (baseCurrencyId: string, quoteCurrencyId: string) => {
+    const endpoint = urls.currencyExchangeRates.paginated
+      .with({
+        Page: page,
+        PageSize: pageSize,
+        BaseCurrencyId: baseCurrencyId,
+        QuoteCurrencyId: quoteCurrencyId,
+      })
+      .toRaw();
+    return client.get(endpoint);
+  };
+
+  const currencies = await client.GetCurrenciesQuery().get();
+
+  let data = null;
+  if (selectedBaseCurrencyId && selectedQuoteCurrencyId) {
+    data = await getDataPromise(selectedBaseCurrencyId, selectedQuoteCurrencyId);
+  }
+
+  if (!data && currencies?.length >= 2) {
+    selectedBaseCurrencyId ??= CURRENCY_IDS.ARS;
+    selectedQuoteCurrencyId ??= CURRENCY_IDS.USD;
+    data = await getDataPromise(selectedBaseCurrencyId!, selectedQuoteCurrencyId!);
+  }
+
+  return {
+    currencies,
+    data: data ?? [],
+    baseCurrencyId: selectedBaseCurrencyId,
+    quoteCurrencyId: selectedQuoteCurrencyId,
+  };
+};
+
+export const meta = () => {
+  return [
+    {
+      title: 'Tipos de Cambio',
+      description: '',
+    },
+  ];
+};
+
+export default CurrencyExchangeRates;

--- a/FinanceFrontEnd/FinanceApp/app/types/currencyExchangeRate.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/currencyExchangeRate.ts
@@ -1,0 +1,19 @@
+export interface CurrencyData {
+  id: string;
+  name: string;
+  shortName: string;
+}
+
+export interface CurrencyExchangeRateRecord {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  timeStamp: string;
+  deactivated: boolean;
+  buyRate: number;
+  sellRate: number;
+  baseCurrencyId: string;
+  quoteCurrencyId: string;
+  baseCurrency: CurrencyData;
+  quoteCurrency: CurrencyData;
+}

--- a/FinanceFrontEnd/FinanceApp/app/utils/currency.constants.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/currency.constants.ts
@@ -1,0 +1,4 @@
+export const CURRENCY_IDS = {
+  ARS: '6d189135-7040-45a1-b713-b1aa6cad1720',
+  USD: 'efbf50bc-34d4-43e9-96f9-9f6213ea11b5',
+} as const;


### PR DESCRIPTION
# Why
The app lacked a dedicated page to view historical currency exchange rate records. This feature adds the Currency Exchange Rates page so users can browse buy/sell rates between currency pairs (defaulting to ARS/USD).

## What is the solution?
- Added `CurrencyData` and `CurrencyExchangeRateRecord` TypeScript interfaces (`app/types/currencyExchangeRate.ts`)
- Added `CURRENCY_IDS` constants for ARS and USD GUIDs (`app/utils/currency.constants.ts`)
- Added a React Router v7 SSR loader route (`app/routes/currency-exchange-rates.tsx`) that fetches paginated exchange rate records from the backend, supporting `baseCurrencyId` / `quoteCurrencyId` query-string filters and defaulting to ARS/USD when none are provided
- Added the `CurrencyExchangeRates` UI component (`app/components/ui/CurrencyExchangeRates/index.tsx`) that renders a paginated table with columns for date, base currency, quote currency, buy rate, and sell rate; positive values are highlighted; currency-pair pickers trigger a navigation reload

## What areas of the site does it impact?
- **New route**: `/currency-exchange-rates` in the FinanceApp (React Router v7 SSR)
- **New component**: `CurrencyExchangeRates` UI component
- **New shared types/constants**: `currencyExchangeRate.ts`, `currency.constants.ts`
- No existing routes or components were modified

## Test scenarios

```gherkin
Scenario: Default view loads ARS/USD exchange rates
  Given I am authenticated
  When I navigate to /currency-exchange-rates with no query params
  Then I see a paginated table of exchange rate records
  And the base currency picker shows ARS
  And the quote currency picker shows USD

Scenario: Filter by custom currency pair
  Given I am on /currency-exchange-rates
  When I select a different base or quote currency from the pickers
  Then the page reloads with the selected pair as query params
  And the table shows records for the chosen currency pair

Scenario: Positive buy/sell rates are highlighted
  Given the table contains records with buyRate or sellRate greater than 0
  Then those values appear in a highlighted success style
```

## Other Notes
Closes #104