### PR TITLE
fix: skip exchange-rate conversion for items already in destination currency

### DIFF
--- a/FinanceBackEnd/src/Finance.Application/Services/CurrencyConversionService.cs
+++ b/FinanceBackEnd/src/Finance.Application/Services/CurrencyConversionService.cs
@@ -45,6 +45,7 @@ public class CurrencyConversionService(
             if (item.CurrencyId == destinationCurrency)
             {
                 result.Add(item.Amount);
+                continue;
             }
 
             var exchangeRate = exchangeRates.Data.FirstOrDefault(er => er.BaseCurrencyId == item.CurrencyId);

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import urls from '@/utils/urls';
+import dayjs from 'dayjs';
+import CommonUtils from '@/utils/common';
+import Picker from '@/components/ui/utils/Picker';
+import { Label } from '@/components/ui/shadcn/label';
+import { useLoaderData, useLocation, useNavigate } from 'react-router';
+import { InputType } from '@/components/ui/utils/InputType';
+import PaginatedTable, {
+  Column,
+  ConditionalClass,
+  Row,
+} from '@/components/ui/utils/PaginatedTable';
+import { cn } from '@/lib/utils';
+import type { CurrencyExchangeRateRecord, CurrencyData } from '@/types/currencyExchangeRate';
+
+interface LoaderData {
+  currencies: CurrencyData[];
+  data: CurrencyExchangeRateRecord[] | { items: CurrencyExchangeRateRecord[]; totalPages: number };
+  baseCurrencyId: string;
+  quoteCurrencyId: string;
+}
+
+interface CurrencyExchangeRateRow extends CurrencyExchangeRateRecord, Omit<Row, 'id'> {}
+
+const dateFormat = 'DD/MM/YYYY';
+
+const CurrencyExchangeRates: React.FC = () => {
+  const { currencies, data, baseCurrencyId, quoteCurrencyId } = useLoaderData<LoaderData>();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const reload = ({
+    currentBaseCurrencyId,
+    currentQuoteCurrencyId,
+  }: {
+    currentBaseCurrencyId?: string;
+    currentQuoteCurrencyId?: string;
+  }) => {
+    const params = CommonUtils.Params({
+      baseCurrencyId: currentBaseCurrencyId ?? baseCurrencyId,
+      quoteCurrencyId: currentQuoteCurrencyId ?? quoteCurrencyId,
+    });
+    navigate(`${location.pathname}?${params}`);
+  };
+
+  const numericHeader = {
+    classes: 'text-end',
+    style: { width: '180px' },
+  };
+
+  const positiveValueClass: ConditionalClass = {
+    class: 'text-success fw-bold',
+    eval: (field: unknown) => field != null && Number(String(field)) > 0,
+  };
+
+  const TableColumns: Column<CurrencyExchangeRateRow>[] = [
+    {
+      id: 'timeStamp',
+      label: 'Fecha',
+      placeholder: 'Fecha',
+      type: InputType.DateTime,
+      editable: {
+        defaultValue: () => dayjs().format(dateFormat),
+      },
+      datetime: {
+        timeFormat: 'HH:mm',
+        timeIntervals: 15,
+        dateFormat: dateFormat,
+        placeholder: 'Seleccionar fecha',
+      },
+      header: {
+        style: { width: '160px' },
+      },
+    },
+    {
+      id: 'baseCurrency',
+      label: 'Moneda base',
+      placeholder: 'Seleccione moneda base',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.currencies.endpoint,
+      mapper: {
+        id: 'id',
+        label: (record) => record.baseCurrency.name,
+      },
+    },
+    {
+      id: 'quoteCurrency',
+      label: 'Moneda cotización',
+      placeholder: 'Seleccione moneda cotización',
+      editable: false,
+      type: InputType.Dropdown,
+      endpoint: urls.currencies.endpoint,
+      mapper: {
+        id: 'id',
+        label: (record) => record.quoteCurrency.name,
+      },
+    },
+    {
+      id: 'buyRate',
+      label: 'Compra',
+      placeholder: 'Compra',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: {
+        defaultValue: 0.0,
+      },
+      mapper: (record) => (record.buyRate != null ? Number(record.buyRate) : null),
+      conditionalClass: positiveValueClass,
+    },
+    {
+      id: 'sellRate',
+      label: 'Venta',
+      placeholder: 'Venta',
+      type: InputType.Decimal,
+      min: 0.0,
+      header: numericHeader,
+      class: 'text-end',
+      editable: {
+        defaultValue: 0.0,
+      },
+      mapper: (record) => (record.sellRate != null ? Number(record.sellRate) : null),
+      conditionalClass: positiveValueClass,
+    },
+  ];
+
+  const paginatedData = Array.isArray(data)
+    ? { items: data, totalPages: 1 }
+    : data;
+
+  return (
+    <div className={cn(['py-10', 'px-40'])}>
+      <div className="flex flex-row justify-center gap-10">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="base-currency-picker">Moneda base</Label>
+          <Picker
+            id="base-currency-picker"
+            placeholder="Moneda base..."
+            value={baseCurrencyId}
+            data={currencies}
+            mapper={{
+              id: 'id',
+              label: (record: unknown) => `${(record as CurrencyData).name}`,
+            }}
+            onChange={(picker: { value: string }) => reload({ currentBaseCurrencyId: picker.value })}
+            className="w-60"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="quote-currency-picker">Moneda cotización</Label>
+          <Picker
+            id="quote-currency-picker"
+            placeholder="Moneda cotización..."
+            value={quoteCurrencyId}
+            data={currencies}
+            mapper={{
+              id: 'id',
+              label: (record: unknown) => `${(record as CurrencyData).name}`,
+            }}
+            onChange={(picker: { value: string }) => reload({ currentQuoteCurrencyId: picker.value })}
+            className="w-60"
+          />
+        </div>
+      </div>
+      <hr className={cn('py-1', 'mb-5', 'mt-5')} />
+      <PaginatedTable<CurrencyExchangeRateRow>
+        name="currency-exchange-rates-table"
+        columns={TableColumns}
+        data={paginatedData}
+        onAdd={() => reload({})}
+        onDelete={() => reload({})}
+        admin={{
+          endpoint: urls.currencyExchangeRates.endpoint,
+          key: [
+            {
+              id: 'BaseCurrencyId',
+              value: baseCurrencyId,
+            },
+            {
+              id: 'QuoteCurrencyId',
+              value: quoteCurrencyId,
+            },
+          ],
+        }}
+      />
+    </div>
+  );
+};
+
+export default CurrencyExchangeRates;

--- a/FinanceFrontEnd/FinanceApp/app/routes/currency-exchange-rates.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/currency-exchange-rates.tsx
@@ -1,0 +1,68 @@
+import { LoaderFunctionArgs } from 'react-router';
+import { getBackendClient } from '@/data/getBackendClient';
+import urls from '@/utils/urls';
+import CurrencyExchangeRates from '@/components/ui/CurrencyExchangeRates';
+import { requireAuth } from '@/services/auth/session.server';
+import { CURRENCY_IDS } from '@/utils/currency.constants';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 100;
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const user = await requireAuth(request);
+
+  if (!user.accessToken) {
+    throw new Error('No access token available');
+  }
+
+  const url = new URL(request.url);
+  const page = Number(url.searchParams.get('page') ?? DEFAULT_PAGE);
+  const pageSize = Number(url.searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE);
+  let selectedBaseCurrencyId = url.searchParams.get('baseCurrencyId') ?? undefined;
+  let selectedQuoteCurrencyId = url.searchParams.get('quoteCurrencyId') ?? undefined;
+
+  const client = await getBackendClient(user.accessToken!);
+
+  const getDataPromise = (baseCurrencyId: string, quoteCurrencyId: string) => {
+    const endpoint = urls.currencyExchangeRates.paginated
+      .with({
+        Page: page,
+        PageSize: pageSize,
+        BaseCurrencyId: baseCurrencyId,
+        QuoteCurrencyId: quoteCurrencyId,
+      })
+      .toRaw();
+    return client.get(endpoint);
+  };
+
+  const currencies = await client.GetCurrenciesQuery().get();
+
+  let data = null;
+  if (selectedBaseCurrencyId && selectedQuoteCurrencyId) {
+    data = await getDataPromise(selectedBaseCurrencyId, selectedQuoteCurrencyId);
+  }
+
+  if (!data && currencies?.length >= 2) {
+    selectedBaseCurrencyId ??= CURRENCY_IDS.ARS;
+    selectedQuoteCurrencyId ??= CURRENCY_IDS.USD;
+    data = await getDataPromise(selectedBaseCurrencyId!, selectedQuoteCurrencyId!);
+  }
+
+  return {
+    currencies,
+    data: data ?? [],
+    baseCurrencyId: selectedBaseCurrencyId,
+    quoteCurrencyId: selectedQuoteCurrencyId,
+  };
+};
+
+export const meta = () => {
+  return [
+    {
+      title: 'Tipos de Cambio',
+      description: '',
+    },
+  ];
+};
+
+export default CurrencyExchangeRates;

--- a/FinanceFrontEnd/FinanceApp/app/types/currencyExchangeRate.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/currencyExchangeRate.ts
@@ -1,0 +1,19 @@
+export interface CurrencyData {
+  id: string;
+  name: string;
+  shortName: string;
+}
+
+export interface CurrencyExchangeRateRecord {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  timeStamp: string;
+  deactivated: boolean;
+  buyRate: number;
+  sellRate: number;
+  baseCurrencyId: string;
+  quoteCurrencyId: string;
+  baseCurrency: CurrencyData;
+  quoteCurrency: CurrencyData;
+}

--- a/FinanceFrontEnd/FinanceApp/app/utils/currency.constants.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/currency.constants.ts
@@ -1,0 +1,4 @@
+export const CURRENCY_IDS = {
+  ARS: '6d189135-7040-45a1-b713-b1aa6cad1720',
+  USD: 'efbf50bc-34d4-43e9-96f9-9f6213ea11b5',
+} as const;


### PR DESCRIPTION
# Why
`CurrencyConversionService.ConvertCollection` was missing a `continue` statement after adding an item that is already in the destination currency. Without it, the loop fell through into the exchange-rate conversion path, causing each such item to be processed twice:

1. Added as-is (correct).
2. Then added again — either as a re-converted value (if an exchange rate with `BaseCurrencyId == destinationCurrency` happened to exist) or as `0` (if no such rate was found).

Both outcomes corrupt the returned collection total.

## What is the solution?
Added a `continue` statement immediately after `result.Add(item.Amount)` inside the `if (item.CurrencyId == destinationCurrency)` guard. This ensures the exchange-rate lookup and conversion are skipped for items already denominated in the destination currency.

## What areas of the site does it impact?
- **Finance.Application** — `CurrencyConversionService.ConvertCollection`
- Any feature that converts a mixed-currency collection to a single currency (e.g. currency exchange rate dashboard, portfolio totals).

## Test scenarios

```gherkin
Scenario: Item already in destination currency is added exactly once
  Given a collection with an item whose CurrencyId equals the destination currency
  When ConvertCollection is called
  Then the result contains that item's amount exactly once

Scenario: Item in a different currency is still converted
  Given a collection with an item whose CurrencyId differs from the destination currency
  And a matching exchange rate exists
  When ConvertCollection is called
  Then the result contains the converted amount for that item

Scenario: Item in a different currency with no exchange rate becomes zero
  Given a collection with an item whose CurrencyId differs from the destination currency
  And no matching exchange rate exists
  When ConvertCollection is called
  Then the result contains 0 for that item
```

## Other Notes
Closes #106