### PR TITLE
fix: strip leading non-numeric prefix in IOL Excel decimal sanitizer

### DIFF
--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/IOLInvestmentExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/IOLInvestmentExcelHelper.cs
@@ -98,10 +98,17 @@ public class IOLInvestmentExcelHelper : IExcelHelper<IOLInvestment>
     }
 
     private object? SanitizeDecimalString(object value)
-        => value?.ToString()?
+    {
+        var text = value?.ToString()?
             .Replace("$", string.Empty)
             .Replace("%", string.Empty)
             .Replace(".", string.Empty)
             .Replace(",", ".")
             .Trim();
+
+        if (text is null) return null;
+
+        var idx = text.IndexOfAny(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-']);
+        return idx > 0 ? text[idx..] : text;
+    }
 }


### PR DESCRIPTION
# Why

`SanitizeDecimalString` in `IOLInvestmentExcelHelper` cleaned up currency symbols (`$`, `%`) and normalised decimal separators (`.` → `,`), but did not strip leading non-numeric text that some IOL Excel exports include before the numeric value (e.g. `ARS 1.234,56` or `USD 500,00`). After the symbol-replacement pass, a residual prefix (e.g. `ARS `) remained at the start of the string, causing downstream `decimal.Parse` calls to throw or silently return `null`.

## What is the solution?

The method was converted from an expression body to a block body so it can apply a two-step sanitisation:

1. Apply the existing symbol/separator replacements.
2. Find the index of the first digit or minus sign (`IndexOfAny`) and slice the string from that position (`text[idx..]`), discarding any residual leading text.

A `null` guard is also added so the method returns `null` immediately when the input resolves to `null` rather than propagating the expression further.

## What areas of the site does it impact?

- **IOL Investment import** — the Excel parsing pipeline for IOL investment records (`IOLInvestmentExcelHelper`).
- No other helpers or modules are affected.

## Test scenarios

```gherkin
Scenario: Numeric cell with currency prefix is parsed correctly
  Given an IOL investment Excel file where a numeric cell contains "ARS 1.234,56"
  When the import process reads that cell through SanitizeDecimalString
  Then the returned value is "1234.56" (i.e. parseable as a decimal)

Scenario: Numeric cell without prefix is unchanged
  Given an IOL investment Excel file where a numeric cell contains "1.234,56"
  When the import process reads that cell through SanitizeDecimalString
  Then the returned value is "1234.56"

Scenario: Null or empty cell does not throw
  Given an IOL investment Excel file where a numeric cell is empty
  When the import process reads that cell through SanitizeDecimalString
  Then the returned value is null and no exception is thrown
```

## Other Notes

Closes #108