### PR TITLE
fix: resolve empty symbol/description in investments table mapper

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Investments/index.tsx
@@ -3,7 +3,6 @@ import urls from '@/utils/urls';
 import Uploader from '@/components/ui/utils/Uploader';
 import PaginatedTable, { Column } from '@/components/ui/utils/PaginatedTable';
 import { InputType } from '@/components/ui/utils/InputType';
-
 type InvestmentField = {
   symbol: string;
   description: string;
@@ -80,7 +79,7 @@ function Movements() {
       placeholder,
       editable: true,
       mapper: (field: unknown) => {
-        const f = field as InvestmentField;
+        const f = (field as Record<string, unknown>).asset as InvestmentField;
         return `${f?.symbol ?? ''} - ${f?.description ?? ''}`;
       },
     },


### PR DESCRIPTION
# Why
The investment symbol/description column in the Investments table was rendering as ` - ` (two empty strings joined by a dash) for every row. The root cause was an incorrect type cast in the column `mapper` function: `field` was cast directly as `InvestmentField`, but the actual `InvestmentField` data is nested under the `asset` property of the row object. As a result, `f.symbol` and `f.description` always resolved to `undefined`.

## What is the solution?
Access the `asset` property before casting to `InvestmentField`:

```ts
// Before (bug)
const f = field as InvestmentField;

// After (fix)
const f = (field as Record<string, unknown>).asset as InvestmentField;
```

## What areas of the site does it impact?
- **Investments page** — the symbol/description column in the investments movements table.

## Test scenarios

```gherkin
Scenario: Investments table displays correct symbol and description
  Given I am on the Investments page
  And there are investment records in the system
  When the page loads
  Then each row in the table should show "<symbol> - <description>" (e.g. "AAPL - Apple Inc.")
  And no row should display " - " with empty symbol or description

Scenario: Investment row with missing asset data renders gracefully
  Given I am on the Investments page
  And an investment record has no asset associated
  When the page loads
  Then that row displays " - " without throwing a runtime error
```

## Other Notes
Closes #111