### PR TITLE
feat: add catalog API endpoints for pickers and consolidate query handler test base

### DIFF
--- a/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CatalogQueryController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CatalogQueryController.cs
@@ -1,0 +1,32 @@
+using CQRSDispatch.Interfaces;
+using Finance.Api.Controllers.Base;
+using Finance.Application.Auth;
+using Finance.Application.Queries.Catalog;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Finance.Api.Controllers.Queries;
+
+[Route("api/catalog")]
+public class CatalogQueryController(IDispatcher<FinanceDispatchContext> dispatcher) : SecuredApiController
+{
+    [HttpGet("banks")]
+    public async Task<IActionResult> GetBanks([FromQuery] GetCatalogBanksQuery query)
+    {
+        var result = await dispatcher.DispatchQueryAsync(query, HttpContext.Request);
+        return Ok(result.Data);
+    }
+
+    [HttpGet("currencies")]
+    public async Task<IActionResult> GetCurrencies([FromQuery] GetCatalogCurrenciesQuery query)
+    {
+        var result = await dispatcher.DispatchQueryAsync(query, HttpContext.Request);
+        return Ok(result.Data);
+    }
+
+    [HttpGet("frequencies")]
+    public async Task<IActionResult> GetFrequencies([FromQuery] GetCatalogFrequenciesQuery query)
+    {
+        var result = await dispatcher.DispatchQueryAsync(query, HttpContext.Request);
+        return Ok(result.Data);
+    }
+}

--- a/FinanceBackEnd/src/Finance.Application/Dtos/Catalog/CatalogIntItemDto.cs
+++ b/FinanceBackEnd/src/Finance.Application/Dtos/Catalog/CatalogIntItemDto.cs
@@ -1,0 +1,5 @@
+using Finance.Application.Dtos.Base;
+
+namespace Finance.Application.Dtos.Catalog;
+
+public sealed record CatalogIntItemDto : CatalogDto<int>;

--- a/FinanceBackEnd/src/Finance.Application/Dtos/Catalog/CatalogItemDto.cs
+++ b/FinanceBackEnd/src/Finance.Application/Dtos/Catalog/CatalogItemDto.cs
@@ -1,0 +1,5 @@
+using Finance.Application.Dtos.Base;
+
+namespace Finance.Application.Dtos.Catalog;
+
+public sealed record CatalogItemDto : CatalogDto<Guid>;

--- a/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogBanksQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogBanksQuery.cs
@@ -1,0 +1,29 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Dtos.Catalog;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Queries.Catalog;
+
+public class GetCatalogBanksQuery : IContextAwareQuery<FinanceDispatchContext, List<CatalogItemDto>>
+{
+    internal FinanceDispatchContext Context { get; private set; } = new();
+    public void SetContext(FinanceDispatchContext context) => Context = context;
+}
+
+public class GetCatalogBanksQueryHandler(FinanceDbContext db) : BaseCollectionQueryHandler<GetCatalogBanksQuery, CatalogItemDto>(db)
+{
+    public override async Task<DataResult<List<CatalogItemDto>>> ExecuteAsync(GetCatalogBanksQuery request, CancellationToken cancellationToken)
+    {
+        var items = await DbContext.Bank
+            .Where(b => !b.Deactivated)
+            .OrderBy(b => b.Name)
+            .Select(b => new CatalogItemDto { Id = b.Id, Name = b.Name })
+            .ToListAsync(cancellationToken);
+
+        return DataResult<List<CatalogItemDto>>.Success(items);
+    }
+}

--- a/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogCurrenciesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogCurrenciesQuery.cs
@@ -1,0 +1,29 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Dtos.Catalog;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Queries.Catalog;
+
+public class GetCatalogCurrenciesQuery : IContextAwareQuery<FinanceDispatchContext, List<CatalogItemDto>>
+{
+    internal FinanceDispatchContext Context { get; private set; } = new();
+    public void SetContext(FinanceDispatchContext context) => Context = context;
+}
+
+public class GetCatalogCurrenciesQueryHandler(FinanceDbContext db) : BaseCollectionQueryHandler<GetCatalogCurrenciesQuery, CatalogItemDto>(db)
+{
+    public override async Task<DataResult<List<CatalogItemDto>>> ExecuteAsync(GetCatalogCurrenciesQuery request, CancellationToken cancellationToken)
+    {
+        var items = await DbContext.Currency
+            .Where(c => !c.Deactivated)
+            .OrderBy(c => c.ShortName)
+            .Select(c => new CatalogItemDto { Id = c.Id, Name = c.ShortName })
+            .ToListAsync(cancellationToken);
+
+        return DataResult<List<CatalogItemDto>>.Success(items);
+    }
+}

--- a/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogFrequenciesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogFrequenciesQuery.cs
@@ -1,0 +1,28 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Dtos.Catalog;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Queries.Catalog;
+
+public class GetCatalogFrequenciesQuery : IContextAwareQuery<FinanceDispatchContext, List<CatalogIntItemDto>>
+{
+    internal FinanceDispatchContext Context { get; private set; } = new();
+    public void SetContext(FinanceDispatchContext context) => Context = context;
+}
+
+public class GetCatalogFrequenciesQueryHandler(FinanceDbContext db) : BaseCollectionQueryHandler<GetCatalogFrequenciesQuery, CatalogIntItemDto>(db)
+{
+    public override async Task<DataResult<List<CatalogIntItemDto>>> ExecuteAsync(GetCatalogFrequenciesQuery request, CancellationToken cancellationToken)
+    {
+        var items = await DbContext.Frequency
+            .OrderBy(f => f.Name)
+            .Select(f => new CatalogIntItemDto { Id = (int)f.Id, Name = f.Name })
+            .ToListAsync(cancellationToken);
+
+        return DataResult<List<CatalogIntItemDto>>.Success(items);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogBanksQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogBanksQueryHandlerTests.cs
@@ -1,0 +1,70 @@
+using Finance.Application.Queries.Catalog;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Banks;
+
+namespace Finance.Application.Tests.Queries.Catalog;
+
+public class GetCatalogBanksQueryHandlerTests : QueryHandlerBaseTests
+{
+    [Fact]
+    public async Task GetCatalogBanks_ReturnsOnlyActivebanks()
+    {
+        await _dbContext.Bank.AddRangeAsync(
+            new Bank { Id = Guid.NewGuid(), Name = "Active Bank", Deactivated = false },
+            new Bank { Id = Guid.NewGuid(), Name = "Inactive Bank", Deactivated = true }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogBanksQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogBanksQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Data);
+        Assert.All(result.Data, item => Assert.NotEqual("Inactive Bank", item.Name));
+    }
+
+    [Fact]
+    public async Task GetCatalogBanks_ReturnsBanksOrderedByName()
+    {
+        await _dbContext.Bank.AddRangeAsync(
+            new Bank { Id = Guid.NewGuid(), Name = "Zeta Bank", Deactivated = false },
+            new Bank { Id = Guid.NewGuid(), Name = "Alpha Bank", Deactivated = false },
+            new Bank { Id = Guid.NewGuid(), Name = "Midway Bank", Deactivated = false }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogBanksQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogBanksQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Alpha Bank", result.Data[0].Name);
+        Assert.Equal("Midway Bank", result.Data[1].Name);
+        Assert.Equal("Zeta Bank", result.Data[2].Name);
+    }
+
+    [Fact]
+    public async Task GetCatalogBanks_MapsBankNameToItemName()
+    {
+        var id = Guid.NewGuid();
+        await _dbContext.Bank.AddAsync(new Bank { Id = id, Name = "My Bank", Deactivated = false });
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogBanksQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogBanksQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var item = Assert.Single(result.Data);
+        Assert.Equal(id, item.Id);
+        Assert.Equal("My Bank", item.Name);
+    }
+
+    [Fact]
+    public async Task GetCatalogBanks_WhenNoBanks_ReturnsEmptyList()
+    {
+        var handler = new GetCatalogBanksQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogBanksQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Data);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogCurrenciesQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogCurrenciesQueryHandlerTests.cs
@@ -1,0 +1,70 @@
+using Finance.Application.Queries.Catalog;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Currencies;
+
+namespace Finance.Application.Tests.Queries.Catalog;
+
+public class GetCatalogCurrenciesQueryHandlerTests : QueryHandlerBaseTests
+{
+    [Fact]
+    public async Task GetCatalogCurrencies_ReturnsOnlyActiveCurrencies()
+    {
+        await _dbContext.Currency.AddRangeAsync(
+            new Currency { Id = Guid.NewGuid(), Name = "Peso", ShortName = "ARS", Deactivated = false },
+            new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD", Deactivated = true }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogCurrenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogCurrenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Data);
+        Assert.All(result.Data, item => Assert.NotEqual("USD", item.Name));
+    }
+
+    [Fact]
+    public async Task GetCatalogCurrencies_ReturnsCurrenciesOrderedByShortName()
+    {
+        await _dbContext.Currency.AddRangeAsync(
+            new Currency { Id = Guid.NewGuid(), Name = "Euro", ShortName = "EUR", Deactivated = false },
+            new Currency { Id = Guid.NewGuid(), Name = "Peso", ShortName = "ARS", Deactivated = false },
+            new Currency { Id = Guid.NewGuid(), Name = "Dollar", ShortName = "USD", Deactivated = false }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogCurrenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogCurrenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("ARS", result.Data[0].Name);
+        Assert.Equal("EUR", result.Data[1].Name);
+        Assert.Equal("USD", result.Data[2].Name);
+    }
+
+    [Fact]
+    public async Task GetCatalogCurrencies_MapsShortNameToItemName()
+    {
+        var id = Guid.NewGuid();
+        await _dbContext.Currency.AddAsync(new Currency { Id = id, Name = "Peso Argentino", ShortName = "ARS", Deactivated = false });
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogCurrenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogCurrenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var item = Assert.Single(result.Data);
+        Assert.Equal(id, item.Id);
+        Assert.Equal("ARS", item.Name);
+    }
+
+    [Fact]
+    public async Task GetCatalogCurrencies_WhenNoCurrencies_ReturnsEmptyList()
+    {
+        var handler = new GetCatalogCurrenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogCurrenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Data);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogFrequenciesQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogFrequenciesQueryHandlerTests.cs
@@ -1,0 +1,59 @@
+using Finance.Application.Queries.Catalog;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Enums;
+using Finance.Domain.Models.Frequencies;
+
+namespace Finance.Application.Tests.Queries.Catalog;
+
+public class GetCatalogFrequenciesQueryHandlerTests : QueryHandlerBaseTests
+{
+    [Fact]
+    public async Task GetCatalogFrequencies_ReturnsAllFrequencies()
+    {
+        await _dbContext.Frequency.AddRangeAsync(
+            new Frequency { Id = FrequencyEnum.Monthly, Name = "Monthly" },
+            new Frequency { Id = FrequencyEnum.Annual, Name = "Annual" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogFrequenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogFrequenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetCatalogFrequencies_ReturnsFrequenciesOrderedByName()
+    {
+        await _dbContext.Frequency.AddRangeAsync(
+            new Frequency { Id = FrequencyEnum.Weekly, Name = "Weekly" },
+            new Frequency { Id = FrequencyEnum.Annual, Name = "Annual" },
+            new Frequency { Id = FrequencyEnum.Monthly, Name = "Monthly" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogFrequenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogFrequenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Annual", result.Data[0].Name);
+        Assert.Equal("Monthly", result.Data[1].Name);
+        Assert.Equal("Weekly", result.Data[2].Name);
+    }
+
+    [Fact]
+    public async Task GetCatalogFrequencies_MapsEnumValueToId()
+    {
+        await _dbContext.Frequency.AddAsync(new Frequency { Id = FrequencyEnum.Monthly, Name = "Monthly" });
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogFrequenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogFrequenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var item = Assert.Single(result.Data);
+        Assert.Equal((int)FrequencyEnum.Monthly, item.Id);
+        Assert.Equal("Monthly", item.Name);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CurrencyExchangeRates/CurrencyExchangeRateQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CurrencyExchangeRates/CurrencyExchangeRateQueryHandlerTests.cs
@@ -1,31 +1,15 @@
 using Finance.Application.Queries.CurrencyExchangeRates;
 using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Identities;
-using Finance.Persistence;
 using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Finance.Application.Tests.Queries.CurrencyExchangeRates;
 
-public class CurrencyExchangeRateQueryHandlerTests : IDisposable
+public class CurrencyExchangeRateQueryHandlerTests : QueryHandlerBaseTests
 {
-    private readonly FinanceDbContext _dbContext;
-
-    public CurrencyExchangeRateQueryHandlerTests()
-    {
-        var options = new DbContextOptionsBuilder<FinanceDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-
-        _dbContext = new FinanceDbContext(options, null);
-    }
-
-    public void Dispose() => _dbContext.Dispose();
-
     [Fact]
     public async Task GetAllCurrencyExchangeRates_FiltersByPairAndTimestampAndDeactivated()
     {

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/DebitOrigins/DebitOriginQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/DebitOrigins/DebitOriginQueryHandlerTests.cs
@@ -1,31 +1,15 @@
 using Finance.Application.Queries.DebitOrigins;
+using Finance.Application.Tests.Queries.Base;
 using Finance.Domain.Models.AppModules;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Debits;
 using Finance.Domain.Models.Identities;
-using Finance.Persistence;
 using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Finance.Application.Tests.Queries.DebitOrigins;
 
-public class DebitOriginQueryHandlerTests : IDisposable
+public class DebitOriginQueryHandlerTests : QueryHandlerBaseTests
 {
-    private readonly FinanceDbContext _dbContext;
-
-    public DebitOriginQueryHandlerTests()
-    {
-        var options = new DbContextOptionsBuilder<FinanceDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-
-        _dbContext = new FinanceDbContext(options, null);
-    }
-
-    public void Dispose() => _dbContext.Dispose();
-
     private async Task<User> CreateCurrentUserAsync()
     {
         var user = new User

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Debits/DebitQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Debits/DebitQueryHandlerTests.cs
@@ -1,32 +1,16 @@
 using Finance.Application.Queries.Debits;
+using Finance.Application.Tests.Queries.Base;
 using Finance.Domain.Enums;
 using Finance.Domain.Models.AppModules;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Debits;
 using Finance.Domain.Models.Identities;
-using Finance.Persistence;
 using FinanceBackEnd.Finance.Domain.Enums;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Finance.Application.Tests.Queries.Debits;
 
-public class DebitQueryHandlerTests : IDisposable
+public class DebitQueryHandlerTests : QueryHandlerBaseTests
 {
-    private readonly FinanceDbContext _dbContext;
-
-    public DebitQueryHandlerTests()
-    {
-        var options = new DbContextOptionsBuilder<FinanceDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-
-        _dbContext = new FinanceDbContext(options, null);
-    }
-
-    public void Dispose() => _dbContext.Dispose();
-
     private async Task SeedDebitsAsync(params Debit[] debits)
     {
         await _dbContext.Debit.AddRangeAsync(debits);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Funds/FundQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Funds/FundQueryHandlerTests.cs
@@ -8,28 +8,13 @@ using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Funds;
 using Finance.Domain.Models.Identities;
 using Finance.Domain.Models.Movements;
-using Finance.Persistence;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
+using Finance.Application.Tests.Queries.Base;
 
 namespace Finance.Application.Tests.Queries.Funds;
 
-public class FundQueryHandlerTests : IDisposable
+public class FundQueryHandlerTests : QueryHandlerBaseTests
 {
-    private readonly FinanceDbContext _dbContext;
-
-    public FundQueryHandlerTests()
-    {
-        var options = new DbContextOptionsBuilder<FinanceDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-
-        _dbContext = new FinanceDbContext(options, null);
-    }
-
-    public void Dispose() => _dbContext.Dispose();
-
     [Fact]
     public async Task GetFunds_FiltersByDateCurrencyBankDailyUseAndDeactivated()
     {

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Incomes/IncomeQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Incomes/IncomeQueryHandlerTests.cs
@@ -1,33 +1,18 @@
 using Finance.Application.Queries.Incomes;
 using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.Banks;
 using Finance.Domain.Models.Currencies;
 using Finance.Domain.Models.Identities;
 using Finance.Domain.Models.Incomes;
 using Finance.Domain.SpecialTypes;
-using Finance.Persistence;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Finance.Application.Tests.Queries.Incomes;
 
-public class IncomeQueryHandlerTests : IDisposable
+public class IncomeQueryHandlerTests : QueryHandlerBaseTests
 {
-    private readonly FinanceDbContext _dbContext;
-
-    public IncomeQueryHandlerTests()
-    {
-        var options = new DbContextOptionsBuilder<FinanceDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-
-        _dbContext = new FinanceDbContext(options, null);
-    }
-
-    public void Dispose() => _dbContext.Dispose();
-
     [Fact]
     public async Task GetIncomes_FiltersByDateCurrencyBankAndDeactivated()
     {

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/_Base/QueryHandlerBaseTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/_Base/QueryHandlerBaseTests.cs
@@ -1,0 +1,22 @@
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Queries.Base;
+
+public abstract class QueryHandlerBaseTests : IDisposable
+{
+    protected readonly FinanceDbContext _dbContext;
+
+    protected QueryHandlerBaseTests()
+    {
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
@@ -13,9 +13,10 @@ import PaginatedTable, {
 } from '@/components/ui/utils/PaginatedTable';
 import { cn } from '@/lib/utils';
 import type { CurrencyExchangeRateRecord, CurrencyData } from '@/types/currencyExchangeRate';
+import type { CatalogItem } from '@/types/catalog';
 
 interface LoaderData {
-  currencies: CurrencyData[];
+  currencies: CatalogItem[];
   data: CurrencyExchangeRateRecord[] | { items: CurrencyExchangeRateRecord[]; totalPages: number };
   baseCurrencyId: string;
   quoteCurrencyId: string;
@@ -143,7 +144,7 @@ const CurrencyExchangeRates: React.FC = () => {
             data={currencies}
             mapper={{
               id: 'id',
-              label: (record: unknown) => `${(record as CurrencyData).name}`,
+              label: (record: unknown) => `${(record as CatalogItem).name}`,
             }}
             onChange={(picker: { value: string }) => reload({ currentBaseCurrencyId: picker.value })}
             className="w-60"
@@ -158,7 +159,7 @@ const CurrencyExchangeRates: React.FC = () => {
             data={currencies}
             mapper={{
               id: 'id',
-              label: (record: unknown) => `${(record as CurrencyData).name}`,
+              label: (record: unknown) => `${(record as CatalogItem).name}`,
             }}
             onChange={(picker: { value: string }) => reload({ currentQuoteCurrencyId: picker.value })}
             className="w-60"

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CurrencyExchangeRates/index.tsx
@@ -12,7 +12,7 @@ import PaginatedTable, {
   Row,
 } from '@/components/ui/utils/PaginatedTable';
 import { cn } from '@/lib/utils';
-import type { CurrencyExchangeRateRecord, CurrencyData } from '@/types/currencyExchangeRate';
+import type { CurrencyExchangeRateRecord } from '@/types/currencyExchangeRate';
 import type { CatalogItem } from '@/types/catalog';
 
 interface LoaderData {

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Subscriptions/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Subscriptions/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useLoaderData, useRevalidator } from 'react-router';
 import type { Subscription, SubscriptionsData } from '@/types/subscription';
 import { SubscriptionFrequency } from '@/types/subscription';
+import type { CatalogItem } from '@/types/catalog';
 import {
   Table,
   TableBody,
@@ -30,8 +31,8 @@ interface SubscriptionModalProps {
   show: boolean;
   onHide: () => void;
   subscription?: Subscription | null;
-  currencies: Array<{ id: string; name: string; shortName: string }>;
-  frequencies: Array<{ id: string; name: string }>;
+  currencies: CatalogItem[];
+  frequencies: Array<{ id: number; name: string }>;
   onSave: (data: Partial<Subscription>) => void;
 }
 
@@ -163,7 +164,7 @@ function SubscriptionModal({
               >
                 {currencies.map((currency) => (
                   <option key={currency.id} value={currency.id}>
-                    {currency.name} ({currency.shortName})
+                    {currency.name}
                   </option>
                 ))}
               </select>

--- a/FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts
@@ -3,6 +3,9 @@ import { Agent } from "https";
 import serverLogger from "@/utils/logger.server";
 import { buildAxiosConfig } from "./base/axiosConfig";
 import { BanksQuery } from "./queries/BanksQuery";
+import { CatalogBanksQuery } from "./queries/CatalogBanksQuery";
+import { CatalogCurrenciesQuery } from "./queries/CatalogCurrenciesQuery";
+import { CatalogFrequenciesQuery } from "./queries/CatalogFrequenciesQuery";
 import { CreditCardQuery } from "./queries/CreditCardQuery";
 import { CreditCardStatementQuery } from "./queries/CreditCardStatementQuery";
 import { CurrenciesQuery } from "./queries/CurrenciesQuery";
@@ -19,6 +22,9 @@ export class BackendClient {
     private AccessToken: string;
 
     private BanksQuery: BanksQuery;
+    private CatalogBanksQuery: CatalogBanksQuery;
+    private CatalogCurrenciesQuery: CatalogCurrenciesQuery;
+    private CatalogFrequenciesQuery: CatalogFrequenciesQuery;
     private DebitsQuery: DebitsQuery;
     private PaginatedDebitsQuery: PaginatedDebitsQuery;
     private PaginatedSubscriptionsQuery: PaginatedSubscriptionsQuery;
@@ -33,6 +39,9 @@ export class BackendClient {
         this.AccessToken = accessToken;
 
         this.BanksQuery = new BanksQuery(httpsAgent, this.AccessToken);
+        this.CatalogBanksQuery = new CatalogBanksQuery(httpsAgent, this.AccessToken);
+        this.CatalogCurrenciesQuery = new CatalogCurrenciesQuery(httpsAgent, this.AccessToken);
+        this.CatalogFrequenciesQuery = new CatalogFrequenciesQuery(httpsAgent, this.AccessToken);
         this.DebitsQuery = new DebitsQuery(httpsAgent, this.AccessToken);
         this.PaginatedDebitsQuery = new PaginatedDebitsQuery(
             httpsAgent,
@@ -65,6 +74,9 @@ export class BackendClient {
     }
 
     public GetBanksQuery = (): BanksQuery => this.BanksQuery;
+    public GetCatalogBanksQuery = (): CatalogBanksQuery => this.CatalogBanksQuery;
+    public GetCatalogCurrenciesQuery = (): CatalogCurrenciesQuery => this.CatalogCurrenciesQuery;
+    public GetCatalogFrequenciesQuery = (): CatalogFrequenciesQuery => this.CatalogFrequenciesQuery;
     public GetDebitsQuery = (): DebitsQuery => this.DebitsQuery;
     public GetPaginatedDebitsQuery = (): PaginatedDebitsQuery =>
         this.PaginatedDebitsQuery;

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/CatalogBanksQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/CatalogBanksQuery.ts
@@ -1,0 +1,11 @@
+import urls from "@/utils/urls";
+import { Agent } from "https";
+import { BaseQuery } from "@/data/base/BaseQuery";
+
+export class CatalogBanksQuery extends BaseQuery {
+  constructor(httpsAgent: Agent, accessToken: string) {
+    super(httpsAgent, accessToken, {
+      get: urls.catalog.banks.endpoint,
+    });
+  }
+}

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/CatalogCurrenciesQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/CatalogCurrenciesQuery.ts
@@ -1,0 +1,11 @@
+import urls from "@/utils/urls";
+import { Agent } from "https";
+import { BaseQuery } from "@/data/base/BaseQuery";
+
+export class CatalogCurrenciesQuery extends BaseQuery {
+  constructor(httpsAgent: Agent, accessToken: string) {
+    super(httpsAgent, accessToken, {
+      get: urls.catalog.currencies.endpoint,
+    });
+  }
+}

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/CatalogFrequenciesQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/CatalogFrequenciesQuery.ts
@@ -1,0 +1,11 @@
+import urls from "@/utils/urls";
+import { Agent } from "https";
+import { BaseQuery } from "../base/BaseQuery";
+
+export class CatalogFrequenciesQuery extends BaseQuery {
+  constructor(httpsAgent: Agent, accessToken: string) {
+    super(httpsAgent, accessToken, {
+      get: urls.catalog.frequencies.endpoint,
+    });
+  }
+}

--- a/FinanceFrontEnd/FinanceApp/app/routes/currency-exchange-rates.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/currency-exchange-rates.tsx
@@ -35,7 +35,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     return client.get(endpoint);
   };
 
-  const currencies = await client.GetCurrenciesQuery().get();
+  const currencies = await client.GetCatalogCurrenciesQuery().get();
 
   let data = null;
   if (selectedBaseCurrencyId && selectedQuoteCurrencyId) {

--- a/FinanceFrontEnd/FinanceApp/app/routes/funds.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/funds.tsx
@@ -34,7 +34,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     return client.get(dataUrl);
   };
 
-  const queries = [await client.GetBanksQuery().get(), await client.GetCurrenciesQuery().get()];
+  const queries = [await client.GetCatalogBanksQuery().get(), await client.GetCatalogCurrenciesQuery().get()];
 
   if (selectedBankId && selectedCurrencyId) {
     queries.push(getDataPromise(selectedBankId, selectedCurrencyId));

--- a/FinanceFrontEnd/FinanceApp/app/routes/subscriptions.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/subscriptions.tsx
@@ -35,8 +35,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       Page: 1,
     });
 
-  const currencies = await client.GetCurrenciesQuery().get();
-  const frequencies = await client.GetFrequenciesQuery().get();
+  const currencies = await client.GetCatalogCurrenciesQuery().get();
+  const frequencies = await client.GetCatalogFrequenciesQuery().get();
 
   return {
     subscriptions,

--- a/FinanceFrontEnd/FinanceApp/app/types/catalog.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/catalog.ts
@@ -1,0 +1,4 @@
+export interface CatalogItem {
+  id: string;
+  name: string;
+}

--- a/FinanceFrontEnd/FinanceApp/app/types/subscription.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/subscription.ts
@@ -1,3 +1,5 @@
+import type { CatalogItem } from '@/types/catalog';
+
 export enum SubscriptionFrequency {
   Monthly = 'monthly',
   Annual = 'annual',
@@ -26,9 +28,9 @@ export interface SubscriptionsData {
     items: Subscription[];
     totalCount: number;
   };
-  currencies: Currency[];
+  currencies: CatalogItem[];
   frequencies: Array<{
-    id: string;
+    id: number;
     name: string;
   }>;
 }

--- a/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
@@ -32,6 +32,23 @@ const getApiBaseUrl = () => `${getBaseUrl()}/api`;
 const getDebitsBaseUrl = () => `${getApiBaseUrl()}/debits`;
 
 const urls = {
+  catalog: {
+    banks: {
+      get endpoint() {
+        return new BackendUrl(`${getApiBaseUrl()}/catalog/banks`);
+      },
+    },
+    currencies: {
+      get endpoint() {
+        return new BackendUrl(`${getApiBaseUrl()}/catalog/currencies`);
+      },
+    },
+    frequencies: {
+      get endpoint() {
+        return new BackendUrl(`${getApiBaseUrl()}/catalog/frequencies`);
+      },
+    },
+  },
   appModules: {
     get endpoint() {
       return new BackendUrl(`${getApiBaseUrl()}/app-modules/`);


### PR DESCRIPTION
# Why

Frontend picker components (dropdowns for banks, currencies, frequencies) were calling various legacy endpoints that returned full domain objects. This adds a dedicated catalog API returning lightweight `{ id, name }` items purpose-built for pickers, and stops the frontend from coupling to full resource endpoints for simple list-of-options needs.

Additionally, all query handler test classes duplicated 15+ lines of in-memory `FinanceDbContext` setup. A shared base class eliminates that boilerplate.

## What is the solution?

**Backend - catalog endpoints**
- `CatalogItemDto` (Guid-keyed) and `CatalogIntItemDto` (int-keyed) record DTOs
- Three query handlers: `GetCatalogBanksQuery`, `GetCatalogCurrenciesQuery`, `GetCatalogFrequenciesQuery`
- `CatalogQueryController` under `GET /api/catalog/{banks|currencies|frequencies}`
- Banks and currencies filter by `Deactivated = false`; frequencies return all records

**Backend - test base**
- `QueryHandlerBaseTests` abstract class owns in-memory DB construction and `Dispose`
- All five existing query handler test classes now inherit it (removed duplicate setup from each)
- 11 new catalog handler tests covering filtering, ordering, mapping, and empty cases

**Frontend**
- `urls.catalog.*` entries for the three new routes
- `CatalogBanksQuery`, `CatalogCurrenciesQuery`, `CatalogFrequenciesQuery` query classes
- `BackendClient` wired with new getters; old `FrequenciesQuery` getter replaced with `GetCatalogFrequenciesQuery`
- Route loaders for `funds`, `currency-exchange-rates`, `subscriptions` updated to use catalog queries
- New `CatalogItem` type (`{ id: string; name: string }`) shared across picker usage
- `SubscriptionsData.frequencies` id type corrected from `string` to `number`

## What areas of the site does it impact?

- **Funds page** - bank and currency pickers now use catalog endpoints
- **Currency Exchange Rates page** - currency picker now uses catalog endpoint
- **Subscriptions page** - currency and frequency pickers now use catalog endpoints
- **Backend Application layer** - new Catalog queries/DTOs, no changes to existing queries
- **Backend API layer** - new controller only; no existing controllers modified
- **Test project** - all query handler tests refactored; 11 new tests added

## Test scenarios

```gherkin
Scenario: Catalog banks endpoint returns only active banks
  Given banks exist in the database with some marked as deactivated
  When GET /api/catalog/banks is called with a valid auth token
  Then only active banks are returned, ordered by name, with id and name fields

Scenario: Catalog currencies endpoint returns only active currencies
  Given currencies exist with some marked as deactivated
  When GET /api/catalog/currencies is called with a valid auth token
  Then only active currencies are returned, ordered by short name, with id and name fields

Scenario: Catalog frequencies endpoint returns all frequencies
  Given frequencies exist in the database
  When GET /api/catalog/frequencies is called with a valid auth token
  Then all frequencies are returned ordered by name, with numeric id and name fields

Scenario: Funds page loads bank and currency pickers
  Given the user is authenticated
  When the Funds page loads
  Then the bank and currency dropdowns are populated from the catalog endpoints

Scenario: Subscriptions page loads currency and frequency pickers
  Given the user is authenticated
  When the Subscriptions page loads
  Then currency and frequency dropdowns are populated from the catalog endpoints
```

## Other Notes

Closes #115