### PR TITLE
docs: add verify steps and enforce unit tests in feature skill files

### DIFF
--- a/.github/skills/feature/backend.md
+++ b/.github/skills/feature/backend.md
@@ -2,6 +2,22 @@
 
 Full step-by-step guide for adding a new entity to the `FinanceBackEnd` solution.
 
+> **IMPORTANT — Read this entire file before starting.** All steps below are required. Steps 1–8 are implementation; **Step 9 (unit tests) is mandatory** and must not be skipped.
+
+---
+
+## Required Steps (all mandatory)
+
+1. Domain Model
+2. Persistence Configuration + Migration
+3. DTO
+4. Commands (Create, Update, Delete)
+5. Queries (GetAll, GetSingle, GetPaginated)
+6. Mapper
+7. Service Requests
+8. API Controllers (Command + Query)
+9. **Unit Tests** — command handler tests, query handler tests, service tests
+
 ---
 
 ## Step 1 — Domain Model

--- a/.github/skills/feature/finance-app.md
+++ b/.github/skills/feature/finance-app.md
@@ -142,6 +142,15 @@ export default <EntityName>s;
 
 ---
 
+## Step 5 — Verify
+
+Run both checks from `FinanceFrontEnd/FinanceApp` and fix any errors before committing:
+
+```powershell
+npm run typecheck
+npm run lint
+```
+
 ## Checklist
 
 - [ ] URL entry added in `utils/urls.ts`
@@ -150,3 +159,5 @@ export default <EntityName>s;
 - [ ] Route file created in `app/routes/`
 - [ ] Route registered in `app/routes.ts`
 - [ ] UI component created in `app/components/ui/<EntityName>s/`
+- [ ] `npm run typecheck` passes with no errors
+- [ ] `npm run lint` passes with no errors

--- a/.github/skills/feature/funds-app.md
+++ b/.github/skills/feature/funds-app.md
@@ -200,6 +200,14 @@ Add a navigation link in `src/components/Navigation.tsx` if the page should appe
 
 ---
 
+## Step 6 — Verify
+
+Run both checks from `FinanceFrontEnd/FinanceFunds` and fix any errors before committing:
+
+```powershell
+npm run lint
+```
+
 ## Checklist
 
 - [ ] Types file created in `services/types/`
@@ -208,3 +216,5 @@ Add a navigation link in `src/components/Navigation.tsx` if the page should appe
 - [ ] Dashboard page created and exported from `pages/index.ts`
 - [ ] Route registered in `App.tsx`
 - [ ] Navigation link added (if applicable)
+- [ ] `npm run typecheck` passes with no errors
+- [ ] `npm run lint` passes with no errors


### PR DESCRIPTION
# Why

The feature skill files (`backend.md`, `finance-app.md`, `funds-app.md`) lacked explicit verification and mandatory-step enforcement sections. AI agents were skipping unit tests and not running typecheck/lint before committing, leading to broken builds and test gaps.

## What is the solution?

Added mandatory verification steps and reinforced required practices across three skill files:

- **`backend.md`**: Added a prominent read-before-starting banner and a numbered list of all 9 required steps, with Step 9 (unit tests) explicitly marked as mandatory and must not be skipped.
- **`finance-app.md`**: Added a **Step 5 — Verify** section with `npm run typecheck` and `npm run lint` commands to run before committing. Added two checklist items for both checks.
- **`funds-app.md`**: Added a **Step 6 — Verify** section with `npm run lint` to run before committing. Added two checklist items for typecheck and lint.

## What areas of the site does it impact?

Affects the `.github/skills/feature/` skill files used by AI agents when implementing new features across:

- Backend (FinanceBackEnd) — unit test enforcement
- Finance App frontend (FinanceFrontEnd/FinanceApp) — typecheck + lint verification
- Funds App frontend (FinanceFrontEnd/FinanceFunds) — lint verification

No production code is changed.

## Other Notes

Closes #117