### PR TITLE
docs: add CQRS, unit-testing reference docs and unit-tests Copilot skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,3 +14,5 @@
 ## Docs (load when relevant)
 - `.github/docs/local-dev-environment.md` — run modes, IPv6 gotcha, env files, start script
 - `.github/docs/finance-query-filters.md` — EF ownership filters, test identity seeding
+- `.github/docs/cqrs-pattern.md` — ICommand/IQuery interfaces, dispatcher methods, base classes, file/folder conventions
+- `.github/docs/unit-testing.md` — xUnit test conventions, base classes, EF query filter seeding, dispatcher mocking, known gotchas

--- a/.github/docs/cqrs-pattern.md
+++ b/.github/docs/cqrs-pattern.md
@@ -1,0 +1,73 @@
+# CQRS Pattern
+
+## Result types
+
+```
+RequestResult (abstract)
+├── IsSuccess: bool
+├── ErrorMessage: string?
+│
+├── CommandResult         — void commands
+│     Success() / Failure(msg)
+│
+└── DataResult<TData>     — data-returning commands & queries
+      Data: TData
+      Success(data) / Failure(msg)
+```
+
+## Interfaces
+
+```csharp
+// Commands
+interface ICommand;                                      // void → returns CommandResult
+interface ICommand<TResult> : ICommand                  // data → returns DataResult<T>
+
+// Handlers
+interface ICommandHandler<TCommand, TResult>             // TResult : RequestResult
+interface ICommandHandler<TCommand>                      // void variant → returns CommandResult
+
+// Queries
+interface IQuery<TResult>;
+interface IQueryHandler<TQuery, TResult>                 // always returns DataResult<TResult>
+```
+
+## Dispatcher
+
+```csharp
+// Commands
+Task<TResult>             DispatchAsync<TResult>(ICommand<TResult> command);
+Task<CommandResult>       DispatchCommandAsync(ICommand command);
+
+// Queries
+Task<DataResult<TResult>> DispatchQueryAsync<TResult>(IQuery<TResult> query);
+```
+
+Context-aware variants (`IContextAwareCommand/Query<TContext, ...>`) accept an additional `HttpRequest?` parameter.
+
+## Base classes
+
+```csharp
+// Commands (in Finance.Application)
+abstract class BaseCommandHandler<TCommand, TEntity>
+    : ICommandHandler<TCommand, DataResult<TEntity>>
+{
+    protected FinanceDbContext DbContext { get; }
+    public abstract Task<DataResult<TEntity>> ExecuteAsync(TCommand command, CancellationToken ct);
+}
+
+// Queries (in Finance.Application)
+abstract class BaseQueryHandler<TQuery, TEntity>
+    : IQueryHandler<TQuery, TEntity>
+{
+    protected FinanceDbContext DbContext { get; }
+    public abstract Task<DataResult<TEntity>> ExecuteAsync(TQuery request, CancellationToken ct);
+}
+```
+
+## Conventions
+
+- Command + handler are **co-located in the same file** under `Finance.Application/Commands/<Domain>/`.
+- Query + handler are **co-located in the same file** under `Finance.Application/Queries/<Domain>/`.
+- Query base classes live in `Finance.Application/Queries/_Base/`: `GetAllQuery<T>`, `GetPaginatedQuery<T>`, `GetSingleByIdQuery<T, TId>`.
+- Commands always return `DataResult<TEntity>` even for write operations (returns the created/updated entity).
+- Use `DataResult<T>.Failure(msg)` for expected failures — no exceptions.

--- a/.github/docs/unit-testing.md
+++ b/.github/docs/unit-testing.md
@@ -1,0 +1,279 @@
+# Unit Testing in Finanzas Backend
+
+## Project
+
+All backend unit tests live in:
+
+```
+FinanceBackEnd/tests/Finance.Application.Tests/
+```
+
+Test runner: **xUnit**. Mocking: **Moq**. Global usings (`Xunit`, `Moq`) are declared in `Usings.cs` — no need to re-import them.
+
+---
+
+## Folder Structure
+
+Tests mirror the `Finance.Application` source layout:
+
+```
+Tests/
+  Commands/
+    CreditCards/
+    Funds/
+    IOLInvestments/
+    ...
+    _Base/           ← ActivateDeactivateTestBase (activate/deactivate helpers)
+  Queries/
+    Currencies/
+    Funds/
+    Summary/
+    ...
+    _Base/           ← QueryHandlerBaseTests (in-memory DbContext)
+  Services/
+    CurrencyConversionServiceTests.cs
+    ...
+  Domain/
+    DataConverters/
+    ...
+```
+
+Rule: one test class per handler/service, in the matching subfolder.
+
+---
+
+## Base Classes
+
+### `QueryHandlerBaseTests`
+
+**File**: `Queries/_Base/QueryHandlerBaseTests.cs`  
+**Namespace**: `Finance.Application.Tests.Queries.Base`
+
+Use this for **any** test that needs `FinanceDbContext`:
+
+- Command handler tests
+- Query handler tests
+- Service tests that take `FinanceDbContext`
+
+```csharp
+public class MyQueryHandlerTests : QueryHandlerBaseTests
+{
+    // _dbContext is available
+}
+```
+
+`Dispose()` is `virtual` — override it when the test class holds its own disposable (e.g. `IMemoryCache`):
+
+```csharp
+public override void Dispose()
+{
+    base.Dispose();
+    _cache.Dispose();
+}
+```
+
+### `ActivateDeactivateTestBase`
+
+**File**: `Commands/_Base/ActivateDeactivateTestBase.cs`  
+**Namespace**: `Finance.Application.Tests.Commands.Base`
+
+Use when testing activate/deactivate command handlers. Provides `DbContext` + a pre-seeded `CurrentUser`.
+
+---
+
+## The In-Memory Database
+
+`QueryHandlerBaseTests` creates a fresh `FinanceDbContext` backed by `UseInMemoryDatabase` with a random name per test class instance. Each test class gets its own isolated database.
+
+### `CurrentUserId`
+
+`FinanceDbContext.CurrentUserId` returns `"IdentityNotFound"` when no `IHttpContextAccessor` is provided (which is always the case in tests). To match the current user in query filters, seed a user whose `Identity.SourceId == "IdentityNotFound"`:
+
+```csharp
+var user = new User
+{
+    Id = Guid.NewGuid(),
+    Username = "u",
+    FirstName = "F",
+    LastName = "L",
+    Identities = [new Identity { SourceId = "IdentityNotFound" }],
+};
+await _dbContext.User.AddAsync(user);
+await _dbContext.SaveChangesAsync();
+```
+
+---
+
+## EF Core Query Filters
+
+Several entities have **global query filters** that restrict reads to owned records. Tests must seed the corresponding `*Permissions` records or the entity will not appear in query results.
+
+| Entity | Permissions Table |
+|---|---|
+| `Fund` | `FundPermissions` |
+| `CurrencyExchangeRate` | `CurrencyExchangeRatePermissions` |
+| `IOLInvestment` | `IOLInvestmentPermissions` |
+| `IOLInvestmentAsset` | `IOLInvestmentAssetPermissions` |
+
+Always seed **both** the entity and its permission record. Example for `Fund`:
+
+```csharp
+var fund = new Fund { Id = Guid.NewGuid(), ... };
+await _dbContext.Fund.AddAsync(fund);
+_dbContext.FundPermissions.Add(new FundPermissions
+{
+    ResourceId = fund.Id,
+    Resource = fund,
+    UserId = user.Id,
+    User = user,
+    PermissionLevels = [PermissionLevelEnum.Owner],
+});
+await _dbContext.SaveChangesAsync();
+```
+
+To query data bypassing filters (e.g. to seed permissions for all records at once):
+
+```csharp
+var all = _dbContext.Fund.IgnoreQueryFilters().ToArray();
+```
+
+`IgnoreQueryFilters` requires `using Microsoft.EntityFrameworkCore;` when not already present.
+
+---
+
+## Mocking the Dispatcher
+
+When a handler or service calls `IDispatcher<FinanceDispatchContext>`, inject a `Mock<IDispatcher<FinanceDispatchContext>>` and set it up by return type:
+
+```csharp
+_dispatcher
+    .Setup(d => d.DispatchQueryAsync<List<CurrencyExchangeRate>>(It.IsAny<IQuery<List<CurrencyExchangeRate>>>()))
+    .ReturnsAsync(DataResult<List<CurrencyExchangeRate>>.Success(rates));
+```
+
+Verify call count when the behavior matters (e.g. cache suppresses a second dispatch):
+
+```csharp
+_dispatcher.Verify(
+    d => d.DispatchQueryAsync<List<CurrencyExchangeRate>>(It.IsAny<IQuery<List<CurrencyExchangeRate>>>()),
+    Times.Once);
+```
+
+### `CurrencyConversionService` — same-currency behavior
+
+- `Convert(holder, targetId)`: **short-circuits** if `holder.CurrencyId == targetId` (no dispatcher call).
+- `ConvertCollection(holders, targetId)`: **always** calls the dispatcher (no short-circuit). Set up rates even when the amounts are in the same currency.
+
+---
+
+## Building and Running Tests
+
+Always build before running to catch compile errors early:
+
+```powershell
+dotnet build FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj
+```
+
+Run all tests:
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj -v q
+```
+
+Run a single test class:
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests/ --filter "FullyQualifiedName~GetCurrentFundsQueryHandlerTests" -v q
+```
+
+---
+
+## Pre-Seeded Data
+
+`EnsureCreated()` runs all `IEntityTypeConfiguration` classes, which include `HasData` seed calls. The following data is always present in every test DB — **never try to insert it again**:
+
+| Data | Source |
+|---|---|
+| `Currency` ARS (ID `6d189135-7040-45a1-b713-b1aa6cad1720`) | `CurrencyConfiguration.HasData` |
+| `Currency` USD (ID `efbf50bc-...`) | `CurrencyConfiguration.HasData` |
+| `CurrencySymbol` records for ARS and USD | `CurrencySymbolConfiguration.HasData` |
+| All `FrequencyEnum` values (`Monthly`, `Annual`, `Weekly`, `Daily`, `OneTime`) | `KeyValueEntityConfiguration<Frequency, FrequencyEnum>` |
+| All `IOLInvestmentAssetTypeEnum` values (incl. `Cedear`) | `KeyValueEntityConfiguration<IOLInvestmentAssetType, IOLInvestmentAssetTypeEnum>` |
+| All `AppModuleTypeEnum` values (incl. `Debits`, `Funds`, `Investments`) | `KeyValueEntityConfiguration<AppModuleType, AppModuleTypeEnum>` |
+
+### Inserting pre-seeded entities causes a duplicate-key crash
+
+```
+System.ArgumentException: An item with the same key has already been added. Key: <id>
+```
+
+**Never** do:
+```csharp
+// ❌ crashes — ARS is already seeded with this exact ID
+var ars = new Currency { Id = Guid.Parse(CurrencyConstants.DefaultCurrencyId), ShortName = "ARS" };
+await _dbContext.Currency.AddAsync(ars);
+
+// ❌ crashes — IOLInvestmentAssetType.Cedear is already seeded
+var type = new IOLInvestmentAssetType { Id = IOLInvestmentAssetTypeEnum.Cedear };
+await _dbContext.IOLInvestmentAssetType.AddAsync(type);
+```
+
+**Instead, fetch the existing entity:**
+```csharp
+// ✅ fetch pre-seeded currency
+var ars = (await _dbContext.Currency.FindAsync(Guid.Parse(CurrencyConstants.DefaultCurrencyId)))!;
+
+// ✅ fetch pre-seeded key-value entity
+var assetType = _dbContext.IOLInvestmentAssetType.First(o => o.Id == IOLInvestmentAssetTypeEnum.Cedear);
+var appModuleType = _dbContext.AppModuleType.Find(AppModuleTypeEnum.Debits)!;
+```
+
+### Asserting counts or ordering when pre-seeded data is present
+
+Tests that call `Assert.Single(result.Data)` or `Assert.Equal(N, result.Data.Count)` will fail if the query returns pre-seeded records too. Scope assertions to the IDs the test controls:
+
+```csharp
+// ❌ fragile — pre-seeded currencies inflate the count
+Assert.Equal(1, result.Data.Count);
+
+// ✅ scope to the test's own records
+var mine = result.Data.Where(x => x.Id == myId || x.Id == otherId).ToList();
+Assert.Single(mine);
+```
+
+---
+
+## `CurrencyFixture`
+
+**File**: `Queries/_Base/CurrencyFixture.cs`  
+**Namespace**: `Finance.Application.Tests.Queries.Base`
+
+Builds `Currency` instances with short names guaranteed not to clash with pre-seeded ARS/USD. Use it in any test that needs to insert a currency into the DB:
+
+```csharp
+// single currency with auto-assigned short name
+var c = CurrencyFixture.Build();
+
+// with explicit attributes
+var inactive = CurrencyFixture.Build(shortName: "JPY", name: "Yen", deactivated: true);
+
+// batch
+var currencies = CurrencyFixture.BuildMany(3);
+```
+
+Available non-seeded short names (rotated automatically): EUR, GBP, JPY, CHF, CAD, BRL, MXN, CNY, KRW, INR, RUB, TRY, ZAR, SEK, NOK, DKK, PLN, CZK, HUF, RON.
+
+---
+
+## Gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `An item with the same key has already been added` | Inserting an entity whose ID matches a pre-seeded record | Fetch from `_dbContext` instead of constructing with `new` |
+| `Assert.Single` / count assertion fails unexpectedly | Pre-seeded rows are included in query results | Scope assertions by the IDs the test seeded |
+| Query returns empty collection | Missing `*Permissions` seed | Add the matching `*Permissions` record for the test user |
+| `IOLInvestment` query always empty even with permissions | `IOLInvestmentAsset` **also** has a query filter | Grant `IOLInvestmentAssetPermissions` for each asset too |
+| `NullReferenceException` in `ConvertCollection` | No dispatcher setup for same-currency call | `SetupDispatcherRates([])` even when all amounts share the same currency |
+| `IgnoreQueryFilters`/`CountAsync` not found | Missing `using Microsoft.EntityFrameworkCore;` | Add the using |
+| Test user not matched by query filter | `Identity.SourceId` ≠ `"IdentityNotFound"` | Use `SourceId = "IdentityNotFound"` for the test user identity |
+| Handler returns failure saying "Default currency not found" | Test expected ARS to be absent — impossible since it's pre-seeded | Assert success instead; the default currency is always present |

--- a/.github/skills/unit-tests/SKILL.md
+++ b/.github/skills/unit-tests/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: unit-tests
+description: "Write backend unit tests for new or changed .NET code. Use when: adding tests for unstaged changes, writing tests for a specific file or set of files, covering a new handler, service, or domain type. Reads source files, infers test cases, writes xUnit tests following project conventions, then builds and runs to verify."
+argument-hint: "[file1 file2 ...]  — workspace-relative paths whose tests to write; omit to use all unstaged changes"
+---
+
+# Unit Test Implementation Workflow
+
+Workflow for writing xUnit tests for changed or specified backend source files, following the conventions of `Finance.Application.Tests`.
+
+## Reference Doc
+
+Load the full testing guide before starting:
+
+```
+.github/docs/unit-testing.md
+```
+
+This doc covers base classes, in-memory DB setup, EF query filter seeding, dispatcher mocking, and known gotchas. **Do not proceed without reading it.**
+
+---
+
+## Step 1 — Identify target files
+
+### If paths are provided
+
+Use the given paths as the target sources directly.
+
+### If no paths are provided
+
+Run:
+
+```powershell
+git diff --name-only HEAD
+git status --short
+```
+
+Filter to `.cs` files under `FinanceBackEnd/src/Finance.Application/` (Commands, Queries, Services). Ignore migration files, generated files, domain models, and EF configuration.
+
+---
+
+## Step 2 — Understand each source file
+
+For each source file:
+
+1. Read it fully.
+2. Identify:
+   - Class type: command handler, query handler, or service
+   - Constructor dependencies (what to mock vs inject)
+   - Whether it accesses `FinanceDbContext` directly
+   - Which entities it reads/writes and whether those have EF query filters (see `.github/docs/unit-testing.md`)
+   - Public methods / `ExecuteAsync` signature and return type
+3. Read the existing test file (if any) to avoid duplicating covered cases.
+
+---
+
+## Step 3 — Find the existing test file
+
+Test file location mirrors source location:
+
+| Source path | Test path |
+|---|---|
+| `src/Finance.Application/Commands/Funds/CreateFundCommandHandler.cs` | `tests/Finance.Application.Tests/Commands/Funds/CreateFundCommandHandlerTests.cs` |
+| `src/Finance.Application/Queries/Currencies/GetCurrencyQueryHandler.cs` | `tests/Finance.Application.Tests/Queries/Currencies/GetCurrencyQueryHandlerTests.cs` |
+| `src/Finance.Application/Services/CurrencyConversionService.cs` | `tests/Finance.Application.Tests/Services/CurrencyConversionServiceTests.cs` |
+
+If the test file exists, **add tests to it**. If not, create a new one.
+
+---
+
+## Step 4 — Plan test cases
+
+Think through:
+
+- **Happy path(s)**: the handler succeeds under normal conditions
+- **Validation / failure paths**: missing entity, invalid input → expected error or false result
+- **Boundary conditions**: empty collections, null values, zero amounts
+- **Filter/ownership paths**: entity not returned because permission not granted
+- **Behavioral assertions**: dispatcher called once vs. not at all (for caching, short-circuits)
+
+Write the list before coding.
+
+---
+
+## Step 5 — Write the tests
+
+### Class skeleton
+
+```csharp
+using Finance.Application.Tests.Queries.Base;
+
+namespace Finance.Application.Tests.Commands.<Module>;   // or Queries / Services
+
+public class XxxCommandHandlerTests : QueryHandlerBaseTests
+{
+    // mocks declared here
+    public XxxCommandHandlerTests() { /* set up mocks */ }
+
+    private XxxCommandHandler CreateHandler() => new(_dbContext, _mock.Object, ...);
+
+    [Fact]
+    public async Task MethodName_Condition_ExpectedOutcome() { ... }
+}
+```
+
+### Naming
+
+`MethodOrAction_Condition_ExpectedOutcome` — e.g. `Upload_WhenHelperReturnsNoRecords_ReturnsFailure`.
+
+### Key rules (from `.github/docs/unit-testing.md`)
+
+- Extend `QueryHandlerBaseTests` for **every** test class that touches `FinanceDbContext`.
+- Seed `Identity { SourceId = "IdentityNotFound" }` on the current user so EF query filters match.
+- Seed `*Permissions` rows for every entity that has an ownership filter or the query will return nothing.
+- For `IOLInvestment` tests: grant **both** `IOLInvestmentPermissions` and `IOLInvestmentAssetPermissions`.
+- `ConvertCollection` always calls the dispatcher — set up rates even for same-currency input.
+- Override `Dispose()` and call `base.Dispose()` first if the class holds an `IMemoryCache`.
+- Do not add code comments unless the logic is non-obvious.
+
+### Avoid
+
+- Don't add narrative comments (e.g. `// Arrange`, `// Act`, `// Assert`, `// Set up the handler`).
+- Don't test behavior already covered in the existing test file.
+- Don't add `using` directives for namespaces not directly referenced in the file.
+
+---
+
+## Step 6 — Build
+
+```powershell
+dotnet build FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary;ForceNoAlign
+```
+
+Fix every compiler error before running tests. Common errors:
+
+| Error | Fix |
+|---|---|
+| `IgnoreQueryFilters`/`CountAsync` not found | Add `using Microsoft.EntityFrameworkCore;` |
+| IDE0005 unused `using` | Remove the import |
+| Type not found | Check the correct namespace in the source file |
+
+---
+
+## Step 7 — Run tests
+
+Run only the newly written test classes first:
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests/ --filter "FullyQualifiedName~XxxTests" -v n
+```
+
+Then run the full suite to check for regressions:
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests/ -v q
+```
+
+Interpret failures:
+
+- **Empty collection / no results**: likely missing `*Permissions` seed.
+- **NullReferenceException in ConvertCollection**: missing dispatcher setup.
+- **Wrong numeric result**: check whether rate direction is buy vs. sell.
+
+Fix failures and re-run until all tests pass.
+
+---
+
+## Step 8 — Done
+
+Report:
+- Which test files were created or modified
+- How many tests were added and which pass
+- Any tests left failing and the known reason


### PR DESCRIPTION
# Why

The project lacked authoritative developer reference docs for two core conventions — the CQRS pattern and unit testing — making it harder for contributors (and AI agents) to apply them consistently. Additionally, there was no automated skill for generating backend unit tests.

## What is the solution?

- Added `.github/docs/cqrs-pattern.md`: covers `ICommand`/`IQuery` interfaces, `CommandResult`/`DataResult` types, dispatcher methods, base handler classes, and file/folder naming conventions.
- Added `.github/docs/unit-testing.md`: covers xUnit project structure, base test classes, in-memory EF seeding, EF query filter seeding, Moq dispatcher mocking, and known gotchas.
- Added `.github/skills/unit-tests/SKILL.md`: a Copilot agent skill that reads source files, infers test cases, generates xUnit tests following project conventions, then builds and runs them to verify.
- Updated `.github/copilot-instructions.md`: registered the two new docs in the "Docs (load when relevant)" index so agents load them on demand.

## What areas of the site does it impact?

- **AI agent workflows** — agents now have on-demand CQRS and unit-testing references, reducing hallucinated conventions.
- **Backend development** — the unit-tests skill covers all handlers in `Finance.Application` and the test project `Finance.Application.Tests`.
- **Developer onboarding** — new contributors get accurate guidance on CQRS patterns and how to write tests.

## Other Notes

Closes #121