### PR TITLE
feat: dashboard summary drill-down and collapsible tables

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/SummaryDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/SummaryDetail.tsx
@@ -1,0 +1,102 @@
+import FetchTable from '@/components/ui/utils/FetchTable';
+import CustomButton from '@/components/ui/utils/CustomButton';
+import urls from '@/utils/urls';
+import {
+  buildFundsColumns,
+  buildInvestmentsColumns,
+  buildSummaryColumns,
+  getSafeValueFrom,
+  moneyFormatter,
+} from './dashboardHelpers';
+
+type Props = {
+  onClose: () => void;
+  tableClasses: string[];
+  tableContainer: string;
+  defaultCurrencySymbol: string;
+};
+
+export default function SummaryDetail({ onClose, tableClasses, tableContainer, defaultCurrencySymbol }: Props) {
+  const summaryColumns = buildSummaryColumns(defaultCurrencySymbol);
+  const investmentsColumns = buildInvestmentsColumns(defaultCurrencySymbol);
+  const fundsColumns = buildFundsColumns(defaultCurrencySymbol);
+
+  return (
+    <div>
+      <div className="flex justify-end mb-4">
+        <CustomButton onClick={onClose} className="bg-gray-500 text-white hover:bg-gray-600">
+          Ver menos
+        </CustomButton>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          {urls.summary.general && (
+            <div className={tableContainer}>
+              <FetchTable
+                name="Summary"
+                title={{ text: `Resúmen`, class: `text-center bg-blue-500 text-white` }}
+                url={urls.summary.general.with({ DailyUse: true })}
+                columns={summaryColumns}
+                classes={tableClasses}
+                showTotals={false}
+              />
+            </div>
+          )}
+        </div>
+        <div>
+          {urls.summary.currentFunds && (
+            <div className={tableContainer}>
+              <FetchTable
+                name="Funds"
+                title={{ text: `Fondos`, class: `text-center bg-indigo-500 text-white` }}
+                url={urls.summary.currentFunds.with({ DailyUse: true })}
+                columns={fundsColumns}
+                classes={tableClasses}
+                collapsible={true}
+                collapsed={true}
+                collapsedSummary={(rows) => {
+                  const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'quoteCurrencyValue'), 0);
+                  return `Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                }}
+              />
+            </div>
+          )}
+          {urls.summary.currentFunds && (
+            <div className={tableContainer}>
+              <FetchTable
+                name="OtherFunds"
+                title={{ text: `Otros Fondos`, class: `text-center bg-indigo-500 text-white` }}
+                url={urls.summary.currentFunds.with({ DailyUse: false })}
+                columns={fundsColumns}
+                classes={tableClasses}
+                collapsible={true}
+                collapsed={true}
+                collapsedSummary={(rows) => {
+                  const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'quoteCurrencyValue'), 0);
+                  return `Otros Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                }}
+              />
+            </div>
+          )}
+          {urls.summary.currentInvestments && (
+            <div className={tableContainer}>
+              <FetchTable
+                name="Investments"
+                title={{ text: `Inversiones`, class: `text-center medium bg-purple-500 text-white` }}
+                url={urls.summary.currentInvestments}
+                columns={investmentsColumns as unknown[]}
+                classes={tableClasses}
+                collapsible={true}
+                collapsed={true}
+                collapsedSummary={(rows) => {
+                  const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'valuedDefaultCurrency'), 0);
+                  return `Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                }}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/SummaryDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/SummaryDetail.tsx
@@ -52,11 +52,12 @@ export default function SummaryDetail({ onClose, tableClasses, tableContainer, d
                 url={urls.summary.currentFunds.with({ DailyUse: true })}
                 columns={fundsColumns}
                 classes={tableClasses}
-                collapsible={true}
-                collapsed={true}
-                collapsedSummary={(rows) => {
-                  const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'quoteCurrencyValue'), 0);
-                  return `Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                collapsible={{
+                  defaultCollapsed: true,
+                  summary: (rows) => {
+                    const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'quoteCurrencyValue'), 0);
+                    return `Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                  }
                 }}
               />
             </div>
@@ -69,11 +70,12 @@ export default function SummaryDetail({ onClose, tableClasses, tableContainer, d
                 url={urls.summary.currentFunds.with({ DailyUse: false })}
                 columns={fundsColumns}
                 classes={tableClasses}
-                collapsible={true}
-                collapsed={true}
-                collapsedSummary={(rows) => {
-                  const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'quoteCurrencyValue'), 0);
-                  return `Otros Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                collapsible={{
+                  defaultCollapsed: true,
+                  summary: (rows) => {
+                    const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'quoteCurrencyValue'), 0);
+                    return `Otros Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                  }
                 }}
               />
             </div>
@@ -86,11 +88,12 @@ export default function SummaryDetail({ onClose, tableClasses, tableContainer, d
                 url={urls.summary.currentInvestments}
                 columns={investmentsColumns as unknown[]}
                 classes={tableClasses}
-                collapsible={true}
-                collapsed={true}
-                collapsedSummary={(rows) => {
-                  const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'valuedDefaultCurrency'), 0);
-                  return `Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                collapsible={{
+                  defaultCollapsed: true,
+                  summary: (rows) => {
+                    const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'valuedDefaultCurrency'), 0);
+                    return `Fondos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                  }
                 }}
               />
             </div>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/dashboardHelpers.ts
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/dashboardHelpers.ts
@@ -108,14 +108,18 @@ export const buildSummaryColumns = (symbol: string) => [
   DecimalColumn('convertedValue', `Monto (${symbol})`, (v: unknown) => getSafeValueFrom(v, 'convertedValue')),
 ];
 
-export const buildFundsColumns = (symbol: string) => {
-  const { totals: _t, type: _ty, ...montoCol } = DecimalColumn('value', 'Monto', getSafeValue);
-  return [
-    new FetchTableColumn('label', 'Origen'),
-    montoCol,
-    DecimalColumn('quoteCurrencyValue', `Monto (${symbol})`, (v: unknown) => getSafeValueFrom(v, 'quoteCurrencyValue')),
-  ];
-};
+export const buildFundsColumns = (symbol: string) => [
+  new FetchTableColumn('label', 'Origen'),
+  {
+    id: 'value',
+    label: 'Monto',
+    class: ['text-end'],
+    headerClass: ['text-end'],
+    mapper: getSafeValue,
+    formatter: moneyFormatter,
+  },
+  DecimalColumn('quoteCurrencyValue', `Monto (${symbol})`, (v: unknown) => getSafeValueFrom(v, 'quoteCurrencyValue')),
+];
 
 export const buildExpensesColumns = (symbol: string) => [
   new FetchTableColumn('label', 'Gasto/Servicio'),

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/dashboardHelpers.ts
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/dashboardHelpers.ts
@@ -1,0 +1,181 @@
+import { Dictionary, toNumber, ValueLike } from '@/utils/common';
+import { InputType } from '@/components/ui/utils/InputType';
+import { FetchTableColumn } from '@/components/ui/utils/FetchTableColumn';
+
+export const backgroundClasses = [
+  'bg-amber-500',
+  'bg-blue-500',
+  'bg-cyan-500',
+  'bg-emerald-500',
+  'bg-fuchsia-500',
+  'bg-green-500',
+  'bg-indigo-500',
+  'bg-lime-500',
+  'bg-orange-500',
+  'bg-purple-500',
+  'bg-pink-500',
+  'bg-red-500',
+  'bg-rose-500',
+  'bg-sky-500',
+  'bg-teal-500',
+  'bg-violet-500',
+  'bg-yellow-500',
+];
+
+export const moneyFormatter = (r: number) => (typeof r === 'number' ? r : 0).toFixed(2);
+
+export const getSafeValue = (v: unknown) => toNumber(v as ValueLike);
+
+export const safeProp = (obj: unknown, prop: string): unknown => {
+  if (obj && typeof obj === 'object') {
+    return (obj as Record<string, unknown>)[prop];
+  }
+  return undefined;
+};
+
+export const getOriginOrName = (record: unknown): string => {
+  const origin = safeProp(record, 'origin');
+  if (origin && typeof origin === 'object') {
+    const name = safeProp(origin, 'name');
+    if (typeof name === 'string') return name;
+  }
+  const name = safeProp(record, 'name');
+  return typeof name === 'string' ? name : '-';
+};
+
+export const getNestedName = (obj: unknown, path: string[]): string => {
+  let cur: unknown = obj;
+  for (const p of path) {
+    cur = safeProp(cur, p);
+    if (cur === undefined) return '-';
+  }
+  return typeof cur === 'string' ? cur : '-';
+};
+
+export const getSafeValueFrom = (v: unknown, prop?: string) => {
+  const value = prop ? safeProp(v, prop) : v;
+  return toNumber(value as ValueLike);
+};
+
+export type Mapper = (v: unknown) => number;
+export type Reducer = (acc: number, v: unknown) => number;
+
+export const DecimalColumn = (id: string, label: string, mapper?: Mapper, totalsReducer?: Reducer) => {
+  const localMapper: Mapper = mapper ?? ((v: unknown) => toNumber(v as ValueLike));
+  const localTotalsReducer: Reducer =
+    totalsReducer ?? ((acc: number, r: unknown) => acc + localMapper(r));
+
+  return {
+    id,
+    label,
+    class: ['text-end'],
+    headerClass: ['text-end'],
+    type: InputType.Decimal,
+    mapper: localMapper,
+    formatter: moneyFormatter,
+    totals: {
+      formatter: moneyFormatter,
+      reducer: localTotalsReducer,
+    },
+  };
+};
+
+export const dollarCalculator = (r: ValueLike, creditCardConversion: unknown) => {
+  const sellRate = safeProp(creditCardConversion, 'sellRate') as ValueLike;
+  return toNumber(r) * toNumber(sellRate, 1);
+};
+
+export const DEBIT_MODULE_PESOS = '4c1ee918-e8f9-4bed-8301-b4126b56cfc0';
+export const DEBIT_MODULE_DOLLARS = '03cc66c7-921c-4e05-810e-9764cd365c1d';
+export const DEBIT_MODULES = [DEBIT_MODULE_PESOS, DEBIT_MODULE_DOLLARS];
+
+export const DEBIT_BACKGROUND_CLASSES: Dictionary<string> = {
+  [DEBIT_MODULE_PESOS]: 'bg-violet-500 text-white',
+  [DEBIT_MODULE_DOLLARS]: 'bg-orange-500 text-white',
+};
+export const DEBIT_TABLE_NAMES: Dictionary<string> = {
+  [DEBIT_MODULE_PESOS]: 'debit-pesos-table',
+  [DEBIT_MODULE_DOLLARS]: 'debit-dollars-table',
+};
+export const DEBIT_TABLE_TITLES: Dictionary<string> = {
+  [DEBIT_MODULE_PESOS]: 'Débitos Pesos',
+  [DEBIT_MODULE_DOLLARS]: 'Débitos Dólares',
+};
+
+export const buildSummaryColumns = (symbol: string) => [
+  new FetchTableColumn('label', 'Dato'),
+  DecimalColumn('value', 'Monto', getSafeValue),
+  DecimalColumn('convertedValue', `Monto (${symbol})`, (v: unknown) => getSafeValueFrom(v, 'convertedValue')),
+];
+
+export const buildFundsColumns = (symbol: string) => {
+  const { totals: _t, type: _ty, ...montoCol } = DecimalColumn('value', 'Monto', getSafeValue);
+  return [
+    new FetchTableColumn('label', 'Origen'),
+    montoCol,
+    DecimalColumn('quoteCurrencyValue', `Monto (${symbol})`, (v: unknown) => getSafeValueFrom(v, 'quoteCurrencyValue')),
+  ];
+};
+
+export const buildExpensesColumns = (symbol: string) => [
+  new FetchTableColumn('label', 'Gasto/Servicio'),
+  DecimalColumn('value', `Monto (${symbol})`, getSafeValue),
+];
+
+export const buildDebitColumns = () => [
+  new FetchTableColumn('origin', 'Débito/Servicio', (record: unknown) => getOriginOrName(record)),
+  DecimalColumn('amount', 'Monto', (a: unknown) => getSafeValueFrom(a, 'amount')),
+];
+
+export const buildInvestmentsColumns = (symbol: string) => [
+  new FetchTableColumn('symbol', 'Activo', (record: unknown) => getNestedName(record, ['label'])),
+  DecimalColumn('averageReturn', 'Rend. prom.', (v: unknown) => {
+    const val = safeProp(v, 'averageReturn');
+    return typeof val === 'number' ? val : getSafeValueFrom(v);
+  }),
+  DecimalColumn('valued', 'Valorado', (v: unknown) => {
+    const val = safeProp(v, 'valued');
+    return typeof val === 'number' ? val : getSafeValueFrom(v);
+  }),
+  DecimalColumn('valuedDefaultCurrency', `Valorado (${symbol})`, (v: unknown) => {
+    const val = safeProp(v, 'valuedDefaultCurrency');
+    return typeof val === 'number' ? val : getSafeValueFrom(v);
+  }),
+];
+
+export const buildCurrencyRatesColumns = () => [
+  new FetchTableColumn('label', 'Base', (v: unknown) => getNestedName(v, ['baseCurrency', 'name']), (v: unknown) => getNestedName(v, ['baseCurrency', 'name'])),
+  new FetchTableColumn('label', 'Cotización', (v: unknown) => getNestedName(v, ['quoteCurrency', 'name']), (v: unknown) => getNestedName(v, ['quoteCurrency', 'name'])),
+  DecimalColumn('value', 'Compra', (v: unknown) => getSafeValueFrom(safeProp(v, 'buyRate'))),
+  DecimalColumn('value', 'Venta', (v: unknown) => getSafeValueFrom(safeProp(v, 'sellRate'))),
+];
+
+export const buildCreditCardColumns = (latestCurrencyExchangeRates: unknown) => [
+  {
+    id: 'timestamp',
+    label: 'Fecha',
+    mapper: (v: unknown) => {
+      const date = safeProp(v, 'timestamp') as string;
+      return date ? new Date(date).toLocaleDateString() : '';
+    },
+  },
+  { id: 'concept', label: 'Concepto' },
+  DecimalColumn('amount', 'Monto', (v: unknown) => toNumber(safeProp(v, 'amount') as ValueLike, 0)),
+  DecimalColumn('amountDollars', 'Dólares', (v: unknown) => toNumber(safeProp(v, 'amountDollars') as ValueLike, 0)),
+  DecimalColumn(
+    'totalAmount',
+    'Total',
+    (v: unknown) => {
+      if (!v) return 0;
+      const amount = toNumber(safeProp(v, 'amount') as ValueLike, 0);
+      const amountDollars = toNumber(safeProp(v, 'amountDollars') as ValueLike, 0);
+      return amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
+    },
+    (acc: number, v: unknown) => {
+      if (!v) return acc;
+      const amount = toNumber(safeProp(v, 'amount') as ValueLike, 0);
+      const amountDollars = toNumber(safeProp(v, 'amountDollars') as ValueLike, 0);
+      return acc + amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
+    }
+  ),
+];

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -1,243 +1,41 @@
 import type { loader } from '@/routes/dashboard';
-import { Outlet, useLoaderData } from 'react-router';
+import { Outlet, useLoaderData, useMatch, useNavigate } from 'react-router';
 
 import urls from '@/utils/urls';
-import { Dictionary, toNumber, ValueLike } from '@/utils/common';
-import { FetchTableColumn } from '@/components/ui/utils/FetchTableColumn';
-import { InputType } from '@/components/ui/utils/InputType';
 import FetchTable from '@/components/ui/utils/FetchTable';
-
-const backgroundClasses = [
-  'bg-amber-500',
-  'bg-blue-500',
-  'bg-cyan-500',
-  'bg-emerald-500',
-  'bg-fuchsia-500',
-  'bg-green-500',
-  'bg-indigo-500',
-  'bg-lime-500',
-  'bg-orange-500',
-  'bg-purple-500',
-  'bg-pink-500',
-  'bg-red-500',
-  'bg-rose-500',
-  'bg-sky-500',
-  'bg-teal-500',
-  'bg-violet-500',
-  'bg-yellow-500',
-  //   "bg-slate-500",
-  //   "bg-zinc-500",
-  //   "bg-neutral-500",
-  //   "bg-stone-500",
-  //   "bg-gray-500",
-];
-
-const moneyFormatter = (r: number) => (typeof r === 'number' ? r : 0).toFixed(2);
-
-const getSafeValue = (v: unknown) => toNumber(v as ValueLike);
-
-const safeProp = (obj: unknown, prop: string): unknown => {
-  if (obj && typeof obj === 'object') {
-    return (obj as Record<string, unknown>)[prop];
-  }
-  return undefined;
-};
-
-const getOriginOrName = (record: unknown): string => {
-  const origin = safeProp(record, 'origin');
-  if (origin && typeof origin === 'object') {
-    const name = safeProp(origin, 'name');
-    if (typeof name === 'string') return name;
-  }
-  const name = safeProp(record, 'name');
-  return typeof name === 'string' ? name : '-';
-};
-
-const getNestedName = (obj: unknown, path: string[]): string => {
-  let cur: unknown = obj;
-  for (const p of path) {
-    cur = safeProp(cur, p);
-    if (cur === undefined) return '-';
-  }
-  return typeof cur === 'string' ? cur : '-';
-};
-
-const getSafeValueFrom = (v: unknown, prop?: string) => {
-  const value = prop ? safeProp(v, prop) : v;
-  return toNumber(value as ValueLike);
-};
-
-type Mapper = (v: unknown) => number;
-type Reducer = (acc: number, v: unknown) => number;
-
-const DecimalColumn = (id: string, label: string, mapper?: Mapper, totalsReducer?: Reducer) => {
-  const localMapper: Mapper = mapper ?? ((v: unknown) => toNumber(v as ValueLike));
-
-  const localTotalsReducer: Reducer =
-    totalsReducer ?? ((acc: number, r: unknown) => acc + localMapper(r));
-
-  const result = {
-    id: id,
-    label: label,
-    class: ['text-end'],
-    headerClass: ['text-end'],
-    type: InputType.Decimal,
-    mapper: localMapper,
-    formatter: moneyFormatter,
-    totals: {
-      formatter: moneyFormatter,
-      reducer: localTotalsReducer,
-    },
-  };
-
-  return result;
-};
-
-const dollarCalculator = function (r: ValueLike, creditCardConversion: unknown) {
-  const sellRate = safeProp(creditCardConversion, 'sellRate') as ValueLike;
-  return toNumber(r) * toNumber(sellRate, 1);
-};
+import CustomButton from '@/components/ui/utils/CustomButton';
+import {
+  backgroundClasses,
+  buildCreditCardColumns,
+  buildCurrencyRatesColumns,
+  buildDebitColumns,
+  buildExpensesColumns,
+  buildFundsColumns,
+  buildInvestmentsColumns,
+  buildSummaryColumns,
+  DEBIT_BACKGROUND_CLASSES,
+  DEBIT_MODULES,
+  DEBIT_TABLE_NAMES,
+  DEBIT_TABLE_TITLES,
+} from './dashboardHelpers';
+import SummaryDetail from './SummaryDetail';
 
 export default function Dashboard() {
   const { creditCards, latestCurrencyExchangeRates, defaultCurrency } = useLoaderData<typeof loader>();
   const defaultCurrencySymbol = defaultCurrency?.symbol ?? '$';
+  const navigate = useNavigate();
+  const isSummary = !!useMatch('/dashboard/summary');
 
   const tableClasses: string[] = [];
   const tableContainer = 'w-auto mb-4 overflow-hidden';
 
-  const debitModulePesos = '4c1ee918-e8f9-4bed-8301-b4126b56cfc0';
-  const debitModuleDollars = '03cc66c7-921c-4e05-810e-9764cd365c1d';
-
-  const debitModules = [debitModulePesos, debitModuleDollars];
-
-  const debitBackgroundClasses: Dictionary<string> = {};
-  debitBackgroundClasses[debitModulePesos] = 'bg-violet-500 text-white';
-  debitBackgroundClasses[debitModuleDollars] = 'bg-orange-500 text-white';
-
-  const debitTableNames: Dictionary<string> = {};
-  debitTableNames[debitModulePesos] = 'debit-pesos-table';
-  debitTableNames[debitModuleDollars] = 'debit-dollars-table';
-
-  const debitTableTitles: Dictionary<string> = {};
-  debitTableTitles[debitModulePesos] = 'Débitos Pesos';
-  debitTableTitles[debitModuleDollars] = 'Débitos Dólares';
-
-  const DebitTableSettings = {
-    columns: [
-      new FetchTableColumn('origin', 'Débito/Servicio', (record: unknown) =>
-        getOriginOrName(record)
-      ),
-      DecimalColumn('amount', 'Monto', (a: unknown) => getSafeValueFrom(a, 'amount')),
-    ],
-  };
-
-  const FundsTableSettings = {
-    columns: [
-      new FetchTableColumn('label', 'Origen'),
-      DecimalColumn('value', 'Monto', getSafeValue),
-    ],
-  };
-
-  const CurrencyExchangeRatesTableSettings = {
-    columns: [
-      new FetchTableColumn(
-        'label',
-        'Origen',
-        (v: unknown) => getNestedName(v, ['baseCurrency', 'name']),
-        (v: unknown) => getNestedName(v, ['baseCurrency', 'name'])
-      ),
-      new FetchTableColumn(
-        'label',
-        'Destino',
-        (v: unknown) => getNestedName(v, ['quoteCurrency', 'name']),
-        (v: unknown) => getNestedName(v, ['quoteCurrency', 'name'])
-      ),
-      DecimalColumn('value', 'Compra', (v: unknown) => getSafeValueFrom(safeProp(v, 'buyRate'))),
-      DecimalColumn('value', 'Venta', (v: unknown) => getSafeValueFrom(safeProp(v, 'sellRate'))),
-    ],
-  };
-
-  const SummaryTableSettings: {
-    columns: unknown[];
-  } = {
-    columns: [
-      new FetchTableColumn('label', 'Dato'),
-      DecimalColumn('value', 'Monto', getSafeValue),
-      DecimalColumn('convertedValue', `Monto (${defaultCurrencySymbol})`, (v: unknown) => getSafeValueFrom(v, 'convertedValue'))
-    ]
-  };
-
-  const ExpensesTableSettings = {
-    columns: [
-      new FetchTableColumn('label', 'Gasto/Servicio'),
-      DecimalColumn('value', `Monto (${defaultCurrencySymbol})`, getSafeValue),
-    ],
-  };
-
-  const InvestmentsTableSettings = {
-    columns: [
-      new FetchTableColumn('symbol', 'Activo', (record: unknown) =>
-        getNestedName(record, ['label'])
-      ),
-      DecimalColumn('averageReturn', 'Rend. prom.', (v: unknown) => {
-        const val = safeProp(v, 'averageReturn');
-        return typeof val === 'number' ? val : getSafeValueFrom(v);
-      }),
-      DecimalColumn('valued', 'Valorado', (v: unknown) => {
-        const val = safeProp(v, 'valued');
-        return typeof val === 'number' ? val : getSafeValueFrom(v);
-      }),
-      DecimalColumn('valuedDefaultCurrency', `Valorado (${defaultCurrencySymbol})`, (v: unknown) => {
-        const val = safeProp(v, 'valuedDefaultCurrency');
-        return typeof val === 'number' ? val : getSafeValueFrom(v);
-      }),
-    ],
-  };
-
-  const CreditCardTableSettings = {
-    columns: [
-      {
-        id: 'timestamp',
-        label: 'Fecha',
-        mapper: (v: unknown) => {
-          const date = safeProp(v, 'timestamp') as string;
-          return date ? new Date(date).toLocaleDateString() : '';
-        },
-      },
-      {
-        id: 'concept',
-        label: 'Concepto',
-      },
-      DecimalColumn('amount', 'Monto', (v: unknown) =>
-        toNumber(safeProp(v, 'amount') as ValueLike, 0)
-      ),
-      DecimalColumn('amountDollars', 'Dólares', (v: unknown) =>
-        toNumber(safeProp(v, 'amountDollars') as ValueLike, 0)
-      ),
-      DecimalColumn(
-        'totalAmount',
-        'Total',
-        (v: unknown) => {
-          if (v) {
-            const amount = toNumber(safeProp(v, 'amount') as ValueLike, 0);
-            const amountDollars = toNumber(safeProp(v, 'amountDollars') as ValueLike, 0);
-            return amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
-          }
-
-          return 0;
-        },
-        (acc: number, v: unknown) => {
-          if (v) {
-            const amount = toNumber(safeProp(v, 'amount') as ValueLike, 0);
-            const amountDollars = toNumber(safeProp(v, 'amountDollars') as ValueLike, 0);
-            return acc + (amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates));
-          }
-
-          return acc;
-        }
-      ),
-    ],
-  };
+  const summaryColumns = buildSummaryColumns(defaultCurrencySymbol);
+  const investmentsColumns = buildInvestmentsColumns(defaultCurrencySymbol);
+  const fundsColumns = buildFundsColumns(defaultCurrencySymbol);
+  const expensesColumns = buildExpensesColumns(defaultCurrencySymbol);
+  const debitColumns = buildDebitColumns();
+  const currencyRatesColumns = buildCurrencyRatesColumns();
+  const creditCardColumns = buildCreditCardColumns(latestCurrencyExchangeRates);
 
   return (
     <>
@@ -245,166 +43,121 @@ export default function Dashboard() {
       <main>
         <section id="expenses-actions">
           <div className="container-fluid mt-4 ml-4 mr-4">
-            <div className="grid grid-cols-3 gap-4">
-              <div id="investments-section" className="column flex-wrap justify-content-center">
-                {urls.summary.currentInvestments && (
-                  <FetchTable
-                    name={`Investments`}
-                    title={{
-                      text: `Inversiones`,
-                      class: `text-center medium bg-purple-500 text-white`,
-                    }}
-                    url={urls.summary.currentInvestments}
-                    columns={InvestmentsTableSettings.columns as unknown as unknown[]}
-                    classes={tableClasses}
-                  />
-                )}
-                {!urls.summary.currentFunds && <div>AASAS</div>}
-              </div>
-              <div id="summary-section" className="column flex-wrap">
-                {urls.summary.general && (
-                  <div className={tableContainer}>
-                    <FetchTable
-                      name={`Summary`}
-                      title={{
-                        text: `Resúmen`,
-                        class: `text-center bg-blue-500 text-white`,
-                      }}
-                      url={urls.summary.general.with({ DailyUse: true })}
-                      columns={SummaryTableSettings.columns}
-                      classes={tableClasses}
-                      showTotals={false}
-                    />
+            {isSummary ? (
+              <SummaryDetail
+                onClose={() => navigate('/dashboard')}
+                tableClasses={tableClasses}
+                tableContainer={tableContainer}
+                defaultCurrencySymbol={defaultCurrencySymbol}
+              />
+            ) : (
+              <div className="grid grid-cols-5 gap-4">
+                <div id="investments-section" className="column flex-wrap justify-content-center">
+                  {urls.currencyExchangeRates.latest && (
+                    <div className={tableContainer}>
+                      <FetchTable
+                        name="CurrencyRates"
+                        title={{ text: `Conversiones de moneda`, class: `text-center bg-sky-500 text-white` }}
+                        url={urls.currencyExchangeRates.latest}
+                        columns={currencyRatesColumns}
+                        classes={tableClasses}
+                        showTotals={false}
+                        collapsible
+                      />
+                    </div>
+                  )}
+                  {!urls.summary.currentFunds && <div>AASAS</div>}
+                </div>
+                <div id="summary-section" className="col-span-2 column flex-wrap">
+                  {urls.summary.general && (
+                    <div className={tableContainer}>
+                      <FetchTable
+                        name="Summary"
+                        title={{ text: `Resúmen`, class: `text-center bg-blue-500 text-white` }}
+                        url={urls.summary.general.with({ DailyUse: true })}
+                        columns={summaryColumns}
+                        classes={tableClasses}
+                        showTotals={false}
+                        collapsible
+                      />
+                    </div>
+                  )}
+                  <div className="flex justify-center mt-2 mb-4">
+                    <CustomButton onClick={() => navigate('/dashboard/summary')} className="bg-blue-500 text-white hover:bg-blue-600">
+                      Ver más
+                    </CustomButton>
                   </div>
-                )}
-                {urls.summary.totalExpenses && (
-                  <div className={tableContainer}>
-                    <FetchTable
-                      name={`Expenses`}
-                      title={{
-                        text: `Gastos`,
-                        class: `text-center bg-red-500 text-white`,
-                      }}
-                      url={urls.summary.totalExpenses}
-                      columns={ExpensesTableSettings.columns}
-                      classes={tableClasses}
-                    />
-                  </div>
-                )}
-                {urls.currencyExchangeRates.latest && (
-                  <div className={tableContainer}>
-                    <FetchTable
-                      name={`CurrencyRates`}
-                      title={{
-                        text: `Conversiones de moneda`,
-                        class: `text-center bg-sky-500 text-white`,
-                      }}
-                      url={urls.currencyExchangeRates.latest}
-                      columns={CurrencyExchangeRatesTableSettings.columns}
-                      classes={tableClasses}
-                      showTotals={false}
-                    />
-                  </div>
-                )}
-                {urls.summary.currentFunds && (
-                  <div className={tableContainer}>
-                    <FetchTable
-                      name={`Funds`}
-                      title={{
-                        text: `Fondos`,
-                        class: `text-center bg-indigo-500 text-white`,
-                      }}
-                      url={urls.summary.currentFunds.with({ DailyUse: true })}
-                      columns={FundsTableSettings.columns}
-                      classes={tableClasses}
-                    />
-                  </div>
-                )}
-                {urls.summary.currentFunds && (
-                  <div className={tableContainer}>
-                    <FetchTable
-                      name={`OtherFunds`}
-                      title={{
-                        text: `Otros Fondos`,
-                        class: `text-center bg-indigo-500 text-white`,
-                      }}
-                      url={urls.summary.currentFunds.with({ DailyUse: false })}
-                      columns={FundsTableSettings.columns}
-                      classes={tableClasses}
-                    />
-                  </div>
-                )}
-                {debitModules && (
+                  {urls.summary.totalExpenses && (
+                    <div className={tableContainer}>
+                      <FetchTable
+                        name="Expenses"
+                        title={{ text: `Gastos`, class: `text-center bg-red-500 text-white` }}
+                        url={urls.summary.totalExpenses}
+                        columns={expensesColumns}
+                        classes={tableClasses}
+                        collapsible
+                      />
+                    </div>
+                  )}
                   <div className={tableContainer}>
                     {urls.debits.monthly.latest &&
-                      debitModules.map((appModuleId) => {
+                      DEBIT_MODULES.map((appModuleId) => {
                         const url = urls.debits.monthly.latest.with({
                           AppModuleId: appModuleId,
                           IncludeDeactivated: false,
                         });
-                        const bgClass = debitBackgroundClasses[appModuleId];
-                        const tableName = debitTableNames[appModuleId];
-                        const title = debitTableTitles[appModuleId];
-
                         return (
                           <FetchTable
                             key={appModuleId}
-                            name={`${tableName}`}
+                            name={DEBIT_TABLE_NAMES[appModuleId]}
                             title={{
-                              text: title,
-                              class: `text-center ${bgClass}`,
+                              text: DEBIT_TABLE_TITLES[appModuleId],
+                              class: `text-center ${DEBIT_BACKGROUND_CLASSES[appModuleId]}`,
                             }}
                             url={url}
-                            columns={DebitTableSettings.columns as unknown as unknown[]}
+                            columns={debitColumns as unknown as unknown[]}
                             classes={tableClasses}
                             hideIfEmpty={true}
-                            wrapper={{
-                              classes: tableContainer.split(' '),
-                            }}
+                            wrapper={{ classes: tableContainer.split(' ') }}
+                            collapsible
                           />
                         );
                       })}
                   </div>
-                )}
+                </div>
+                <div id="credit-cards-section" className="col-span-2 justify-content-center">
+                  {creditCards &&
+                    creditCards.map((c: unknown, _index: number) => {
+                      const data = c as { id?: string; name?: string; bank?: { name?: string } };
+                      const url = urls.creditCardMovements.latest.with({
+                        CreditCardId: data.id,
+                        Page: 1,
+                        PageSize: 10,
+                      });
+                      const idx =
+                        _index < backgroundClasses.length
+                          ? _index
+                          : backgroundClasses.length - _index - 1;
+                      return (
+                        <FetchTable
+                          name={`${data.name}-${data.bank?.name}-table`}
+                          key={_index}
+                          title={{
+                            text: `${data.name} ${data.bank?.name}`,
+                            class: `text-center ${backgroundClasses[idx]} text-white`,
+                          }}
+                          url={url}
+                          columns={creditCardColumns as unknown as unknown[]}
+                          classes={tableClasses}
+                          hideIfEmpty={true}
+                          wrapper={{ classes: tableContainer.split(' ') }}
+                          collapsible
+                        />
+                      );
+                    })}
+                </div>
               </div>
-              <div id="credit-cards-section" className="justify-content-center">
-                {creditCards &&
-                  creditCards.map((c: unknown, _index: number) => {
-                    const data = c as {
-                      id?: string;
-                      name?: string;
-                      bank?: { name?: string };
-                    };
-                    const url = urls.creditCardMovements.latest.with({
-                      CreditCardId: data.id,
-                      Page: 1,
-                      PageSize: 10,
-                    });
-                    const idx =
-                      _index < backgroundClasses.length
-                        ? _index
-                        : backgroundClasses.length - _index - 1;
-                    const bgClass = backgroundClasses[idx];
-                    return (
-                      <FetchTable
-                        name={`${data.name}-${data.bank?.name}-table`}
-                        key={_index}
-                        title={{
-                          text: `${data.name} ${data.bank?.name}`,
-                          class: `text-center ${bgClass} text-white`,
-                        }}
-                        url={url}
-                        columns={CreditCardTableSettings.columns as unknown as unknown[]}
-                        classes={tableClasses}
-                        hideIfEmpty={true}
-                        wrapper={{
-                          classes: tableContainer.split(' '),
-                        }}
-                      />
-                    );
-                  })}
-              </div>
-            </div>
+            )}
           </div>
         </section>
       </main>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -94,10 +94,11 @@ export default function Dashboard() {
                         url={urls.summary.totalExpenses}
                         columns={expensesColumns}
                         classes={tableClasses}
-                        collapsible
-                        collapsedSummary={(rows) => {
-                          const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'value'), 0);
-                          return `Gastos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                        collapsible={{
+                          summary: (rows) => {
+                            const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'value'), 0);
+                            return `Gastos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                          }
                         }}
                       />
                     </div>
@@ -122,10 +123,11 @@ export default function Dashboard() {
                             classes={tableClasses}
                             hideIfEmpty={true}
                             wrapper={{ classes: tableContainer.split(' ') }}
-                            collapsible
-                            collapsedSummary={(rows) => {
-                              const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
-                              return `${DEBIT_TABLE_TITLES[appModuleId]}: ${moneyFormatter(total)}`;
+                            collapsible={{
+                              summary: (rows) => {
+                                const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
+                                return `${DEBIT_TABLE_TITLES[appModuleId]}: ${moneyFormatter(total)}`;
+                              }
                             }}
                           />
                         );
@@ -158,16 +160,17 @@ export default function Dashboard() {
                           classes={tableClasses}
                           hideIfEmpty={true}
                           wrapper={{ classes: tableContainer.split(' ') }}
-                          collapsible
-                          collapsedSummary={(rows) => {
-                            const totalPesos = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
-                            const totalDollars = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amountDollars'), 0);
-                            const total = rows.reduce((acc, r) => {
-                              const amount = getSafeValueFrom(r, 'amount');
-                              const amountDollars = getSafeValueFrom(r, 'amountDollars');
-                              return acc + amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
-                            }, 0);
-                            return `${data.name}: $${moneyFormatter(totalPesos)} | USD ${moneyFormatter(totalDollars)} | ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                          collapsible={{
+                            summary: (rows) => {
+                              const totalPesos = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
+                              const totalDollars = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amountDollars'), 0);
+                              const total = rows.reduce((acc, r) => {
+                                const amount = getSafeValueFrom(r, 'amount');
+                                const amountDollars = getSafeValueFrom(r, 'amountDollars');
+                                return acc + amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
+                              }, 0);
+                              return `${data.name}: $${moneyFormatter(totalPesos)} | USD ${moneyFormatter(totalDollars)} | ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                            }
                           }}
                         />
                       );

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -15,6 +15,9 @@ import {
   DEBIT_MODULES,
   DEBIT_TABLE_NAMES,
   DEBIT_TABLE_TITLES,
+  dollarCalculator,
+  getSafeValueFrom,
+  moneyFormatter,
 } from './dashboardHelpers';
 import SummaryDetail from './SummaryDetail';
 
@@ -92,6 +95,10 @@ export default function Dashboard() {
                         columns={expensesColumns}
                         classes={tableClasses}
                         collapsible
+                        collapsedSummary={(rows) => {
+                          const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'value'), 0);
+                          return `Gastos: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                        }}
                       />
                     </div>
                   )}
@@ -116,6 +123,10 @@ export default function Dashboard() {
                             hideIfEmpty={true}
                             wrapper={{ classes: tableContainer.split(' ') }}
                             collapsible
+                            collapsedSummary={(rows) => {
+                              const total = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
+                              return `${DEBIT_TABLE_TITLES[appModuleId]}: ${moneyFormatter(total)}`;
+                            }}
                           />
                         );
                       })}
@@ -148,6 +159,16 @@ export default function Dashboard() {
                           hideIfEmpty={true}
                           wrapper={{ classes: tableContainer.split(' ') }}
                           collapsible
+                          collapsedSummary={(rows) => {
+                            const totalPesos = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
+                            const totalDollars = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amountDollars'), 0);
+                            const total = rows.reduce((acc, r) => {
+                              const amount = getSafeValueFrom(r, 'amount');
+                              const amountDollars = getSafeValueFrom(r, 'amountDollars');
+                              return acc + amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
+                            }, 0);
+                            return `${data.name}: $${moneyFormatter(totalPesos)} | USD ${moneyFormatter(totalDollars)} | ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                          }}
                         />
                       );
                     })}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -10,8 +10,6 @@ import {
   buildCurrencyRatesColumns,
   buildDebitColumns,
   buildExpensesColumns,
-  buildFundsColumns,
-  buildInvestmentsColumns,
   buildSummaryColumns,
   DEBIT_BACKGROUND_CLASSES,
   DEBIT_MODULES,
@@ -30,8 +28,6 @@ export default function Dashboard() {
   const tableContainer = 'w-auto mb-4 overflow-hidden';
 
   const summaryColumns = buildSummaryColumns(defaultCurrencySymbol);
-  const investmentsColumns = buildInvestmentsColumns(defaultCurrencySymbol);
-  const fundsColumns = buildFundsColumns(defaultCurrencySymbol);
   const expensesColumns = buildExpensesColumns(defaultCurrencySymbol);
   const debitColumns = buildDebitColumns();
   const currencyRatesColumns = buildCurrencyRatesColumns();

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
@@ -320,6 +320,9 @@ const FetchTable: React.FC<FetchTableProps> = ({
             <div
               className={`h-10 px-2 flex items-center justify-center font-medium cursor-pointer select-none relative ${title.class ?? ''}`}
               onClick={() => setCollapsed((c) => !c)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setCollapsed((c) => !c); }}
+              role="button"
+              tabIndex={0}
             >
               {collapsed && collapsedSummary && data ? collapsedSummary(data) : title.text}
               <span className="absolute right-2">

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import SafeLogger from '@/utils/SafeLogger';
 import type { BackendUrl } from '@/utils/BackendUrl';
 import dates from '@/utils/dates';
@@ -53,6 +54,9 @@ interface FetchTableProps {
   hideIfEmpty?: boolean;
   onFetch?: (data: Row[]) => void;
   showTotals?: boolean;
+  collapsible?: boolean;
+  collapsed?: boolean;
+  collapsedSummary?: (data: Row[]) => React.ReactNode;
 }
 
 interface FetchTableRowProps {
@@ -71,10 +75,14 @@ const FetchTable: React.FC<FetchTableProps> = ({
   onFetch,
   showTotals = true,
   hideIfEmpty = false,
+  collapsible = false,
+  collapsed: initialCollapsed = false,
+  collapsedSummary,
 }) => {
   const [data, setData] = useState<Row[] | null>(initialData ?? null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(initialCollapsed);
 
   // Sync with initialData prop changes when data is passed directly
   useEffect(() => {
@@ -210,10 +218,10 @@ const FetchTable: React.FC<FetchTableProps> = ({
     );
   };
 
-  const Content = () => (
+  const TableContent = () => (
     <Table>
       <TableHeader id={name} className={[...(classes ?? [])].join(' ')}>
-        {title && (
+        {!collapsible && title && (
           <TableRow>
             <TableHead colSpan={columns.length} className={title.class}>
               {title.text}
@@ -303,6 +311,36 @@ const FetchTable: React.FC<FetchTableProps> = ({
       )}
     </Table>
   );
+
+  const Content = () => {
+    if (collapsible) {
+      return (
+        <div>
+          {title && (
+            <div
+              className={`h-10 px-2 flex items-center justify-center font-medium cursor-pointer select-none relative ${title.class ?? ''}`}
+              onClick={() => setCollapsed((c) => !c)}
+            >
+              {collapsed && collapsedSummary && data ? collapsedSummary(data) : title.text}
+              <span className="absolute right-2">
+                {collapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+              </span>
+            </div>
+          )}
+          <div
+            className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${
+              collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
+            }`}
+          >
+            <div className="overflow-hidden min-h-0">
+              <TableContent />
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return <TableContent />;
+  };
 
   return wrapper ? (
     <div className={wrapper.classes?.join(' ')}>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
@@ -54,9 +54,7 @@ interface FetchTableProps {
   hideIfEmpty?: boolean;
   onFetch?: (data: Row[]) => void;
   showTotals?: boolean;
-  collapsible?: boolean;
-  collapsed?: boolean;
-  collapsedSummary?: (data: Row[]) => React.ReactNode;
+  collapsible?: boolean | { defaultCollapsed?: boolean; summary?: (data: Row[]) => React.ReactNode };
 }
 
 interface FetchTableRowProps {
@@ -75,14 +73,15 @@ const FetchTable: React.FC<FetchTableProps> = ({
   onFetch,
   showTotals = true,
   hideIfEmpty = false,
-  collapsible = false,
-  collapsed: initialCollapsed = false,
-  collapsedSummary,
+  collapsible,
 }) => {
+  const isCollapsible = !!collapsible;
+  const defaultCollapsed = typeof collapsible === 'object' ? (collapsible.defaultCollapsed ?? false) : false;
+  const collapsedSummary = typeof collapsible === 'object' ? collapsible.summary : undefined;
   const [data, setData] = useState<Row[] | null>(initialData ?? null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState(initialCollapsed);
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
 
   // Sync with initialData prop changes when data is passed directly
   useEffect(() => {
@@ -221,7 +220,7 @@ const FetchTable: React.FC<FetchTableProps> = ({
   const TableContent = () => (
     <Table>
       <TableHeader id={name} className={[...(classes ?? [])].join(' ')}>
-        {!collapsible && title && (
+        {!isCollapsible && title && (
           <TableRow>
             <TableHead colSpan={columns.length} className={title.class}>
               {title.text}
@@ -313,7 +312,7 @@ const FetchTable: React.FC<FetchTableProps> = ({
   );
 
   const Content = () => {
-    if (collapsible) {
+    if (isCollapsible) {
       return (
         <div>
           {title && (

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/PaginatedTable.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import type { Settings as InputControlSettings } from '@/components/ui/utils/InputControl';
 import { Form } from '@/components/ui/utils/Form';
 import dates from '@/utils/dates';
@@ -102,6 +103,8 @@ export interface PaginatedTableProps<T extends Row = Row> {
   onAdd?: (data: unknown) => void;
   onDelete?: (data: unknown) => void;
   reloadData?: number;
+  title?: { text: React.ReactNode; class?: string } | null;
+  collapsible?: boolean | { defaultCollapsed?: boolean; summary?: (data: T[]) => React.ReactNode };
 }
 
 function PaginatedTable<T extends Row = Row>({
@@ -114,7 +117,12 @@ function PaginatedTable<T extends Row = Row>({
   onAdd,
   onDelete,
   reloadData,
+  title,
+  collapsible,
 }: PaginatedTableProps<T>) {
+  const isCollapsible = !!collapsible;
+  const defaultCollapsed = typeof collapsible === 'object' ? (collapsible.defaultCollapsed ?? false) : false;
+  const collapsedSummary = typeof collapsible === 'object' ? collapsible.summary : undefined;
   const [tableData, setTableData] = useState<Data<T>>({
     items: [],
     totalPages: 0,
@@ -128,6 +136,7 @@ function PaginatedTable<T extends Row = Row>({
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [loading, setLoading] = useState(!url ? false : true);
   const [reloadFlag, setReloadFlag] = useState(!url ? false : true);
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
   useEffect(() => {
     if (reloadData) setReloadFlag(true);
@@ -488,8 +497,9 @@ function PaginatedTable<T extends Row = Row>({
   const adminEnabled = adminAddEnabled || adminDeletedEnabled;
   const visibleColumns = columns.filter((c) => c.visible !== false);
   const columnCount = visibleColumns.length + (adminEnabled ? 2 : 0);
+  const currentItems = data?.items ?? tableData.items;
 
-  return (
+  const tableContent = (
     <div className="paginated-Table">
       <Form>
         <Table id={name}>
@@ -555,6 +565,38 @@ function PaginatedTable<T extends Row = Row>({
         title="Confirmar eliminación"
         text="¿Estás seguro de que deseas eliminar los elementos seleccionados?"
       />
+    </div>
+  );
+
+  if (!isCollapsible) return tableContent;
+
+  return (
+    <div>
+      {title && (
+        <div
+          className={`h-10 px-2 flex items-center justify-center font-medium cursor-pointer select-none relative ${title.class ?? ''}`}
+          onClick={() => setIsCollapsed((c) => !c)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') setIsCollapsed((c) => !c);
+          }}
+          role="button"
+          tabIndex={0}
+        >
+          {isCollapsed && collapsedSummary ? collapsedSummary(currentItems) : title.text}
+          <span className="absolute right-2">
+            {isCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+          </span>
+        </div>
+      )}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${
+          isCollapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
+        }`}
+      >
+        <div className="overflow-hidden min-h-0">
+          {tableContent}
+        </div>
+      </div>
     </div>
   );
 }

--- a/FinanceFrontEnd/FinanceApp/app/routes/dashboard.summary.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/dashboard.summary.tsx
@@ -1,0 +1,5 @@
+// Route exists to make /dashboard/summary a bookmarkable URL.
+// The parent Dashboard layout drives rendering via useMatch.
+export default function DashboardSummary() {
+  return null;
+}

--- a/FinanceFrontEnd/FinanceApp/app/utils/SafeLogger.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/SafeLogger.ts
@@ -50,6 +50,10 @@ const SafeLogger = {
         // Always print errors so they are visible in server logs
         console.error(message, ...args.map(redact));
     },
+    debug: (message?: unknown, ...args: unknown[]) => {
+        if (!isDev) return;
+        console.warn(message, ...args.map(redact));
+    },
 };
 
 export default SafeLogger;


### PR DESCRIPTION
# Why

The dashboard was a single dense view mixing summary totals, debits, credit cards, and currency rates in a flat 3-column grid. There was no way to drill into the full detail of investments, funds, and summary breakdowns without leaving the page. This feature adds a compact collapsible overview mode and a navigable summary detail panel so users can quickly scan the dashboard and expand into full detail on demand.

## What is the solution?

- **Dashboard refactored to a 5-column grid** with collapsible FetchTable panels for currency rates, summary, expenses, debits, and credit cards.
- **dashboardHelpers.ts** — extracts all column-builder functions and constants (background classes, debit module IDs/titles) out of the component, reducing Dashboard/index.tsx from ~400 to ~160 lines.
- **SummaryDetail.tsx** — new component that renders the full expanded view: investments, daily-use funds, other funds, and full summary. Shown in-place within the parent Dashboard layout.
- **dashboard.summary.tsx** — registers the `/dashboard/summary` route so it is bookmarkable. Renders null; the parent Dashboard layout drives content via `useMatch('/dashboard/summary')`.
- **"Ver mas" / "Ver menos" buttons** — navigate between compact and full modes using React Router `useNavigate`.
- **FetchTable collapsible prop** — adds `collapsible`, `collapsed` (initial state), and `collapsedSummary` props. The header row becomes a clickable chevron toggle; the table body animates open/closed using a CSS `grid-template-rows` transition.
- **collapsedSummary on each table** — when collapsed, each table header shows a live total in the title bar:
  - Gastos: total in default currency
  - Debitos: total amount per module
  - Credit cards: pesos total | USD total | combined total
  - Funds and Investments: totals in default currency (in SummaryDetail)
- **SafeLogger.debug()** — new method that proxies to `console.warn` in dev mode only.

## What areas of the site does it impact?

- **Dashboard page** (`/dashboard`, `/dashboard/summary`) — layout, navigation, and data display
- **FetchTable component** — all existing usages are unaffected (collapsible defaults to false); any consumer can opt into the new collapsible behaviour
- **SafeLogger** — additive only, no breaking changes

## Test scenarios

```gherkin
Scenario: Dashboard compact view shows collapsible tables
  Given the user navigates to /dashboard
  Then the summary, expenses, debit, credit card, and currency rate tables are visible and expanded by default
  When the user clicks a table header
  Then the table collapses with an animation and a ChevronDown icon appears

Scenario: Collapsed table shows totals in the header
  Given a collapsible table with data is expanded
  When the user collapses it
  Then the header displays the computed total(s) inline

Scenario: Navigate to summary detail
  Given the user is on /dashboard
  When the user clicks "Ver mas"
  Then they are navigated to /dashboard/summary
  And the SummaryDetail panel shows investments, funds, and full summary tables

Scenario: Return to compact view
  Given the user is on /dashboard/summary
  When the user clicks "Ver menos"
  Then they are navigated back to /dashboard
  And the compact 5-column grid is shown

Scenario: /dashboard/summary is bookmarkable
  Given the user opens /dashboard/summary directly in the browser
  Then the SummaryDetail panel renders correctly via the parent Dashboard layout

Scenario: FetchTable without collapsible behaves as before
  Given a FetchTable rendered without the collapsible prop
  Then it renders exactly as it did before (no chevron, no toggle, no animation)
```

## Other Notes

Closes #123