### PR TITLE
docs: add pre-push lint step to PR workflow skills

### DIFF
--- a/.github/skills/gh-bug-fix-pr/SKILL.md
+++ b/.github/skills/gh-bug-fix-pr/SKILL.md
@@ -77,7 +77,27 @@ Closes #<issue-number>"
 
 Do NOT stage files outside the paths the user specified.
 
-### 5 — Publish the branch
+### 5 — Run lint before pushing
+
+If any of the changed files are frontend (TypeScript/TSX/JS under `FinanceFrontEnd/`), run lint from the relevant app directory and fix any errors before proceeding. Do **not** push if lint fails.
+
+```powershell
+# For FinanceApp changes:
+cd FinanceFrontEnd/FinanceApp; npm run lint
+
+# For FinanceFunds changes:
+cd FinanceFrontEnd/FinanceFunds; npm run lint
+```
+
+If `lint:fix` is available and there are auto-fixable errors, run it and amend the commit:
+
+```powershell
+npm run lint:fix
+git add <affected-files>
+git commit --amend --no-edit
+```
+
+### 6 — Publish the branch
 
 ```powershell
 git push -u origin fix/<short-slug>

--- a/.github/skills/gh-docs-pr/SKILL.md
+++ b/.github/skills/gh-docs-pr/SKILL.md
@@ -77,7 +77,27 @@ Closes #<issue-number>"
 
 Do NOT stage files outside the paths the user specified.
 
-### 5 — Publish the branch
+### 5 — Run lint before pushing
+
+If any of the changed files are frontend (TypeScript/TSX/JS under `FinanceFrontEnd/`), run lint from the relevant app directory and fix any errors before proceeding. Do **not** push if lint fails.
+
+```powershell
+# For FinanceApp changes:
+cd FinanceFrontEnd/FinanceApp; npm run lint
+
+# For FinanceFunds changes:
+cd FinanceFrontEnd/FinanceFunds; npm run lint
+```
+
+If `lint:fix` is available and there are auto-fixable errors, run it and amend the commit:
+
+```powershell
+npm run lint:fix
+git add <affected-files>
+git commit --amend --no-edit
+```
+
+### 6 — Publish the branch
 
 ```powershell
 git push -u origin docs/<short-slug>

--- a/.github/skills/gh-feature-pr/SKILL.md
+++ b/.github/skills/gh-feature-pr/SKILL.md
@@ -77,7 +77,27 @@ Closes #<issue-number>"
 
 Do NOT stage files outside the paths the user specified.
 
-### 5 — Publish the branch
+### 5 — Run lint before pushing
+
+If any of the changed files are frontend (TypeScript/TSX/JS under `FinanceFrontEnd/`), run lint from the relevant app directory and fix any errors before proceeding. Do **not** push if lint fails.
+
+```powershell
+# For FinanceApp changes:
+cd FinanceFrontEnd/FinanceApp; npm run lint
+
+# For FinanceFunds changes:
+cd FinanceFrontEnd/FinanceFunds; npm run lint
+```
+
+If `lint:fix` is available and there are auto-fixable errors, run it and amend the commit:
+
+```powershell
+npm run lint:fix
+git add <affected-files>
+git commit --amend --no-edit
+```
+
+### 6 — Publish the branch
 
 ```powershell
 git push -u origin feature/<short-slug>


### PR DESCRIPTION
# Why

The three PR workflow skills (`gh-bug-fix-pr`, `gh-docs-pr`, `gh-feature-pr`) lacked a lint gate before pushing. This meant frontend changes could be committed and pushed with linting errors, causing CI failures or dirty PRs.

## What is the solution?

A new Step 5 — "Run lint before pushing" — was inserted into all three SKILL.md files. It:

- Detects whether any changed files are frontend files (TypeScript/TSX/JS under `FinanceFrontEnd/`)
- Runs `npm run lint` from the relevant app directory (`FinanceApp` or `FinanceFunds`)
- Blocks the push if lint fails
- If `lint:fix` is available and errors are auto-fixable, runs it and amends the commit before pushing

The previous Step 5 (Publish the branch) was renumbered to Step 6 in all three skills.

## What areas of the site does it impact?

Affects the AI agent workflow skills used when shipping feature, bug-fix, and docs PRs. No runtime code is changed — only the skill instruction files that guide the coding agent.

## Test scenarios

```gherkin
Scenario: Frontend files changed, lint passes
  Given a PR skill workflow is invoked with frontend file changes
  When Step 5 runs npm run lint
  Then lint exits cleanly and the branch is pushed

Scenario: Frontend files changed, lint fails with auto-fixable errors
  Given a PR skill workflow is invoked with frontend file changes
  When Step 5 runs npm run lint and detects errors
  Then lint:fix is run, the commit is amended, and the branch is pushed

Scenario: No frontend files changed
  Given a PR skill workflow is invoked with only backend or doc changes
  When Step 5 is evaluated
  Then the lint step is skipped and the branch is pushed directly
```

## Other Notes

Closes #125