### PR TITLE
feat: credit card statement detail with transaction management

### DIFF
--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardMovementCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardMovementCommandController.cs
@@ -19,6 +19,10 @@ public class CreditCardTransactionCommandController(IMappingService mapper, IDis
     public async Task<IActionResult> Create(CreateCreditCardTransactionCommand request)
         => await ExecuteAsync(request);
 
+    [HttpPut]
+    public async Task<IActionResult> Update(UpdateCreditCardTransactionCommand request)
+        => await ExecuteAsync(request);
+
     [HttpDelete]
     public async Task<IActionResult> Delete(DeleteCreditCardTransactionCommand request)
         => await ExecuteAsync(request);

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardTransactionCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardTransactionCommand.cs
@@ -40,7 +40,25 @@ public class CreateCreditCardTransactionCommandHandler : BaseCommandHandler<Crea
             Deactivated = command.Deactivated
         };
 
-        await transactionRepository.AddAsync(newTransaction, cancellationToken);
+        if (command.CreditCardStatementId.HasValue)
+        {
+            await transactionRepository.AddAsync(newTransaction, cancellationToken);
+
+            var statementTx = new CreditCardStatementTransaction
+            {
+                StatementId = command.CreditCardStatementId.Value,
+                CreditCardTransactionId = newTransaction.Id,
+                PostedDate = newTransaction.Timestamp,
+                Amount = newTransaction.Amount,
+                Description = newTransaction.Concept
+            };
+            DbContext.Add(statementTx);
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+        else
+        {
+            await transactionRepository.AddAsync(newTransaction, cancellationToken);
+        }
 
         return DataResult<CreditCardTransaction>.Success(newTransaction);
     }
@@ -50,6 +68,8 @@ public class CreateCreditCardTransactionCommand : ICommand
 {
     [Required]
     public Guid CreditCardId { get; set; }
+
+    public Guid? CreditCardStatementId { get; set; }
 
     [Required]
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardTransactionCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardTransactionCommand.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.SpecialTypes;
+using Finance.Persistence;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class UpdateCreditCardTransactionCommandHandler(
+    IRepository<CreditCardTransaction, Guid> transactionRepository,
+    FinanceDbContext db)
+    : BaseUpdateCommandHandler<CreditCardTransaction, Guid, UpdateCreditCardTransactionCommand>(
+        transactionRepository, db)
+{
+    protected override Task<CreditCardTransaction> UpdateRecord(
+        UpdateCreditCardTransactionCommand command,
+        CreditCardTransaction record,
+        CancellationToken cancellationToken)
+    {
+        record.Timestamp = command.Timestamp;
+        record.Concept = command.Concept;
+        record.Amount = command.Amount;
+        return Task.FromResult(record);
+    }
+}
+
+public class UpdateCreditCardTransactionCommand : BaseUpdateCommand<CreditCardTransaction, Guid>
+{
+    [Required]
+    public DateTime Timestamp { get; set; }
+    [Required]
+    [StringLength(500)]
+    public string Concept { get; set; } = string.Empty;
+    [Required]
+    public Money Amount { get; set; } = 0;
+}
+
+public class UpdateCreditCardTransactionCommandValidator
+    : BaseUpdateCommandValidator<UpdateCreditCardTransactionCommand, CreditCardTransaction, Guid>
+{
+    public UpdateCreditCardTransactionCommandValidator(
+        IRepository<CreditCardTransaction, Guid> repository)
+        : base(repository)
+    {
+    }
+}

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementsQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementsQuery.cs
@@ -42,5 +42,5 @@ public class GetCreditCardStatementQueryHandler : BaseCollectionQueryHandler<Get
 
 public class GetCreditCardStatementsQuery : GetAllQuery<CreditCardStatement>
 {
-    public Guid? CreditCardId { get; private set; }
+    public Guid? CreditCardId { get; set; }
 }

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardTransactionsQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardTransactionsQuery.cs
@@ -22,6 +22,16 @@ public class GetCreditCardTransactionsQueryHandler : BaseCollectionQueryHandler<
                 .ThenInclude(o => o.Bank)
             .AsQueryable();
 
+        if (request.StatementId.HasValue)
+        {
+            var transactionIds = await DbContext.CreditCardStatementTransaction
+                .Where(st => st.StatementId == request.StatementId.Value && st.CreditCardTransactionId != null)
+                .Select(st => st.CreditCardTransactionId!.Value)
+                .ToListAsync(cancellationToken);
+
+            query = query.Where(o => transactionIds.Contains(o.Id));
+        }
+
         if (request.CreditCardId.HasValue)
         {
             query = query.Where(o => o.CreditCardId == request.CreditCardId.Value);
@@ -42,8 +52,6 @@ public class GetCreditCardTransactionsQueryHandler : BaseCollectionQueryHandler<
             query = query.Where(o => !o.Deactivated);
         }
 
-        var data = await query.ToListAsync();
-
         return DataResult<List<CreditCardTransaction>>.Success(
             await query
                 .OrderByDescending(o => o.Timestamp)
@@ -57,6 +65,8 @@ public class GetCreditCardTransactionsQueryHandler : BaseCollectionQueryHandler<
 public class GetCreditCardTransactionsQuery : GetAllQuery<CreditCardTransaction>
 {
     public Guid? CreditCardId { get; set; }
+
+    public Guid? StatementId { get; set; }
 
     /// <summary>
     /// Gets or sets date to filter from. Format: YYYY-MM-DDTHH:mm:ss.sssZ.

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQuery.cs
@@ -20,12 +20,14 @@ public class GetLatestCreditCardTransactionsFromStatementsQueryHandler : BaseCol
         List<CreditCardTransaction> result;
         try
         {
-            // Get the latest statement IDs for each credit card (or specific card if requested)
-            var latestStatementIds = await DbContext.CreditCard
-                .Where(cc => !cc.Deactivated)
-                .Where(cc => !request.CreditCardId.HasValue || cc.Id == request.CreditCardId.Value)
-                .Select(cc => cc.CurrentStatementId)
-                .Where(statementId => statementId != null)
+            var statementsQuery = DbContext.CreditCardStatement
+                .Where(s => !s.Deactivated)
+                .Where(s => !request.CreditCardId.HasValue || s.CreditCardId == request.CreditCardId.Value)
+                .AsQueryable();
+
+            var latestStatementIds = await statementsQuery
+                .GroupBy(s => s.CreditCardId)
+                .Select(g => g.OrderByDescending(s => s.ClosureDate).First().Id)
                 .ToListAsync(cancellationToken);
 
             if (!latestStatementIds.Any())

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardTransactionCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardTransactionCommandHandlerTests.cs
@@ -1,0 +1,109 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.SpecialTypes;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class CreateCreditCardTransactionCommandHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IRepository<CreditCard, Guid>> _creditCardRepo;
+    private readonly Mock<IRepository<CreditCardTransaction, Guid>> _transactionRepo;
+
+    public CreateCreditCardTransactionCommandHandlerTests()
+    {
+        _creditCardRepo = new Mock<IRepository<CreditCard, Guid>>();
+        _transactionRepo = new Mock<IRepository<CreditCardTransaction, Guid>>();
+    }
+
+    private CreateCreditCardTransactionCommandHandler CreateHandler() =>
+        new(_dbContext, _creditCardRepo.Object, _transactionRepo.Object);
+
+    [Fact]
+    public async Task Create_WithoutStatementId_AddsTransactionAndReturnsSuccess()
+    {
+        var creditCard = new CreditCard { Id = Guid.NewGuid(), Name = "Visa" };
+        var command = new CreateCreditCardTransactionCommand
+        {
+            CreditCardId = creditCard.Id,
+            Timestamp = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Supermercado",
+            Amount = new Money(1500m),
+        };
+
+        _creditCardRepo
+            .Setup(r => r.GetByIdAsync(creditCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(creditCard);
+        _transactionRepo
+            .Setup(r => r.AddAsync(It.IsAny<CreditCardTransaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(creditCard.Id, result.Data.CreditCardId);
+        Assert.Equal("Supermercado", result.Data.Concept);
+        _transactionRepo.Verify(
+            r => r.AddAsync(It.IsAny<CreditCardTransaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WithStatementId_CreatesStatementTransactionInDb()
+    {
+        var creditCard = new CreditCard { Id = Guid.NewGuid(), Name = "Mastercard" };
+        var statementId = Guid.NewGuid();
+        var command = new CreateCreditCardTransactionCommand
+        {
+            CreditCardId = creditCard.Id,
+            CreditCardStatementId = statementId,
+            Timestamp = new DateTime(2025, 3, 5, 0, 0, 0, DateTimeKind.Utc),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Farmacia",
+            Amount = new Money(250m),
+        };
+
+        _creditCardRepo
+            .Setup(r => r.GetByIdAsync(creditCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(creditCard);
+        _transactionRepo
+            .Setup(r => r.AddAsync(It.IsAny<CreditCardTransaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .Callback<CreditCardTransaction, CancellationToken, bool>((tx, _, _) => tx.Id = Guid.NewGuid())
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        var statementTx = _dbContext.CreditCardStatementTransaction
+            .IgnoreQueryFilters()
+            .Where(st => st.StatementId == statementId)
+            .ToList();
+        Assert.Single(statementTx);
+        Assert.Equal("Farmacia", statementTx[0].Description);
+        _transactionRepo.Verify(
+            r => r.AddAsync(It.IsAny<CreditCardTransaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WhenCreditCardNotFound_ThrowsException()
+    {
+        var command = new CreateCreditCardTransactionCommand
+        {
+            CreditCardId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow,
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Test",
+            Amount = new Money(100m),
+        };
+
+        _creditCardRepo
+            .Setup(r => r.GetByIdAsync(command.CreditCardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CreditCard?)null);
+
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardTransactionCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardTransactionCommandHandlerTests.cs
@@ -1,0 +1,72 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.SpecialTypes;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class UpdateCreditCardTransactionCommandHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IRepository<CreditCardTransaction, Guid>> _transactionRepo;
+
+    public UpdateCreditCardTransactionCommandHandlerTests()
+    {
+        _transactionRepo = new Mock<IRepository<CreditCardTransaction, Guid>>();
+    }
+
+    private UpdateCreditCardTransactionCommandHandler CreateHandler() =>
+        new(_transactionRepo.Object, _dbContext);
+
+    [Fact]
+    public async Task Update_HappyPath_UpdatesFieldsAndReturnsSuccess()
+    {
+        var transaction = new CreditCardTransaction
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Concept = "Original concept",
+            Amount = new Money(100m),
+        };
+        var command = new UpdateCreditCardTransactionCommand
+        {
+            Id = transaction.Id,
+            Timestamp = new DateTime(2025, 3, 10, 0, 0, 0, DateTimeKind.Utc),
+            Concept = "Updated concept",
+            Amount = new Money(350m),
+        };
+
+        _transactionRepo
+            .Setup(r => r.GetByIdAsync(transaction.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transaction);
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(command.Timestamp, result.Data.Timestamp);
+        Assert.Equal("Updated concept", result.Data.Concept);
+        Assert.Equal(350m, (decimal)result.Data.Amount);
+        _transactionRepo.Verify(
+            r => r.UpdateAsync(transaction, It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Once);
+        _transactionRepo.Verify(r => r.PersistAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Update_WhenTransactionNotFound_ThrowsException()
+    {
+        var command = new UpdateCreditCardTransactionCommand
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow,
+            Concept = "Test",
+            Amount = new Money(100m),
+        };
+
+        _transactionRepo
+            .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CreditCardTransaction?)null);
+
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetCreditCardTransactionsQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetCreditCardTransactionsQueryHandlerTests.cs
@@ -1,0 +1,131 @@
+using Finance.Application.Queries.CreditCards;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.Banks;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Finance.Domain.SpecialTypes;
+using FinanceBackEnd.Finance.Domain.Enums;
+
+namespace Finance.Application.Tests.Queries.CreditCards;
+
+public class GetCreditCardTransactionsQueryHandlerTests : QueryHandlerBaseTests
+{
+    private GetCreditCardTransactionsQueryHandler CreateHandler() => new(_dbContext);
+
+    private async Task<(CreditCard card, CreditCardTransaction tx)> SeedTransactionAsync(
+        string concept = "Test",
+        decimal amount = 100m,
+        bool deactivated = false,
+        DateTime? timestamp = null)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = "IdentityNotFound" }],
+        };
+        var bank = new Bank { Id = Guid.NewGuid(), Name = "Bank" };
+        var card = new CreditCard { Id = Guid.NewGuid(), Name = "Card", BankId = bank.Id };
+        var tx = new CreditCardTransaction
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = card.Id,
+            Timestamp = timestamp ?? new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = concept,
+            Amount = new Money(amount),
+            Deactivated = deactivated,
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.Bank.AddAsync(bank);
+        await _dbContext.CreditCard.AddAsync(card);
+        _dbContext.CreditCardPermissions.Add(new CreditCardPermissions
+        {
+            ResourceId = card.Id,
+            Resource = card,
+            UserId = user.Id,
+            User = user,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        });
+        await _dbContext.CreditCardTransaction.AddAsync(tx);
+        await _dbContext.SaveChangesAsync();
+        return (card, tx);
+    }
+
+    [Fact]
+    public async Task Execute_WithNoFilters_ReturnsAllActiveTransactions()
+    {
+        var (_, tx1) = await SeedTransactionAsync("Tx1", 100m);
+        var (_, tx2) = await SeedTransactionAsync("Tx2", 200m);
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardTransactionsQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var myIds = new[] { tx1.Id, tx2.Id };
+        var mine = result.Data.Where(t => myIds.Contains(t.Id)).ToList();
+        Assert.Equal(2, mine.Count);
+    }
+
+    [Fact]
+    public async Task Execute_WithStatementIdFilter_ReturnsOnlyStatementTransactions()
+    {
+        var (card1, txLinked) = await SeedTransactionAsync("Linked", 100m);
+        var (_, txOther) = await SeedTransactionAsync("Other", 200m);
+
+        var statement = new CreditCardStatement
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = card1.Id,
+            ClosureDate = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc),
+            ExpiringDate = new DateTime(2025, 4, 15, 0, 0, 0, DateTimeKind.Utc),
+        };
+        _dbContext.CreditCardStatement.Add(statement);
+        _dbContext.CreditCardStatementTransaction.Add(new CreditCardStatementTransaction
+        {
+            Id = Guid.NewGuid(),
+            StatementId = statement.Id,
+            CreditCardTransactionId = txLinked.Id,
+            PostedDate = txLinked.Timestamp,
+            Amount = txLinked.Amount,
+            Description = txLinked.Concept,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(
+            new GetCreditCardTransactionsQuery { StatementId = statement.Id }, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Data, t => t.Id == txLinked.Id);
+        Assert.DoesNotContain(result.Data, t => t.Id == txOther.Id);
+    }
+
+    [Fact]
+    public async Task Execute_WithCreditCardIdFilter_ReturnsOnlyMatchingCard()
+    {
+        var (card1, tx1) = await SeedTransactionAsync("Tx1", 100m);
+        var (_, tx2) = await SeedTransactionAsync("Tx2", 200m);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new GetCreditCardTransactionsQuery { CreditCardId = card1.Id }, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Data, t => t.Id == tx1.Id);
+        Assert.DoesNotContain(result.Data, t => t.Id == tx2.Id);
+    }
+
+    [Fact]
+    public async Task Execute_WhenIncludeDeactivatedIsFalse_ExcludesDeactivatedTransactions()
+    {
+        var (_, activeTx) = await SeedTransactionAsync("Active", 100m, deactivated: false);
+        var (_, deactivatedTx) = await SeedTransactionAsync("Deactivated", 200m, deactivated: true);
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardTransactionsQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Data, t => t.Id == activeTx.Id);
+        Assert.DoesNotContain(result.Data, t => t.Id == deactivatedTx.Id);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests.cs
@@ -1,0 +1,163 @@
+using Finance.Application.Queries.CreditCards;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.Banks;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Finance.Domain.SpecialTypes;
+using FinanceBackEnd.Finance.Domain.Enums;
+
+namespace Finance.Application.Tests.Queries.CreditCards;
+
+public class GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests : QueryHandlerBaseTests
+{
+    private GetLatestCreditCardTransactionsFromStatementsQueryHandler CreateHandler() => new(_dbContext);
+
+    private async Task<(CreditCard card, CreditCardStatement statement, CreditCardTransaction tx)> SeedAsync(
+        DateTime closureDate,
+        bool statementDeactivated = false,
+        bool txDeactivated = false)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = "IdentityNotFound" }],
+        };
+        var bank = new Bank { Id = Guid.NewGuid(), Name = "Bank" };
+        var card = new CreditCard { Id = Guid.NewGuid(), Name = "Card", BankId = bank.Id };
+        var statement = new CreditCardStatement
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = card.Id,
+            ClosureDate = closureDate,
+            ExpiringDate = closureDate.AddDays(15),
+            Deactivated = statementDeactivated,
+        };
+        var tx = new CreditCardTransaction
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = card.Id,
+            Timestamp = closureDate.AddDays(-5),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Purchase",
+            Amount = new Money(100m),
+            Deactivated = txDeactivated,
+        };
+        var statementTx = new CreditCardStatementTransaction
+        {
+            Id = Guid.NewGuid(),
+            StatementId = statement.Id,
+            CreditCardTransactionId = tx.Id,
+            PostedDate = tx.Timestamp,
+            Amount = tx.Amount,
+            Description = tx.Concept,
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.Bank.AddAsync(bank);
+        await _dbContext.CreditCard.AddAsync(card);
+        _dbContext.CreditCardPermissions.Add(new CreditCardPermissions
+        {
+            ResourceId = card.Id,
+            Resource = card,
+            UserId = user.Id,
+            User = user,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        });
+        await _dbContext.CreditCardStatement.AddAsync(statement);
+        await _dbContext.CreditCardTransaction.AddAsync(tx);
+        _dbContext.CreditCardStatementTransaction.Add(statementTx);
+        await _dbContext.SaveChangesAsync();
+        return (card, statement, tx);
+    }
+
+    [Fact]
+    public async Task Execute_WithDeactivatedStatement_DoesNotReturnItsTransactions()
+    {
+        var closureDate = new DateTime(2025, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+        var (card, _, tx) = await SeedAsync(closureDate, statementDeactivated: true);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new GetLatestCreditCardTransactionsFromStatementsQuery { CreditCardId = card.Id }, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.DoesNotContain(result.Data, t => t.Id == tx.Id);
+    }
+
+    [Fact]
+    public async Task Execute_WithMultipleStatementsForSameCard_ReturnsLatestStatementTransactions()
+    {
+        var olderClosureDate = new DateTime(2025, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+        var newerClosureDate = new DateTime(2025, 2, 28, 0, 0, 0, DateTimeKind.Utc);
+
+        var (card, _, olderTx) = await SeedAsync(olderClosureDate);
+
+        var newerStatement = new CreditCardStatement
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = card.Id,
+            ClosureDate = newerClosureDate,
+            ExpiringDate = newerClosureDate.AddDays(15),
+        };
+        var newerTx = new CreditCardTransaction
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = card.Id,
+            Timestamp = new DateTime(2025, 2, 20, 0, 0, 0, DateTimeKind.Utc),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Newer purchase",
+            Amount = new Money(200m),
+        };
+        _dbContext.CreditCardStatement.Add(newerStatement);
+        _dbContext.CreditCardTransaction.Add(newerTx);
+        _dbContext.CreditCardStatementTransaction.Add(new CreditCardStatementTransaction
+        {
+            Id = Guid.NewGuid(),
+            StatementId = newerStatement.Id,
+            CreditCardTransactionId = newerTx.Id,
+            PostedDate = newerTx.Timestamp,
+            Amount = newerTx.Amount,
+            Description = newerTx.Concept,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(
+            new GetLatestCreditCardTransactionsFromStatementsQuery { CreditCardId = card.Id }, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Data, t => t.Id == newerTx.Id);
+        Assert.DoesNotContain(result.Data, t => t.Id == olderTx.Id);
+    }
+
+    [Fact]
+    public async Task Execute_WithCreditCardIdFilter_ReturnsOnlyMatchingCard()
+    {
+        var closureDate = new DateTime(2025, 2, 28, 0, 0, 0, DateTimeKind.Utc);
+        var (card1, _, tx1) = await SeedAsync(closureDate);
+        var (_, _, tx2) = await SeedAsync(closureDate);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new GetLatestCreditCardTransactionsFromStatementsQuery { CreditCardId = card1.Id }, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Data, t => t.Id == tx1.Id);
+        Assert.DoesNotContain(result.Data, t => t.Id == tx2.Id);
+    }
+
+    [Fact]
+    public async Task Execute_WhenTransactionIsDeactivated_ExcludesItFromDefaultResult()
+    {
+        var closureDate = new DateTime(2025, 2, 28, 0, 0, 0, DateTimeKind.Utc);
+        var (_, _, activeTx) = await SeedAsync(closureDate, txDeactivated: false);
+        var (_, _, deactivatedTx) = await SeedAsync(closureDate, txDeactivated: true);
+
+        var result = await CreateHandler().ExecuteAsync(
+            new GetLatestCreditCardTransactionsFromStatementsQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Data, t => t.Id == activeTx.Id);
+        Assert.DoesNotContain(result.Data, t => t.Id == deactivatedTx.Id);
+    }
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useLoaderData, useNavigate } from 'react-router';
 import {
   Table,
   TableBody,
@@ -12,6 +13,14 @@ import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
 import { Separator } from '@/components/ui/shadcn/separator';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  type CarouselApi,
+} from '@/components/ui/shadcn/carousel';
 import { toNumber, ValueLike } from '@/utils/common';
 import SafeLogger from '@/utils/SafeLogger';
 import {
@@ -23,6 +32,7 @@ import {
 } from '@/components/ui/utils/Modal';
 import urls from '@/utils/urls';
 import type { CreditCard, CreditCardStatement, CreditCardTransaction } from '@/types/creditCard';
+import EditStatementModal from './EditStatementModal';
 
 const formatDate = (dateStr: string) => {
   if (!dateStr) return '-';
@@ -42,38 +52,70 @@ function StatementPicker({
   currentIndex: number;
   onNavigate: (index: number) => void;
 }) {
+  const [api, setApi] = useState<CarouselApi>();
+
+  useEffect(() => {
+    if (!api) return;
+    api.scrollTo(currentIndex, true);
+  }, [api, currentIndex]);
+
   if (statements.length === 0) return null;
 
-  const current = statements[currentIndex];
-  const canGoPrev = currentIndex < statements.length - 1;
-  const canGoNext = currentIndex > 0;
+  const lastIndex = statements.length - 1;
 
   return (
-    <div className="flex items-center justify-center gap-4 mb-6">
+    <div className="flex items-center justify-center gap-2 mb-6 px-4">
       <Button
         variant="outline"
         size="sm"
-        disabled={!canGoPrev}
-        onClick={() => onNavigate(currentIndex + 1)}
+        disabled={currentIndex === 0}
+        onClick={() => onNavigate(0)}
       >
-        ← Anterior
+        Último
       </Button>
-      <div className="text-sm font-medium px-4 py-2 rounded-md border bg-muted min-w-[300px] text-center">
-        Cierre: {formatDate(current.closureDate)} — Vto: {formatDate(current.expiringDate)}
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={currentIndex === 0}
+        onClick={() => onNavigate(currentIndex - 1)}
+      >
+        ←
+      </Button>
+      <div className="flex-1 max-w-sm">
+        <Carousel
+          opts={{ align: 'center', loop: false }}
+          setApi={setApi}
+          className="w-full"
+        >
+          <CarouselContent>
+            {statements.map((s, i) => (
+              <CarouselItem key={s.id} onClick={() => onNavigate(i)} className="cursor-pointer">
+                <div className={`text-sm font-medium px-4 py-2 rounded-md border text-center transition-colors ${
+                  i === currentIndex ? 'bg-muted' : 'text-muted-foreground'
+                }`}>
+                  Cierre: {formatDate(s.closureDate)} — Vto: {formatDate(s.expiringDate)}
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
       </div>
       <Button
         variant="outline"
         size="sm"
-        disabled={!canGoNext}
-        onClick={() => onNavigate(currentIndex - 1)}
+        disabled={currentIndex === lastIndex}
+        onClick={() => onNavigate(currentIndex + 1)}
       >
-        Siguiente →
+        →
       </Button>
-      {currentIndex !== 0 && (
-        <Button variant="outline" size="sm" onClick={() => onNavigate(0)}>
-          Último
-        </Button>
-      )}
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={currentIndex === lastIndex}
+        onClick={() => onNavigate(lastIndex)}
+      >
+        Primero
+      </Button>
     </div>
   );
 }
@@ -216,12 +258,30 @@ function CreateStatementModal({
   );
 }
 
-function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => void }) {
+function CreditCardDetail() {
+  const { card, cards } = useLoaderData<{ card: CreditCard; cards: CreditCard[] }>();
+  const navigate = useNavigate();
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [statements, setStatements] = useState<CreditCardStatement[]>([]);
   const [statementIndex, setStatementIndex] = useState(0);
   const [transactions, setTransactions] = useState<CreditCardTransaction[]>([]);
   const [loading, setLoading] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+
+  useEffect(() => {
+    if (!carouselApi) return;
+    const currentIndex = cards.findIndex((c) => c.id === card.id);
+    carouselApi.scrollTo(currentIndex, true);
+    const onSelect = () => {
+      const idx = carouselApi.selectedScrollSnap();
+      if (cards[idx]?.id !== card.id) {
+        navigate(`/credit-cards/statement/${cards[idx].id}`);
+      }
+    };
+    carouselApi.on('select', onSelect);
+    return () => { carouselApi.off('select', onSelect); };
+  }, [carouselApi, card.id, cards, navigate]);
 
   const fetchStatements = useCallback(async () => {
     try {
@@ -251,26 +311,9 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
 
     setLoading(true);
     try {
-      let url: ReturnType<typeof urls.creditCardMovements.latest.with>;
-
-      if (statementIndex === 0) {
-        url = urls.creditCardMovements.latest.with({
-          CreditCardId: card.id,
-          Page: 1,
-          PageSize: 200,
-        });
-      } else {
-        const currentStatement = statements[statementIndex];
-        const prevStatement = statements[statementIndex + 1];
-        const params: Record<string, unknown> = {
-          CreditCardId: card.id,
-          To: currentStatement.closureDate,
-        };
-        if (prevStatement) {
-          params.From = prevStatement.closureDate;
-        }
-        url = urls.creditCardTransactions.endpoint.append('/all').with(params);
-      }
+      const currentStatement = statements[statementIndex];
+      const params: Record<string, unknown> = { StatementId: currentStatement.id };
+      const url = urls.creditCardTransactions.endpoint.append('/all').with(params);
 
       const res = await fetch(String(url));
       const data = await res.json();
@@ -292,12 +335,30 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
     <>
       <div className="row flex justify-between items-center mb-4">
         <div className="flex items-center gap-4">
-          <Button variant="outline" size="sm" onClick={onBack}>
+          <Button variant="outline" size="sm" onClick={() => navigate('/credit-cards')}>
             ← Volver
           </Button>
-          <h1 className="text-base font-medium">
-            {card.name} — {card.bank?.name}
-          </h1>
+          <div className="flex items-center gap-2 px-8">
+            <Carousel
+              opts={{ align: 'center', loop: false }}
+              setApi={setCarouselApi}
+              className="w-64"
+            >
+              <CarouselContent>
+                {cards.map((c) => (
+                  <CarouselItem key={c.id}>
+                    <div className={`text-center text-sm font-medium px-2 py-1 rounded-md transition-colors ${
+                      c.id === card.id ? 'text-foreground' : 'text-muted-foreground'
+                    }`}>
+                      {c.bank?.name ?? '-'} — {c.name}
+                    </div>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -316,6 +377,16 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
           >
             Nuevo Resúmen
           </Button>
+          {statements.length > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-primary text-primary hover:bg-primary/10"
+              onClick={() => setShowEditModal(true)}
+            >
+              Editar Resúmen
+            </Button>
+          )}
         </div>
       </div>
       <Separator className="my-5" />
@@ -338,6 +409,19 @@ function CreditCardDetail({ card, onBack }: { card: CreditCard; onBack: () => vo
         creditCardId={card.id}
         onCreated={fetchStatements}
       />
+
+      {statements.length > 0 && (
+        <EditStatementModal
+          show={showEditModal}
+          onHide={() => setShowEditModal(false)}
+          statement={statements[statementIndex]}
+          transactions={transactions}
+          onSaved={() => {
+            fetchStatements();
+            fetchTransactions();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
@@ -1,0 +1,292 @@
+import { useState, useEffect } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/shadcn/table';
+import { Button } from '@/components/ui/shadcn/button';
+import { Input } from '@/components/ui/shadcn/input';
+import { Label } from '@/components/ui/shadcn/label';
+import { Separator } from '@/components/ui/shadcn/separator';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalBody,
+  ModalFooter,
+} from '@/components/ui/utils/Modal';
+import urls from '@/utils/urls';
+import type { CreditCardStatement, CreditCardTransaction } from '@/types/creditCard';
+
+interface DraftTransaction {
+  id?: string;
+  timestamp: string;
+  concept: string;
+  amount: string;
+  isDeleted: boolean;
+  isModified: boolean;
+}
+
+export default function EditStatementModal({
+  show,
+  onHide,
+  statement,
+  transactions,
+  onSaved,
+}: {
+  show: boolean;
+  onHide: () => void;
+  statement: CreditCardStatement;
+  transactions: CreditCardTransaction[];
+  onSaved: () => void;
+}) {
+  const [closureDate, setClosureDate] = useState('');
+  const [expiringDate, setExpiringDate] = useState('');
+  const [draftTxs, setDraftTxs] = useState<DraftTransaction[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (show) {
+      setClosureDate(statement.closureDate.slice(0, 10));
+      setExpiringDate(statement.expiringDate.slice(0, 10));
+      setDraftTxs(
+        transactions.map((tx) => ({
+          id: tx.id,
+          timestamp: tx.timestamp.slice(0, 10),
+          concept: tx.concept,
+          amount: String(tx.amount),
+          isDeleted: false,
+          isModified: false,
+        }))
+      );
+    }
+  }, [show, statement, transactions]);
+
+  const updateTx = (
+    index: number,
+    field: keyof Pick<DraftTransaction, 'timestamp' | 'concept' | 'amount'>,
+    value: string
+  ) => {
+    setDraftTxs((prev) =>
+      prev.map((tx, i) => (i === index ? { ...tx, [field]: value, isModified: true } : tx))
+    );
+  };
+
+  const deleteTx = (index: number) => {
+    setDraftTxs((prev) =>
+      prev.map((tx, i) => (i === index ? { ...tx, isDeleted: true } : tx))
+    );
+  };
+
+  const addRow = () => {
+    const d = new Date();
+    const localDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    setDraftTxs((prev) => [
+      ...prev,
+      {
+        timestamp: localDate,
+        concept: '',
+        amount: '0',
+        isDeleted: false,
+        isModified: false,
+      },
+    ]);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const origClosure = statement.closureDate.slice(0, 10);
+      const origExpiring = statement.expiringDate.slice(0, 10);
+      if (closureDate !== origClosure || expiringDate !== origExpiring) {
+        const res = await fetch(String(urls.creditCardStatements.endpoint), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            id: statement.id,
+            creditCardId: statement.creditCardId,
+            closureDate: new Date(closureDate).toISOString(),
+            expiringDate: new Date(expiringDate).toISOString(),
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      for (const tx of draftTxs.filter((t) => t.isDeleted && t.id !== undefined)) {
+        const res = await fetch(String(urls.creditCardTransactions.endpoint), {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: tx.id }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      for (const tx of draftTxs.filter((t) => !t.isDeleted && t.id === undefined)) {
+        const res = await fetch(String(urls.creditCardTransactions.endpoint), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            creditCardId: statement.creditCardId,
+            creditCardStatementId: statement.id,
+            timestamp: new Date(tx.timestamp).toISOString(),
+            concept: tx.concept,
+            amount: Number(tx.amount),
+            transactionType: 0,
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      for (const tx of draftTxs.filter(
+        (t) => !t.isDeleted && t.id !== undefined && t.isModified
+      )) {
+        const res = await fetch(String(urls.creditCardTransactions.endpoint), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            id: tx.id,
+            timestamp: new Date(tx.timestamp).toISOString(),
+            concept: tx.concept,
+            amount: Number(tx.amount),
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+      }
+
+      onSaved();
+      onHide();
+    } catch (err) {
+      alert(`Error al guardar: ${err}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const visibleTxs = draftTxs.filter((t) => !t.isDeleted);
+
+  return (
+    <Modal show={show} onHide={onHide} size="4xl">
+      <form onSubmit={handleSave}>
+        <ModalHeader closeButton>
+          <ModalTitle>
+            <h3 className="text-lg font-medium">Editar Resúmen</h3>
+          </ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="edit-closure-date" className="block mb-2">
+                  Fecha de Cierre
+                </Label>
+                <Input
+                  id="edit-closure-date"
+                  type="date"
+                  required
+                  value={closureDate}
+                  onChange={(e) => setClosureDate(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-expiring-date" className="block mb-2">
+                  Fecha de Vencimiento
+                </Label>
+                <Input
+                  id="edit-expiring-date"
+                  type="date"
+                  required
+                  value={expiringDate}
+                  onChange={(e) => setExpiringDate(e.target.value)}
+                />
+              </div>
+            </div>
+            <Separator />
+            <div>
+              <p className="text-sm font-medium mb-3">Movimientos</p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-36">Fecha</TableHead>
+                    <TableHead>Concepto</TableHead>
+                    <TableHead className="w-28 text-right">Monto</TableHead>
+                    <TableHead className="w-10"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visibleTxs.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center text-muted-foreground">
+                        Sin movimientos
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    visibleTxs.map((tx) => {
+                      const realIndex = draftTxs.indexOf(tx);
+                      return (
+                        <TableRow key={tx.id ?? `new-${realIndex}`}>
+                          <TableCell>
+                            <Input
+                              type="date"
+                              value={tx.timestamp}
+                              onChange={(e) => updateTx(realIndex, 'timestamp', e.target.value)}
+                              className="h-8 text-sm"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              value={tx.concept}
+                              onChange={(e) => updateTx(realIndex, 'concept', e.target.value)}
+                              className="h-8 text-sm"
+                              placeholder="Concepto"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Input
+                              type="number"
+                              step="0.01"
+                              value={tx.amount}
+                              onChange={(e) => updateTx(realIndex, 'amount', e.target.value)}
+                              className="h-8 text-sm text-right"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => deleteTx(realIndex)}
+                              className="text-destructive hover:text-destructive h-8 w-8 p-0"
+                            >
+                              ×
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })
+                  )}
+                </TableBody>
+              </Table>
+              <Button type="button" variant="outline" size="sm" className="mt-2" onClick={addRow}>
+                + Agregar fila
+              </Button>
+            </div>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <div className="flex justify-end space-x-2 mt-6">
+            <Button type="button" variant="outline" onClick={onHide}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Guardando...' : 'Guardar'}
+            </Button>
+          </div>
+        </ModalFooter>
+      </form>
+    </Modal>
+  );
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/index.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { useLoaderData } from 'react-router';
+import { useLoaderData, useNavigate } from 'react-router';
 import {
   Table,
   TableBody,
@@ -9,8 +8,6 @@ import {
   TableRow,
 } from '@/components/ui/shadcn/table';
 import { Separator } from '@/components/ui/shadcn/separator';
-import { cn } from '@/lib/utils';
-import CreditCardDetail from './CreditCardDetail';
 import type { CreditCard, CreditCardsData } from '@/types/creditCard';
 
 function CreditCardList({
@@ -66,16 +63,13 @@ function CreditCardList({
 
 function CreditCards() {
   const { creditCards } = useLoaderData<CreditCardsData>();
-  const [selectedCard, setSelectedCard] = useState<CreditCard | null>(null);
+  const navigate = useNavigate();
 
   return (
-    <div className={cn('py-10', 'px-40')}>
-      {selectedCard ? (
-        <CreditCardDetail card={selectedCard} onBack={() => setSelectedCard(null)} />
-      ) : (
-        <CreditCardList creditCards={creditCards ?? []} onSelectCard={setSelectedCard} />
-      )}
-    </div>
+    <CreditCardList
+      creditCards={creditCards ?? []}
+      onSelectCard={(card) => navigate(`/credit-cards/statement/${card.id}`)}
+    />
   );
 }
 

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/shadcn/carousel.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/shadcn/carousel.tsx
@@ -1,0 +1,227 @@
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/shadcn/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+  return context
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins
+  )
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+  const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [])
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        scrollPrev()
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        scrollNext()
+      }
+    },
+    [scrollPrev, scrollNext]
+  )
+
+  React.useEffect(() => {
+    if (!api || !setApi) return
+    setApi(api)
+  }, [api, setApi])
+
+  React.useEffect(() => {
+    if (!api) return
+    onSelect(api)
+    api.on("reInit", onSelect)
+    api.on("select", onSelect)
+    return () => {
+      api?.off("select", onSelect)
+    }
+  }, [api, onSelect])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation,
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Modal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/Modal.tsx
@@ -5,6 +5,17 @@ type ModalProps = {
     onHide?: () => void;
     show?: boolean;
     children?: React.ReactNode;
+    size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+};
+
+const sizeClass: Record<NonNullable<ModalProps['size']>, string> = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl',
+    '4xl': 'max-w-4xl',
 };
 
 const ModalContext = createContext<{ onHide?: () => void }>({});
@@ -13,6 +24,7 @@ export const Modal: React.FC<ModalProps> = ({
     children,
     show = false,
     onHide,
+    size = 'md',
 }) => {
     return (
         <ModalContext.Provider value={{ onHide }}>
@@ -45,7 +57,7 @@ export const Modal: React.FC<ModalProps> = ({
                                 leaveFrom="opacity-100 scale-100"
                                 leaveTo="opacity-0 scale-95"
                             >
-                                <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                                <Dialog.Panel className={`w-full ${sizeClass[size]} transform overflow-hidden rounded-2xl bg-background text-foreground p-6 text-left align-middle shadow-xl transition-all border border-border`}>
                                     {children}
                                 </Dialog.Panel>
                             </Transition.Child>
@@ -74,7 +86,7 @@ export const ModalHeader: React.FC<ModalHeaderProps> = ({
                 <button
                     aria-label="close"
                     onClick={onHide}
-                    className="ml-4 text-gray-500 hover:text-gray-700"
+                    className="ml-4 text-muted-foreground hover:text-foreground"
                 >
                     ×
                 </button>

--- a/FinanceFrontEnd/FinanceApp/app/routes/credit-cards._index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/credit-cards._index.tsx
@@ -1,0 +1,37 @@
+import { LoaderFunctionArgs } from 'react-router';
+import CreditCards from '@/components/ui/CreditCards';
+import { getBackendClient } from '@/data/getBackendClient';
+import { requireAuth } from '@/services/auth/session.server';
+import type { CreditCard, CreditCardStatement } from '@/types/creditCard';
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const user = await requireAuth(request);
+  const client = await getBackendClient(user.accessToken!);
+
+  const [creditCards, latestStatements] = await Promise.all([
+    client.GetCreditCardsQuery().get(),
+    client.GetCreditCardStatementsQuery().getLatest(),
+  ]);
+
+  const statementsById = new Map<string, CreditCardStatement>(
+    (latestStatements as CreditCardStatement[]).map((s: CreditCardStatement) => [s.creditCardId, s])
+  );
+
+  const enrichedCards = (creditCards as CreditCard[]).map((card: CreditCard) => ({
+    ...card,
+    creditCardStatement: statementsById.get(card.id) ?? null,
+  }));
+
+  return { creditCards: enrichedCards };
+};
+
+export const meta = () => {
+  return [
+    {
+      title: 'Tarjetas de Crédito',
+      description: 'Credit cards management',
+    },
+  ];
+};
+
+export default CreditCards;

--- a/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.statement.$id.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.statement.$id.tsx
@@ -1,0 +1,26 @@
+import { LoaderFunctionArgs, redirect } from 'react-router';
+import { getBackendClient } from '@/data/getBackendClient';
+import { requireAuth } from '@/services/auth/session.server';
+import type { CreditCard } from '@/types/creditCard';
+import CreditCardDetail from '@/components/ui/CreditCards/CreditCardDetail';
+
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  const user = await requireAuth(request);
+  const client = await getBackendClient(user.accessToken!);
+
+  const cards = (await client.GetCreditCardsQuery().get()) as CreditCard[];
+  const card = cards.find((c) => c.id === params.id);
+  if (!card) return redirect('/credit-cards');
+
+  return { card, cards };
+};
+
+export const meta = ({ data }: { data: { card: CreditCard } | undefined }) => {
+  return [
+    {
+      title: data?.card ? `${data.card.name} — Tarjeta de Crédito` : 'Tarjeta de Crédito',
+    },
+  ];
+};
+
+export default CreditCardDetail;

--- a/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.tsx
@@ -1,37 +1,10 @@
-import { LoaderFunctionArgs } from 'react-router';
-import CreditCards from '@/components/ui/CreditCards';
-import { getBackendClient } from '@/data/getBackendClient';
-import { requireAuth } from '@/services/auth/session.server';
-import type { CreditCard, CreditCardStatement } from '@/types/creditCard';
+import { cn } from '@/lib/utils';
+import { Outlet } from 'react-router';
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
-  const user = await requireAuth(request);
-  const client = await getBackendClient(user.accessToken!);
-
-  const [creditCards, latestStatements] = await Promise.all([
-    client.GetCreditCardsQuery().get(),
-    client.GetCreditCardStatementsQuery().getLatest(),
-  ]);
-
-  const statementsById = new Map<string, CreditCardStatement>(
-    (latestStatements as CreditCardStatement[]).map((s: CreditCardStatement) => [s.creditCardId, s])
+export default function CreditCardsLayout() {
+  return (
+    <div className={cn('py-10', 'px-40')}>
+      <Outlet />
+    </div>
   );
-
-  const enrichedCards = (creditCards as CreditCard[]).map((card: CreditCard) => ({
-    ...card,
-    creditCardStatement: statementsById.get(card.id) ?? null,
-  }));
-
-  return { creditCards: enrichedCards };
-};
-
-export const meta = () => {
-  return [
-    {
-      title: 'Tarjetas de Crédito',
-      description: 'Credit cards management',
-    },
-  ];
-};
-
-export default CreditCards;
+}


### PR DESCRIPTION
# Why

Credit card statements needed a dedicated detail page where users can view the transactions recorded under each statement period. Previously, there was no way to navigate into a specific statement, nor to create or edit transactions in the context of a statement.

## What is the solution?

**Backend:**
- Added `UpdateCreditCardTransactionCommand` with a PUT endpoint so existing transactions can have their timestamp, concept, and amount updated.
- Extended `CreateCreditCardTransactionCommand` with an optional `CreditCardStatementId` field; when provided, the new transaction is linked to the statement via a `CreditCardStatementTransaction` join record.
- Added a `StatementId` filter to `GetCreditCardTransactionsQuery` so the API can return only the transactions belonging to a specific statement.
- Refactored `GetLatestCreditCardTransactionsFromStatementsQuery` to derive the latest statement per card by querying statements directly with a `GroupBy` on `CreditCardId`, ordered by `ClosureDate` — replacing the previous approach that relied on `CreditCard.CurrentStatementId`.
- Made `CreditCardId` setter public on `GetCreditCardStatementsQuery` to allow it to be set from route params.

**Frontend:**
- Converted `credit-cards.tsx` into a layout route that renders `<Outlet />`, and extracted the original loader/component into a new `credit-cards._index.tsx` index route.
- Added `credit-cards.statement.$id.tsx` as a dedicated statement detail route.
- Added `EditStatementModal.tsx` — a modal for creating new transactions or editing existing ones (timestamp, concept, amount) within the context of a statement.
- Updated `CreditCardDetail.tsx` and `CreditCards/index.tsx` to support navigation into statement detail.
- Added a shadcn `carousel.tsx` component used in the statement detail view.
- Updated `Modal.tsx` with minor improvements.

## What areas of the site does it impact?

- **Credit Cards module** (all layers): backend commands, queries, API controller, and the full React frontend for credit cards.
- No other modules are affected.

## Test scenarios

```gherkin
Scenario: Navigate to statement detail
  Given the user is on the credit cards list page
  When they click on a credit card's current statement
  Then they are taken to the statement detail page showing that statement's transactions

Scenario: Create a transaction linked to a statement
  Given the user is on the statement detail page
  When they open the EditStatementModal and submit a new transaction
  Then the transaction is created and linked to the current statement
  And the transaction appears in the statement's transaction list

Scenario: Edit an existing transaction within a statement
  Given the statement detail page shows at least one transaction
  When the user opens the EditStatementModal for that transaction and changes the amount
  Then the transaction is updated via the PUT endpoint
  And the updated amount is reflected in the list

Scenario: Latest statement resolution
  Given a credit card has multiple statements
  When the credit cards index page loads
  Then the most recently closed statement (by ClosureDate) is shown as the current statement for each card
```

## Other Notes

Closes #127