### PR TITLE
feat: add currency support to credit card transactions

### DIFF
--- a/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CreditCardStatementTransactionQueryController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CreditCardStatementTransactionQueryController.cs
@@ -4,7 +4,10 @@ using Finance.Application.Auth;
 using Finance.Application.Dtos.CreditCards;
 using Finance.Application.Mapping;
 using Finance.Application.Queries.CreditCards;
+using Finance.Application.Services;
 using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Interfaces;
+using Finance.Persistence.Constants;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,10 +15,27 @@ namespace Finance.Api.Controllers.Queries;
 
 [Route("api/credit-card-statement-transactions")]
 [Authorize(Policy = "AdminOrOwnerPolicy")]
-public class CreditCardStatementTransactionQueryController(IMappingService mapper, IDispatcher<FinanceDispatchContext> dispatcher)
+public class CreditCardStatementTransactionQueryController(
+    IMappingService mapper,
+    IDispatcher<FinanceDispatchContext> dispatcher,
+    CurrencyConversionService currencyConversionService)
     : ApiBaseQueryController<CreditCardTransaction, Guid, CreditCardTransactionDto>(mapper, dispatcher)
 {
     [HttpGet("latest")]
     public async Task<IActionResult> GetLatest([FromQuery] GetLatestCreditCardTransactionsFromStatementsQuery query)
-        => await ExecuteAsync(query);
+    {
+        var dataResult = await Dispatcher.DispatchQueryAsync(query, Request);
+        var dtos = dataResult.Data.Select(MappingService.Map<CreditCardTransactionDto>).ToList();
+
+        var defaultCurrencyId = Guid.Parse(CurrencyConstants.DefaultCurrencyId);
+        var convertedAmounts = await currencyConversionService.ConvertCollection(
+            dtos.Cast<IAmountHolder>().ToList(),
+            defaultCurrencyId);
+
+        var convertedList = convertedAmounts.ToList();
+        for (int i = 0; i < dtos.Count; i++)
+            dtos[i].ConvertedAmount = convertedList[i];
+
+        return Ok(dtos);
+    }
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CreditCardTransactionQueryController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CreditCardTransactionQueryController.cs
@@ -4,7 +4,9 @@ using Finance.Application.Auth;
 using Finance.Application.Dtos.CreditCards;
 using Finance.Application.Mapping;
 using Finance.Application.Queries.CreditCards;
+using Finance.Application.Services;
 using Finance.Domain.Models.CreditCards;
+using Finance.Persistence.Constants;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,7 +14,10 @@ namespace Finance.Api.Controllers.Queries;
 
 [Route("api/credit-card-transactions")]
 [Authorize(Policy = "AdminOrOwnerPolicy")]
-public class CreditCardTransactionQueryController(IMappingService mapper, IDispatcher<FinanceDispatchContext> dispatcher)
+public class CreditCardTransactionQueryController(
+    IMappingService mapper,
+    IDispatcher<FinanceDispatchContext> dispatcher,
+    CurrencyConversionService currencyConversionService)
     : ApiBaseQueryController<CreditCardTransaction, Guid, CreditCardTransactionDto>(mapper, dispatcher)
 {
     [HttpGet]
@@ -25,8 +30,18 @@ public class CreditCardTransactionQueryController(IMappingService mapper, IDispa
         try
         {
             var dataResult = await Dispatcher.DispatchQueryAsync(query, Request);
-            var result = dataResult.Data.Select(MappingService.Map<CreditCardTransactionDto>).ToArray();
-            return Ok(result);
+            var dtos = dataResult.Data.Select(MappingService.Map<CreditCardTransactionDto>).ToList();
+
+            var defaultCurrencyId = Guid.Parse(CurrencyConstants.DefaultCurrencyId);
+            var convertedAmounts = await currencyConversionService.ConvertCollection(
+                dtos.Cast<Finance.Domain.Models.Interfaces.IAmountHolder>().ToList(),
+                defaultCurrencyId);
+
+            var convertedList = convertedAmounts.ToList();
+            for (int i = 0; i < dtos.Count; i++)
+                dtos[i].ConvertedAmount = convertedList[i];
+
+            return Ok(dtos);
         }
         catch (Exception ex)
         {

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardTransactionCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardTransactionCommand.cs
@@ -37,7 +37,8 @@ public class CreateCreditCardTransactionCommandHandler : BaseCommandHandler<Crea
             Concept = command.Concept,
             Amount = command.Amount,
             Reference = command.Reference,
-            Deactivated = command.Deactivated
+            Deactivated = command.Deactivated,
+            CurrencyId = command.CurrencyId
         };
 
         if (command.CreditCardStatementId.HasValue)
@@ -50,7 +51,8 @@ public class CreateCreditCardTransactionCommandHandler : BaseCommandHandler<Crea
                 CreditCardTransactionId = newTransaction.Id,
                 PostedDate = newTransaction.Timestamp,
                 Amount = newTransaction.Amount,
-                Description = newTransaction.Concept
+                Description = newTransaction.Concept,
+                CurrencyId = command.CurrencyId
             };
             DbContext.Add(statementTx);
             await DbContext.SaveChangesAsync(cancellationToken);
@@ -86,6 +88,8 @@ public class CreateCreditCardTransactionCommand : ICommand
 
     [StringLength(200)]
     public string? Reference { get; set; }
+
+    public Guid CurrencyId { get; set; }
 
     public bool Deactivated { get; set; } = false;
 }

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardTransactionCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardTransactionCommand.cs
@@ -21,6 +21,7 @@ public class UpdateCreditCardTransactionCommandHandler(
         record.Timestamp = command.Timestamp;
         record.Concept = command.Concept;
         record.Amount = command.Amount;
+        record.CurrencyId = command.CurrencyId;
         return Task.FromResult(record);
     }
 }
@@ -34,6 +35,8 @@ public class UpdateCreditCardTransactionCommand : BaseUpdateCommand<CreditCardTr
     public string Concept { get; set; } = string.Empty;
     [Required]
     public Money Amount { get; set; } = 0;
+
+    public Guid CurrencyId { get; set; }
 }
 
 public class UpdateCreditCardTransactionCommandValidator

--- a/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardStatementTransactionDto.cs
+++ b/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardStatementTransactionDto.cs
@@ -1,4 +1,5 @@
 using Finance.Application.Dtos.Base;
+using Finance.Application.Dtos.Currencies;
 using Finance.Domain.SpecialTypes;
 
 namespace Finance.Application.Dtos.CreditCards;
@@ -12,6 +13,8 @@ public record CreditCardStatementTransactionDto : Dto<Guid>
     public DateTime PostedDate { get; set; }
     public Money Amount { get; set; } = 0;
     public string Description { get; set; } = string.Empty;
+    public Guid CurrencyId { get; set; }
+    public CurrencyDto? Currency { get; set; }
 
     public CreditCardStatementTransactionDto() : base()
     {

--- a/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardTransactionDto.cs
+++ b/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardTransactionDto.cs
@@ -1,10 +1,12 @@
 using Finance.Application.Dtos.Base;
+using Finance.Application.Dtos.Currencies;
 using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Interfaces;
 using Finance.Domain.SpecialTypes;
 
 namespace Finance.Application.Dtos.CreditCards;
 
-public record CreditCardTransactionDto : Dto<Guid>
+public record CreditCardTransactionDto : Dto<Guid>, IAmountHolder
 {
     public Guid CreditCardId { get; set; }
     public CreditCardDto? CreditCard { get; set; }
@@ -14,7 +16,10 @@ public record CreditCardTransactionDto : Dto<Guid>
     public CreditCardTransactionType TransactionType { get; set; }
     public string Concept { get; set; } = string.Empty;
     public Money Amount { get; set; } = 0;
+    public Money ConvertedAmount { get; set; } = 0;
     public string? Reference { get; set; }
+    public Guid CurrencyId { get; set; }
+    public CurrencyDto? Currency { get; set; }
 
     public CreditCardTransactionDto() : base()
     {

--- a/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogCurrenciesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/Catalog/GetCatalogCurrenciesQuery.cs
@@ -18,11 +18,15 @@ public class GetCatalogCurrenciesQueryHandler(FinanceDbContext db) : BaseCollect
 {
     public override async Task<DataResult<List<CatalogItemDto>>> ExecuteAsync(GetCatalogCurrenciesQuery request, CancellationToken cancellationToken)
     {
-        var items = await DbContext.Currency
+        var currencies = await DbContext.Currency
             .Where(c => !c.Deactivated)
             .OrderBy(c => c.ShortName)
-            .Select(c => new CatalogItemDto { Id = c.Id, Name = c.ShortName })
+            .Include(c => c.Symbols)
             .ToListAsync(cancellationToken);
+
+        var items = currencies
+            .Select(c => new CatalogItemDto { Id = c.Id, Name = c.Symbols.FirstOrDefault()?.Symbol ?? c.ShortName })
+            .ToList();
 
         return DataResult<List<CatalogItemDto>>.Success(items);
     }

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardTransactionsQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardTransactionsQuery.cs
@@ -20,6 +20,8 @@ public class GetCreditCardTransactionsQueryHandler : BaseCollectionQueryHandler<
         var query = DbContext.CreditCardTransaction
             .Include(o => o.CreditCard)
                 .ThenInclude(o => o.Bank)
+            .Include(o => o.Currency)
+                .ThenInclude(c => c.Symbols)
             .AsQueryable();
 
         if (request.StatementId.HasValue)

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetLatestCreditCardStatementTransactionsQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetLatestCreditCardStatementTransactionsQuery.cs
@@ -52,6 +52,8 @@ public class GetLatestCreditCardStatementTransactionsQueryHandler : BaseCollecti
                 .Include(o => o.Statement)
                 .ThenInclude(o => o.CreditCard)
                 .ThenInclude(o => o.Bank)
+                .Include(o => o.Currency)
+                .ThenInclude(c => c.Symbols)
                 .Where(o => latestStatementIds.Contains(o.StatementId))
                 .AsQueryable();
 

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQuery.cs
@@ -47,6 +47,8 @@ public class GetLatestCreditCardTransactionsFromStatementsQueryHandler : BaseCol
                 var transactionsQuery = DbContext.CreditCardTransaction
                     .Include(t => t.CreditCard)
                     .ThenInclude(cc => cc.Bank)
+                    .Include(t => t.Currency)
+                    .ThenInclude(c => c.Symbols)
                     .Where(t => latestTransactionIds.Contains(t.Id))
                     .AsQueryable();
 

--- a/FinanceBackEnd/src/Finance.Application/Queries/Summary/GetCreditCardExpensesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/Summary/GetCreditCardExpensesQuery.cs
@@ -1,31 +1,38 @@
 using CQRSDispatch;
 using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
 using Finance.Application.Dtos.Summary;
-using Finance.Persistence;
-using Microsoft.EntityFrameworkCore;
+using Finance.Application.Queries.CreditCards;
+using Finance.Application.Services;
+using Finance.Domain.Models.Interfaces;
+using Finance.Domain.SpecialTypes;
+using Finance.Persistence.Constants;
 
 namespace Finance.Application.Queries.Summary;
 
 public record GetCreditCardExpensesQuery : IQuery<Expense>;
 
-public class GetCreditCardExpensesQueryHandler(FinanceDbContext db) : IQueryHandler<GetCreditCardExpensesQuery, Expense>
+public class GetCreditCardExpensesQueryHandler(
+    IDispatcher<FinanceDispatchContext> dispatcher,
+    CurrencyConversionService currencyConverter)
+    : IQueryHandler<GetCreditCardExpensesQuery, Expense>
 {
-    private readonly FinanceDbContext _db = db;
+    private readonly IDispatcher<FinanceDispatchContext> _dispatcher = dispatcher;
+    private readonly CurrencyConversionService _currencyConverter = currencyConverter;
 
     public async Task<DataResult<Expense>> ExecuteAsync(GetCreditCardExpensesQuery request, CancellationToken cancellationToken)
     {
-        var total = 0;
-        var creditCards = _db.CreditCard.Include(o => o.Bank).Where(o => !o.Deactivated).ToArray();
-        foreach (var creditCard in creditCards)
-        {
-            var baseQuery = _db.CreditCardTransaction.Where(o => o.CreditCardId == creditCard.Id);
-            var count = await baseQuery.CountAsync(cancellationToken);
-            if (count > 0)
-            {
-                var timeStamp = await baseQuery.MaxAsync(o => o.Timestamp, cancellationToken);
-                total += await baseQuery.Where(o => o.Timestamp == timeStamp).SumAsync(o => o.Amount, cancellationToken);
-            }
-        }
+        var defaultCurrencyId = Guid.Parse(CurrencyConstants.DefaultCurrencyId);
+
+        var transactionsResult = await _dispatcher.DispatchQueryAsync(
+            new GetLatestCreditCardTransactionsFromStatementsQuery { IncludeDeactivated = false });
+
+        var holders = transactionsResult.Data
+            .Select(t => (IAmountHolder)new TransactionAmountHolder { CurrencyId = t.CurrencyId, Amount = t.Amount })
+            .ToList();
+
+        var convertedAmounts = await _currencyConverter.ConvertCollection(holders, defaultCurrencyId);
+        var total = convertedAmounts.Sum(m => (decimal)m);
 
         return DataResult<Expense>.Success(new Expense()
         {
@@ -33,5 +40,11 @@ public class GetCreditCardExpensesQueryHandler(FinanceDbContext db) : IQueryHand
             Label = "Tarjetas de crédito",
             Value = total
         });
+    }
+
+    private sealed class TransactionAmountHolder : IAmountHolder
+    {
+        public Guid CurrencyId { get; set; }
+        public Money Amount { get; set; }
     }
 }

--- a/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardStatementTransaction.cs
+++ b/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardStatementTransaction.cs
@@ -1,4 +1,5 @@
 using Finance.Domain.Models.Base;
+using Finance.Domain.Models.Currencies;
 using Finance.Domain.SpecialTypes;
 
 namespace Finance.Domain.Models.CreditCards;
@@ -10,4 +11,6 @@ public class CreditCardStatementTransaction : CreditCardStatementEntity
     public DateTime PostedDate { get; set; }
     public Money Amount { get; set; } = 0;
     public string Description { get; set; } = string.Empty;
+    public Guid CurrencyId { get; set; }
+    public virtual Currency Currency { get; set; } = default!;
 }

--- a/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardTransaction.cs
+++ b/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardTransaction.cs
@@ -1,4 +1,5 @@
 using Finance.Domain.Models.Base;
+using Finance.Domain.Models.Currencies;
 using Finance.Domain.SpecialTypes;
 
 namespace Finance.Domain.Models.CreditCards;
@@ -12,6 +13,8 @@ public class CreditCardTransaction : CreditCardEntity
     public string Concept { get; set; } = string.Empty;
     public Money Amount { get; set; } = 0;
     public string? Reference { get; set; }
+    public Guid CurrencyId { get; set; }
+    public virtual Currency Currency { get; set; } = default!;
 }
 
 public enum CreditCardTransactionType

--- a/FinanceBackEnd/src/Finance.Migrations/20260329061819_AddCurrencyToTransactions.Designer.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260329061819_AddCurrencyToTransactions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Finance.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Finance.Domain.Migrations
 {
     [DbContext(typeof(FinanceDbContext))]
-    partial class FinanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329061819_AddCurrencyToTransactions")]
+    partial class AddCurrencyToTransactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FinanceBackEnd/src/Finance.Migrations/20260329061819_AddCurrencyToTransactions.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260329061819_AddCurrencyToTransactions.cs
@@ -1,0 +1,83 @@
+﻿using Finance.Persistence.Constants;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Finance.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCurrencyToTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CurrencyId",
+                table: "CreditCardTransaction",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid($"{CurrencyConstants.DefaultCurrencyId}"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CurrencyId",
+                table: "CreditCardStatementTransaction",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid($"{CurrencyConstants.DefaultCurrencyId}"));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CreditCardTransaction_CurrencyId",
+                table: "CreditCardTransaction",
+                column: "CurrencyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CreditCardStatementTransaction_CurrencyId",
+                table: "CreditCardStatementTransaction",
+                column: "CurrencyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CreditCardStatementTransaction_Currency_CurrencyId",
+                table: "CreditCardStatementTransaction",
+                column: "CurrencyId",
+                principalTable: "Currency",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CreditCardTransaction_Currency_CurrencyId",
+                table: "CreditCardTransaction",
+                column: "CurrencyId",
+                principalTable: "Currency",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CreditCardStatementTransaction_Currency_CurrencyId",
+                table: "CreditCardStatementTransaction");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CreditCardTransaction_Currency_CurrencyId",
+                table: "CreditCardTransaction");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CreditCardTransaction_CurrencyId",
+                table: "CreditCardTransaction");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CreditCardStatementTransaction_CurrencyId",
+                table: "CreditCardStatementTransaction");
+
+            migrationBuilder.DropColumn(
+                name: "CurrencyId",
+                table: "CreditCardTransaction");
+
+            migrationBuilder.DropColumn(
+                name: "CurrencyId",
+                table: "CreditCardStatementTransaction");
+        }
+    }
+}

--- a/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardStatementTransactionConfiguration.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardStatementTransactionConfiguration.cs
@@ -37,6 +37,13 @@ public class CreditCardStatementTransactionConfiguration : IEntityTypeConfigurat
             .OnDelete(DeleteBehavior.SetNull);
 
         builder
+            .HasOne(st => st.Currency)
+            .WithMany()
+            .HasForeignKey(st => st.CurrencyId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder
             .HasIndex(st => new { st.StatementId, st.PostedDate });
     }
 }

--- a/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardTransactionConfiguration.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardTransactionConfiguration.cs
@@ -46,6 +46,13 @@ public class CreditCardTransactionConfiguration : IEntityTypeConfiguration<Credi
             .OnDelete(DeleteBehavior.SetNull);
 
         builder
+            .HasOne(t => t.Currency)
+            .WithMany()
+            .HasForeignKey(t => t.CurrencyId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder
             .HasIndex(t => new { t.CreditCardId, t.Timestamp });
     }
 }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardTransactionCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardTransactionCommandHandlerTests.cs
@@ -89,6 +89,67 @@ public class CreateCreditCardTransactionCommandHandlerTests : QueryHandlerBaseTe
     }
 
     [Fact]
+    public async Task Create_WithCurrencyId_SetsCurrencyIdOnTransaction()
+    {
+        var currencyId = Guid.NewGuid();
+        var creditCard = new CreditCard { Id = Guid.NewGuid(), Name = "Visa" };
+        var command = new CreateCreditCardTransactionCommand
+        {
+            CreditCardId = creditCard.Id,
+            Timestamp = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Test",
+            Amount = new Money(500m),
+            CurrencyId = currencyId,
+        };
+
+        _creditCardRepo
+            .Setup(r => r.GetByIdAsync(creditCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(creditCard);
+        _transactionRepo
+            .Setup(r => r.AddAsync(It.IsAny<CreditCardTransaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(currencyId, result.Data.CurrencyId);
+    }
+
+    [Fact]
+    public async Task Create_WithStatementIdAndCurrencyId_SetsCurrencyIdOnStatementTransaction()
+    {
+        var currencyId = Guid.NewGuid();
+        var creditCard = new CreditCard { Id = Guid.NewGuid(), Name = "Mastercard" };
+        var statementId = Guid.NewGuid();
+        var command = new CreateCreditCardTransactionCommand
+        {
+            CreditCardId = creditCard.Id,
+            CreditCardStatementId = statementId,
+            Timestamp = new DateTime(2025, 3, 5, 0, 0, 0, DateTimeKind.Utc),
+            TransactionType = CreditCardTransactionType.Purchase,
+            Concept = "Farmacia",
+            Amount = new Money(250m),
+            CurrencyId = currencyId,
+        };
+
+        _creditCardRepo
+            .Setup(r => r.GetByIdAsync(creditCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(creditCard);
+        _transactionRepo
+            .Setup(r => r.AddAsync(It.IsAny<CreditCardTransaction>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .Callback<CreditCardTransaction, CancellationToken, bool>((tx, _, _) => tx.Id = Guid.NewGuid())
+            .Returns(Task.CompletedTask);
+
+        await CreateHandler().ExecuteAsync(command, default);
+
+        var statementTx = _dbContext.CreditCardStatementTransaction
+            .IgnoreQueryFilters()
+            .Single(st => st.StatementId == statementId);
+        Assert.Equal(currencyId, statementTx.CurrencyId);
+    }
+
+    [Fact]
     public async Task Create_WhenCreditCardNotFound_ThrowsException()
     {
         var command = new CreateCreditCardTransactionCommand

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardTransactionCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardTransactionCommandHandlerTests.cs
@@ -53,6 +53,37 @@ public class UpdateCreditCardTransactionCommandHandlerTests : QueryHandlerBaseTe
     }
 
     [Fact]
+    public async Task Update_WithNewCurrencyId_UpdatesCurrencyId()
+    {
+        var newCurrencyId = Guid.NewGuid();
+        var transaction = new CreditCardTransaction
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Concept = "Original",
+            Amount = new Money(100m),
+            CurrencyId = Guid.NewGuid(),
+        };
+        var command = new UpdateCreditCardTransactionCommand
+        {
+            Id = transaction.Id,
+            Timestamp = transaction.Timestamp,
+            Concept = transaction.Concept,
+            Amount = transaction.Amount,
+            CurrencyId = newCurrencyId,
+        };
+
+        _transactionRepo
+            .Setup(r => r.GetByIdAsync(transaction.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transaction);
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(newCurrencyId, result.Data.CurrencyId);
+    }
+
+    [Fact]
     public async Task Update_WhenTransactionNotFound_ThrowsException()
     {
         var command = new UpdateCreditCardTransactionCommand

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogCurrenciesQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Catalog/GetCatalogCurrenciesQueryHandlerTests.cs
@@ -66,7 +66,24 @@ public class GetCatalogCurrenciesQueryHandlerTests : QueryHandlerBaseTests
         var result = await handler.ExecuteAsync(new GetCatalogCurrenciesQuery(), default);
 
         Assert.True(result.IsSuccess);
-        Assert.Contains(result.Data, x => x.Name == "ARS");
+        Assert.Contains(result.Data, x => x.Name == "$");
         Assert.Contains(result.Data, x => x.Name == "USD");
+    }
+
+    [Fact]
+    public async Task GetCatalogCurrencies_WhenCurrencyHasSymbol_UsesSymbolAsName()
+    {
+        var currency = CurrencyFixture.Build(
+            shortName: "BRL",
+            symbols: [new Finance.Domain.Models.Currencies.CurrencySymbol { Symbol = "R$" }]);
+        await _dbContext.Currency.AddAsync(currency);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetCatalogCurrenciesQueryHandler(_dbContext);
+        var result = await handler.ExecuteAsync(new GetCatalogCurrenciesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var item = result.Data.Single(x => x.Id == currency.Id);
+        Assert.Equal("R$", item.Name);
     }
 }

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetCreditCardTransactionsQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetCreditCardTransactionsQueryHandlerTests.cs
@@ -38,6 +38,7 @@ public class GetCreditCardTransactionsQueryHandlerTests : QueryHandlerBaseTests
             Concept = concept,
             Amount = new Money(amount),
             Deactivated = deactivated,
+            CurrencyId = Guid.Parse("6d189135-7040-45a1-b713-b1aa6cad1720"),
         };
         await _dbContext.User.AddAsync(user);
         await _dbContext.Bank.AddAsync(bank);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests.cs
@@ -45,6 +45,7 @@ public class GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests : Qu
             Concept = "Purchase",
             Amount = new Money(100m),
             Deactivated = txDeactivated,
+            CurrencyId = Guid.Parse("6d189135-7040-45a1-b713-b1aa6cad1720"),
         };
         var statementTx = new CreditCardStatementTransaction
         {
@@ -109,6 +110,7 @@ public class GetLatestCreditCardTransactionsFromStatementsQueryHandlerTests : Qu
             TransactionType = CreditCardTransactionType.Purchase,
             Concept = "Newer purchase",
             Amount = new Money(200m),
+            CurrencyId = Guid.Parse("6d189135-7040-45a1-b713-b1aa6cad1720"),
         };
         _dbContext.CreditCardStatement.Add(newerStatement);
         _dbContext.CreditCardTransaction.Add(newerTx);

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Summary/GetCreditCardExpensesQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/Summary/GetCreditCardExpensesQueryHandlerTests.cs
@@ -1,0 +1,138 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Queries.Summary;
+using Finance.Application.Services;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Currencies;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Policies;
+using Finance.Domain.SpecialTypes;
+using Finance.Persistence.Constants;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Finance.Application.Tests.Queries.Summary;
+
+public class GetCreditCardExpensesQueryHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
+    private readonly IMemoryCache _cache;
+    private readonly CurrencyConversionService _currencyConverter;
+
+    private static readonly Guid DefaultCurrencyId = Guid.Parse(CurrencyConstants.DefaultCurrencyId);
+    private static readonly Guid UsdCurrencyId = Guid.Parse(CurrencyConstants.DollarId);
+
+    public GetCreditCardExpensesQueryHandlerTests()
+    {
+        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _currencyConverter = new CurrencyConversionService(_dispatcher.Object, _dbContext, new CurrencyConversionPolicy(), _cache);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _cache.Dispose();
+    }
+
+    private GetCreditCardExpensesQueryHandler CreateHandler() =>
+        new(_dispatcher.Object, _currencyConverter);
+
+    private void SetupTransactions(List<CreditCardTransaction> transactions)
+    {
+        _dispatcher
+            .Setup(d => d.DispatchQueryAsync<List<CreditCardTransaction>>(It.IsAny<IQuery<List<CreditCardTransaction>>>()))
+            .ReturnsAsync(DataResult<List<CreditCardTransaction>>.Success(transactions));
+    }
+
+    private void SetupExchangeRates(List<CurrencyExchangeRate> rates)
+    {
+        _dispatcher
+            .Setup(d => d.DispatchQueryAsync<List<CurrencyExchangeRate>>(It.IsAny<IQuery<List<CurrencyExchangeRate>>>()))
+            .ReturnsAsync(DataResult<List<CurrencyExchangeRate>>.Success(rates));
+    }
+
+    [Fact]
+    public async Task Execute_WhenNoTransactions_ReturnsZeroValue()
+    {
+        SetupTransactions([]);
+        SetupExchangeRates([]);
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardExpensesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0m, result.Data.Value);
+    }
+
+    [Fact]
+    public async Task Execute_WithDefaultCurrencyTransactions_ReturnsSumDirectly()
+    {
+        var transactions = new List<CreditCardTransaction>
+        {
+            new() { Id = Guid.NewGuid(), CurrencyId = DefaultCurrencyId, Amount = new Money(1000m) },
+            new() { Id = Guid.NewGuid(), CurrencyId = DefaultCurrencyId, Amount = new Money(500m) },
+        };
+        SetupTransactions(transactions);
+        SetupExchangeRates([]);
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardExpensesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1500m, result.Data.Value);
+    }
+
+    [Fact]
+    public async Task Execute_WithForeignCurrencyTransactions_ConvertsToDefaultCurrency()
+    {
+        var transactions = new List<CreditCardTransaction>
+        {
+            new() { Id = Guid.NewGuid(), CurrencyId = UsdCurrencyId, Amount = new Money(100m) },
+        };
+        var rates = new List<CurrencyExchangeRate>
+        {
+            new()
+            {
+                BaseCurrencyId = DefaultCurrencyId,
+                QuoteCurrencyId = UsdCurrencyId,
+                BuyRate = 1000m,
+                SellRate = 1100m,
+                TimeStamp = DateTime.UtcNow,
+            },
+        };
+        SetupTransactions(transactions);
+        SetupExchangeRates(rates);
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardExpensesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(110000m, result.Data.Value);
+    }
+
+    [Fact]
+    public async Task Execute_WithMixedCurrencyTransactions_ConvertsAndSumsAll()
+    {
+        var transactions = new List<CreditCardTransaction>
+        {
+            new() { Id = Guid.NewGuid(), CurrencyId = DefaultCurrencyId, Amount = new Money(2000m) },
+            new() { Id = Guid.NewGuid(), CurrencyId = UsdCurrencyId, Amount = new Money(50m) },
+        };
+        var rates = new List<CurrencyExchangeRate>
+        {
+            new()
+            {
+                BaseCurrencyId = DefaultCurrencyId,
+                QuoteCurrencyId = UsdCurrencyId,
+                BuyRate = 900m,
+                SellRate = 1000m,
+                TimeStamp = DateTime.UtcNow,
+            },
+        };
+        SetupTransactions(transactions);
+        SetupExchangeRates(rates);
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardExpensesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(52000m, result.Data.Value);
+    }
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -122,7 +122,7 @@ function StatementPicker({
 
 function TransactionsTable({ transactions }: { transactions: CreditCardTransaction[] }) {
   const totalAmount = transactions.reduce(
-    (acc, tx) => acc + toNumber(tx.amount as unknown as ValueLike, 0),
+    (acc, tx) => acc + toNumber(tx.convertedAmount as unknown as ValueLike, 0),
     0
   );
 
@@ -132,13 +132,14 @@ function TransactionsTable({ transactions }: { transactions: CreditCardTransacti
         <TableRow>
           <TableHead>Fecha</TableHead>
           <TableHead>Concepto</TableHead>
-          <TableHead className="text-right">Monto</TableHead>
+          <TableHead className="w-20">Moneda</TableHead>
+          <TableHead className="w-32 text-right">Monto</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {transactions.length === 0 ? (
           <TableRow>
-            <TableCell colSpan={3} className="text-center text-muted-foreground">
+            <TableCell colSpan={4} className="text-center text-muted-foreground">
               No se encontraron movimientos
             </TableCell>
           </TableRow>
@@ -147,6 +148,7 @@ function TransactionsTable({ transactions }: { transactions: CreditCardTransacti
             <TableRow key={tx.id}>
               <TableCell>{formatDate(tx.timestamp)}</TableCell>
               <TableCell>{tx.concept}</TableCell>
+              <TableCell>{tx.currency?.defaultSymbol ?? tx.currency?.shortName}</TableCell>
               <TableCell className="text-right">{formatMoney(tx.amount)}</TableCell>
             </TableRow>
           ))
@@ -156,6 +158,7 @@ function TransactionsTable({ transactions }: { transactions: CreditCardTransacti
         <TableFooter>
           <TableRow>
             <TableCell className="font-medium">Total</TableCell>
+            <TableCell></TableCell>
             <TableCell></TableCell>
             <TableCell className="text-right font-medium">{formatMoney(totalAmount)}</TableCell>
           </TableRow>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
@@ -21,11 +21,17 @@ import {
 import urls from '@/utils/urls';
 import type { CreditCardStatement, CreditCardTransaction } from '@/types/creditCard';
 
+interface Currency {
+  id: string;
+  name: string;
+}
+
 interface DraftTransaction {
   id?: string;
   timestamp: string;
   concept: string;
   amount: string;
+  currencyId: string;
   isDeleted: boolean;
   isModified: boolean;
 }
@@ -47,6 +53,16 @@ export default function EditStatementModal({
   const [expiringDate, setExpiringDate] = useState('');
   const [draftTxs, setDraftTxs] = useState<DraftTransaction[]>([]);
   const [submitting, setSubmitting] = useState(false);
+  const [currencies, setCurrencies] = useState<Currency[]>([]);
+
+  useEffect(() => {
+    fetch(String(urls.catalog.currencies.endpoint))
+      .then((r) => r.json())
+      .then((data: Currency[]) => setCurrencies(data))
+      .catch(() => {});
+  }, []);
+
+  const defaultCurrencyId = currencies[0]?.id ?? '';
 
   useEffect(() => {
     if (show) {
@@ -58,16 +74,17 @@ export default function EditStatementModal({
           timestamp: tx.timestamp.slice(0, 10),
           concept: tx.concept,
           amount: String(tx.amount),
+          currencyId: tx.currencyId ?? defaultCurrencyId,
           isDeleted: false,
           isModified: false,
         }))
       );
     }
-  }, [show, statement, transactions]);
+  }, [show, statement, transactions, currencies]);
 
   const updateTx = (
     index: number,
-    field: keyof Pick<DraftTransaction, 'timestamp' | 'concept' | 'amount'>,
+    field: keyof Pick<DraftTransaction, 'timestamp' | 'concept' | 'amount' | 'currencyId'>,
     value: string
   ) => {
     setDraftTxs((prev) =>
@@ -90,6 +107,7 @@ export default function EditStatementModal({
         timestamp: localDate,
         concept: '',
         amount: '0',
+        currencyId: defaultCurrencyId,
         isDeleted: false,
         isModified: false,
       },
@@ -135,6 +153,7 @@ export default function EditStatementModal({
             timestamp: new Date(tx.timestamp).toISOString(),
             concept: tx.concept,
             amount: Number(tx.amount),
+            currencyId: tx.currencyId,
             transactionType: 0,
           }),
         });
@@ -152,6 +171,7 @@ export default function EditStatementModal({
             timestamp: new Date(tx.timestamp).toISOString(),
             concept: tx.concept,
             amount: Number(tx.amount),
+            currencyId: tx.currencyId,
           }),
         });
         if (!res.ok) throw new Error(await res.text());
@@ -212,6 +232,7 @@ export default function EditStatementModal({
                   <TableRow>
                     <TableHead className="w-36">Fecha</TableHead>
                     <TableHead>Concepto</TableHead>
+                    <TableHead className="w-28">Moneda</TableHead>
                     <TableHead className="w-28 text-right">Monto</TableHead>
                     <TableHead className="w-10"></TableHead>
                   </TableRow>
@@ -219,7 +240,7 @@ export default function EditStatementModal({
                 <TableBody>
                   {visibleTxs.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={4} className="text-center text-muted-foreground">
+                      <TableCell colSpan={5} className="text-center text-muted-foreground">
                         Sin movimientos
                       </TableCell>
                     </TableRow>
@@ -243,6 +264,17 @@ export default function EditStatementModal({
                               className="h-8 text-sm"
                               placeholder="Concepto"
                             />
+                          </TableCell>
+                          <TableCell>
+                            <select
+                              value={tx.currencyId}
+                              onChange={(e) => updateTx(realIndex, 'currencyId', e.target.value)}
+                              className="h-8 w-full text-sm rounded-md border border-input bg-background px-2"
+                            >
+                              {currencies.map((c) => (
+                                <option key={c.id} value={c.id}>{c.name}</option>
+                              ))}
+                            </select>
                           </TableCell>
                           <TableCell>
                             <Input

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/dashboardHelpers.ts
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/dashboardHelpers.ts
@@ -85,6 +85,23 @@ export const dollarCalculator = (r: ValueLike, creditCardConversion: unknown) =>
   return toNumber(r) * toNumber(sellRate, 1);
 };
 
+export const convertToDefaultCurrency = (
+  amount: number,
+  currencyId: string,
+  defaultCurrencyId: string,
+  rates: unknown
+): number => {
+  if (!currencyId || currencyId === defaultCurrencyId) return amount;
+  const ratesList = Array.isArray(rates) ? rates : [];
+  const rate = ratesList.find(
+    (r) =>
+      safeProp(r, 'baseCurrencyId') === defaultCurrencyId &&
+      safeProp(r, 'quoteCurrencyId') === currencyId
+  );
+  if (!rate) return amount;
+  return amount * toNumber(safeProp(rate, 'sellRate') as ValueLike, 1);
+};
+
 export const DEBIT_MODULE_PESOS = '4c1ee918-e8f9-4bed-8301-b4126b56cfc0';
 export const DEBIT_MODULE_DOLLARS = '03cc66c7-921c-4e05-810e-9764cd365c1d';
 export const DEBIT_MODULES = [DEBIT_MODULE_PESOS, DEBIT_MODULE_DOLLARS];
@@ -154,7 +171,7 @@ export const buildCurrencyRatesColumns = () => [
   DecimalColumn('value', 'Venta', (v: unknown) => getSafeValueFrom(safeProp(v, 'sellRate'))),
 ];
 
-export const buildCreditCardColumns = (latestCurrencyExchangeRates: unknown) => [
+export const buildCreditCardColumns = () => [
   {
     id: 'timestamp',
     label: 'Fecha',
@@ -164,22 +181,27 @@ export const buildCreditCardColumns = (latestCurrencyExchangeRates: unknown) => 
     },
   },
   { id: 'concept', label: 'Concepto' },
-  DecimalColumn('amount', 'Monto', (v: unknown) => toNumber(safeProp(v, 'amount') as ValueLike, 0)),
-  DecimalColumn('amountDollars', 'Dólares', (v: unknown) => toNumber(safeProp(v, 'amountDollars') as ValueLike, 0)),
-  DecimalColumn(
-    'totalAmount',
-    'Total',
-    (v: unknown) => {
-      if (!v) return 0;
-      const amount = toNumber(safeProp(v, 'amount') as ValueLike, 0);
-      const amountDollars = toNumber(safeProp(v, 'amountDollars') as ValueLike, 0);
-      return amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
+  {
+    id: 'currency',
+    label: 'Moneda',
+    mapper: (v: unknown) => {
+      const currency = safeProp(v, 'currency');
+      return (safeProp(currency, 'shortName') as string) ?? '';
     },
-    (acc: number, v: unknown) => {
-      if (!v) return acc;
-      const amount = toNumber(safeProp(v, 'amount') as ValueLike, 0);
-      const amountDollars = toNumber(safeProp(v, 'amountDollars') as ValueLike, 0);
-      return acc + amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
-    }
+  },
+  {
+    id: 'amount',
+    label: 'Monto',
+    class: ['text-end'],
+    headerClass: ['text-end'],
+    type: InputType.Decimal,
+    mapper: (v: unknown) => toNumber(safeProp(v, 'amount') as ValueLike, 0),
+    formatter: moneyFormatter,
+  },
+  DecimalColumn(
+    'convertedAmount',
+    'Total',
+    (v: unknown) => toNumber(safeProp(v, 'convertedAmount') as ValueLike, 0),
+    (acc: number, v: unknown) => acc + toNumber(safeProp(v, 'convertedAmount') as ValueLike, 0)
   ),
 ];

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -15,14 +15,13 @@ import {
   DEBIT_MODULES,
   DEBIT_TABLE_NAMES,
   DEBIT_TABLE_TITLES,
-  dollarCalculator,
   getSafeValueFrom,
   moneyFormatter,
 } from './dashboardHelpers';
 import SummaryDetail from './SummaryDetail';
 
 export default function Dashboard() {
-  const { creditCards, latestCurrencyExchangeRates, defaultCurrency } = useLoaderData<typeof loader>();
+  const { creditCards, defaultCurrency } = useLoaderData<typeof loader>();
   const defaultCurrencySymbol = defaultCurrency?.symbol ?? '$';
   const navigate = useNavigate();
   const isSummary = !!useMatch('/dashboard/summary');
@@ -34,7 +33,7 @@ export default function Dashboard() {
   const expensesColumns = buildExpensesColumns(defaultCurrencySymbol);
   const debitColumns = buildDebitColumns();
   const currencyRatesColumns = buildCurrencyRatesColumns();
-  const creditCardColumns = buildCreditCardColumns(latestCurrencyExchangeRates);
+  const creditCardColumns = buildCreditCardColumns();
 
   return (
     <>
@@ -162,14 +161,10 @@ export default function Dashboard() {
                           wrapper={{ classes: tableContainer.split(' ') }}
                           collapsible={{
                             summary: (rows) => {
-                              const totalPesos = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amount'), 0);
-                              const totalDollars = rows.reduce((acc, r) => acc + getSafeValueFrom(r, 'amountDollars'), 0);
                               const total = rows.reduce((acc, r) => {
-                                const amount = getSafeValueFrom(r, 'amount');
-                                const amountDollars = getSafeValueFrom(r, 'amountDollars');
-                                return acc + amount + dollarCalculator(amountDollars, latestCurrencyExchangeRates);
+                                return acc + getSafeValueFrom(r, 'convertedAmount');
                               }, 0);
-                              return `${data.name}: $${moneyFormatter(totalPesos)} | USD ${moneyFormatter(totalDollars)} | ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                              return `${data.name}: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
                             }
                           }}
                         />

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/utils/FetchTable.tsx
@@ -263,14 +263,8 @@ const FetchTable: React.FC<FetchTableProps> = ({
                 column.type !== undefined &&
                 [InputType.Decimal, InputType.Integer].includes(column.type as InputType);
 
-              if (!isNumericCol)
+              if (!isNumericCol || !column?.totals?.reducer)
                 return <TableCell key={cellKey} style={{ borderTop: '3px solid' }} />;
-
-              if (!column?.totals?.reducer) {
-                throw new Error(
-                  `Totals reducer for table "${name}"'s colum "${column.id}" undefined`
-                );
-              }
 
               const value = (data ?? []).reduce(
                 (acc, item) =>

--- a/FinanceFrontEnd/FinanceApp/app/routes/dashboard.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/dashboard.tsx
@@ -12,7 +12,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     let creditCards = [];
     let latestCurrencyExchangeRates = null;
-    let defaultCurrency: { symbol: string } | null = null;
+    let defaultCurrency: { id: string; symbol: string } | null = null;
     try {
       if (!user.accessToken) {
         throw new Error('No access token available');
@@ -26,7 +26,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       creditCards = creditCardsResult;
       latestCurrencyExchangeRates = exchangeRatesResult;
       const symbol = (currencyResult as { defaultSymbol?: string } | undefined)?.defaultSymbol;
-      defaultCurrency = symbol ? { symbol } : null;
+      defaultCurrency = symbol ? { id: CURRENCY_IDS.ARS, symbol } : null;
     } catch (e) {
       serverLogger.error('[dashboard loader] Error fetching dashboard data', e);
     }

--- a/FinanceFrontEnd/FinanceApp/app/types/creditCard.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/creditCard.ts
@@ -25,6 +25,9 @@ export interface CreditCardTransaction {
   timestamp: string;
   concept: string;
   amount: number;
+  convertedAmount: number;
+  currencyId: string;
+  currency?: { id: string; name: string; shortName: string; defaultSymbol?: string };
   amountDollars?: number;
   reference?: string;
 }


### PR DESCRIPTION
# Why
Credit card transactions previously had no currency field — all amounts were treated as the default currency (ARS). This made it impossible to correctly track foreign-currency transactions (e.g. USD purchases), which caused dashboard expense totals and the edit statement modal to show incorrect values when multiple currencies were involved.

## What is the solution?
- Added `CurrencyId` (FK) to `CreditCardTransaction` and `CreditCardStatementTransaction` domain models, with an EF migration (`AddCurrencyToTransactions`)
- Create/Update commands now accept and persist `CurrencyId`
- `GetCatalogCurrenciesQuery` now returns the currency symbol (e.g. `$`, `USD`) instead of the ISO short name, for use in pickers
- `GetCreditCardExpensesQuery` was fully rewritten: it dispatches `GetLatestCreditCardTransactionsFromStatementsQuery` to get each card's latest statement transactions and then converts all amounts to ARS via `CurrencyConversionService`
- Transaction DTOs expose `CurrencyId` and `ConvertedAmount`
- `EditStatementModal` fetches the currency catalog and renders a currency picker for each transaction
- Dashboard credit-card totals use the pre-converted `convertedAmount` field
- `FetchTable` no longer throws when a numeric column has no `totals.reducer`
- Unit tests added for all changed handlers

## What areas of the site does it impact?
- **Credit Cards** — Edit Statement modal (currency picker), transaction list columns
- **Dashboard** — expense summary total for credit cards
- **Backend API** — credit card transaction create/update/read endpoints; catalog currencies endpoint; summary expenses endpoint
- **Database** — new `CurrencyId` column on `CreditCardTransaction` and `CreditCardStatementTransaction`

## Test scenarios

```gherkin
Scenario: Create transaction with a specific currency
  Given I open the Edit Statement modal for a credit card
  When I add a new transaction and select "USD" as the currency
  Then the transaction is saved with CurrencyId pointing to USD

Scenario: Dashboard expense total converts foreign currencies
  Given I have credit card transactions in ARS and USD
  When I view the dashboard
  Then the credit card expense total shows the sum in ARS using the current exchange rate

Scenario: Currency catalog returns symbol
  Given the currency catalog endpoint is called
  Then the response for ARS shows name "$"
  And the response for USD shows name "USD"

Scenario: FetchTable numeric column with no totals reducer
  Given a table column is configured as Decimal type with no totals.reducer
  When the table renders its footer
  Then no runtime error is thrown and the footer cell is empty
```

## Other Notes
Closes #131