### PR TITLE
docs(tooling): add Claude Code commands, AGENTS.md, CLAUDE.md and sync Copilot skills

### DIFF
--- a/.claude/commands/bug/SKILL.md
+++ b/.claude/commands/bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: gh-bug-fix-pr
-description: "Create a GitHub bug issue, branch, commit, publish, and open a PR for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping a bug fix, creating a bug PR, committing changes, publishing a fix branch."
+name: bug
+description: "Create a GitHub bug issue, branch, commit, and publish a fix branch for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping a bug fix, committing changes, publishing a fix branch."
 argument-hint: "<path1> [path2 ...]  — one or more workspace-relative paths whose changes to include"
 ---
 
@@ -26,6 +26,8 @@ Multiple paths can be provided space-separated or as a list.
 ## Procedure
 
 ### 1 — Inspect changes
+
+**Paths:** $ARGUMENTS
 
 For each provided path run:
 
@@ -103,36 +105,11 @@ git commit --amend --no-edit
 git push -u origin fix/<short-slug>
 ```
 
-### 6 — Open the PR using the repo's PR template
-
-Read `.github/PULL_REQUEST_TEMPLATE.md` and populate every section with content derived from the diff analysis. Then run:
-
-```powershell
-$prBody = @'
-<populated PR template body>
-'@
-
-gh pr create `
-  --base main `
-  --head fix/<short-slug> `
-  --title "fix: <same title as issue>" `
-  --body $prBody
-```
-
-> **Important:** Always assign the PR body to a variable using a PowerShell here-string (`@' ... '@`) before passing it to `gh pr create`. Passing the body as an inline string with backtick line-continuation causes PowerShell to silently truncate the body at the first backtick inside the content (e.g. inline code fences).
-
-The PR body must follow the template structure from [.github/PULL_REQUEST_TEMPLATE.md](../../PULL_REQUEST_TEMPLATE.md):
-
-- **# Why** — what the bug was
-- **## What is the solution?** — how the fix was implemented
-- **## What areas of the site does it impact?** — which modules/layers are affected
-- **## Test scenarios** — Gherkin scenarios covering the fix
-- **## Other Notes** — `Closes #<issue-number>`
-
 ## Output
 
 Report to the user:
 - Issue URL
 - Branch name
 - Commit SHA (from `git log -1 --oneline`)
-- PR URL
+
+Run `/pr` to open the pull request when ready.

--- a/.claude/commands/docs/SKILL.md
+++ b/.claude/commands/docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: gh-docs-pr
-description: "Create a GitHub docs issue, branch, commit, publish, and open a PR for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping documentation changes, creating a docs PR, committing doc updates, publishing a docs branch."
+name: docs
+description: "Create a GitHub docs issue, branch, commit, and publish a docs branch for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping documentation changes, committing doc updates, publishing a docs branch."
 argument-hint: "<path1> [path2 ...]  — one or more workspace-relative paths whose changes to include"
 ---
 
@@ -26,6 +26,8 @@ Multiple paths can be provided space-separated or as a list.
 ## Procedure
 
 ### 1 — Inspect changes
+
+**Paths:** $ARGUMENTS
 
 For each provided path run:
 
@@ -103,35 +105,11 @@ git commit --amend --no-edit
 git push -u origin docs/<short-slug>
 ```
 
-### 6 — Open the PR using the repo's PR template
-
-Read `.github/PULL_REQUEST_TEMPLATE.md` and populate every section with content derived from the diff analysis. Then run:
-
-```powershell
-$prBody = @'
-<populated PR template body>
-'@
-
-gh pr create `
-  --base main `
-  --head docs/<short-slug> `
-  --title "docs: <same title as issue>" `
-  --body $prBody
-```
-
-> **Important:** Always assign the PR body to a variable using a PowerShell here-string (`@' ... '@`) before passing it to `gh pr create`. Passing the body as an inline string with backtick line-continuation causes PowerShell to silently truncate the body at the first backtick inside the content (e.g. inline code fences).
-
-The PR body must follow the template structure from [.github/PULL_REQUEST_TEMPLATE.md](../../PULL_REQUEST_TEMPLATE.md):
-
-- **# Why** — what prompted the documentation change
-- **## What is the solution?** — what was written or updated and how it helps
-- **## What areas of the site does it impact?** — which modules, layers, or workflows the docs relate to
-- **## Other Notes** — `Closes #<issue-number>`
-
 ## Output
 
 Report to the user:
 - Issue URL
 - Branch name
 - Commit SHA (from `git log -1 --oneline`)
-- PR URL
+
+Run `/pr` to open the pull request when ready.

--- a/.claude/commands/feat/SKILL.md
+++ b/.claude/commands/feat/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: gh-feature-pr
-description: "Create a GitHub feature issue, branch, commit, publish, and open a PR for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping a new feature, creating a feature PR, committing changes, publishing a feature branch."
+name: feat
+description: "Create a GitHub feature issue, branch, commit, and publish a feature branch for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping a new feature, committing changes, publishing a feature branch."
 argument-hint: "<path1> [path2 ...]  — one or more workspace-relative paths whose changes to include"
 ---
 
@@ -26,6 +26,8 @@ Multiple paths can be provided space-separated or as a list.
 ## Procedure
 
 ### 1 — Inspect changes
+
+**Paths:** $ARGUMENTS
 
 For each provided path run:
 
@@ -103,36 +105,11 @@ git commit --amend --no-edit
 git push -u origin feature/<short-slug>
 ```
 
-### 6 — Open the PR using the repo's PR template
-
-Read `.github/PULL_REQUEST_TEMPLATE.md` and populate every section with content derived from the diff analysis. Then run:
-
-```powershell
-$prBody = @'
-<populated PR template body>
-'@
-
-gh pr create `
-  --base main `
-  --head feature/<short-slug> `
-  --title "feat: <same title as issue>" `
-  --body $prBody
-```
-
-> **Important:** Always assign the PR body to a variable using a PowerShell here-string (`@' ... '@`) before passing it to `gh pr create`. Passing the body as an inline string with backtick line-continuation causes PowerShell to silently truncate the body at the first backtick inside the content (e.g. inline code fences).
-
-The PR body must follow the template structure from [.github/PULL_REQUEST_TEMPLATE.md](../../PULL_REQUEST_TEMPLATE.md):
-
-- **# Why** — what the feature is and why it was added
-- **## What is the solution?** — how the feature was implemented at a high level
-- **## What areas of the site does it impact?** — which modules/layers are affected
-- **## Test scenarios** — Gherkin scenarios covering the new functionality
-- **## Other Notes** — `Closes #<issue-number>`
-
 ## Output
 
 Report to the user:
 - Issue URL
 - Branch name
 - Commit SHA (from `git log -1 --oneline`)
-- PR URL
+
+Run `/pr` to open the pull request when ready.

--- a/.claude/commands/feature/SKILL.md
+++ b/.claude/commands/feature/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: feature
+description: "Implement a new full-stack feature end-to-end in this codebase. Use when: adding a new entity, adding a new module, building a new screen, implementing a new backend capability, wiring up a new API endpoint, adding a new frontend page. Covers all layers: Domain model → EF config & migration → Commands/Queries/DTOs/Mapper → API controllers → Frontend route → UI component."
+argument-hint: "<feature description>  — describe the feature to implement (e.g. 'Budgets entity with CRUD')"
+---
+
+# Feature Implementation Workflow
+
+End-to-end guide for adding a new feature to the Finanzas full-stack application.
+
+**Feature to implement:** $ARGUMENTS
+
+Read the reference file(s) relevant to the scope of the feature using the Read tool, then follow their steps in order.
+
+## Scope → Reference File
+
+| Scope | Reference |
+|-------|-----------|
+| Backend API (.NET) | `.claude/commands/feature/backend.md` |
+| FinanceApp frontend (React Router / SSR) | `.claude/commands/feature/finance-app.md` |
+| FinanceFunds frontend (Vite / SPA) | `.claude/commands/feature/funds-app.md` |
+
+A full-stack feature typically requires all three. Read each file as you reach that layer.
+
+## Architecture at a Glance
+
+```
+FinanceBackEnd/src/
+  Finance.Domain          ← Entity models
+  Finance.Persistence     ← EF Core config, DbContext, migrations
+  Finance.Application     ← Commands, Queries, DTOs, Mapping, Services
+  Finance.Api             ← REST controllers (Command / Query split)
+
+FinanceFrontEnd/
+  FinanceApp/             ← React Router SSR app (Next-style loader pattern)
+  FinanceFunds/           ← Vite SPA (Mantine UI, Auth0, direct ApiClient calls)
+```

--- a/.claude/commands/feature/backend.md
+++ b/.claude/commands/feature/backend.md
@@ -1,0 +1,608 @@
+# Backend Feature — .NET API
+
+Full step-by-step guide for adding a new entity to the `FinanceBackEnd` solution.
+
+> **IMPORTANT — Read this entire file before starting.** All steps below are required. Steps 1–8 are implementation; **Step 9 (unit tests) is mandatory** and must not be skipped.
+
+---
+
+## Required Steps (all mandatory)
+
+1. Domain Model
+2. Persistence Configuration + Migration
+3. DTO
+4. Commands (Create, Update, Delete)
+5. Queries (GetAll, GetSingle, GetPaginated)
+6. Mapper
+7. Service Requests
+8. API Controllers (Command + Query)
+9. **Unit Tests** — command handler tests, query handler tests, service tests
+
+---
+
+## Step 1 — Domain Model
+
+**Location:** `FinanceBackEnd/src/Finance.Domain/Models/<EntityName>s/<EntityName>.cs`
+
+Inherit from:
+- `Entity<Guid>` — for simple entities
+- `AuditedEntity<Guid>` — for entities that need `CreatedAt` / `UpdatedAt`
+
+```csharp
+using Finance.Domain.Models.Base;
+
+namespace Finance.Domain.Models.<EntityName>s;
+
+public class <EntityName> : AuditedEntity<Guid>
+{
+    public string Name { get; set; } = default!;
+    // add properties; use Guid FKs + virtual navigation properties
+}
+```
+
+---
+
+## Step 2 — Persistence Configuration
+
+### 2a. EF Core configuration
+
+**Location:** `FinanceBackEnd/src/Finance.Persistence/Configurations/<EntityName>Configuration.cs`
+
+```csharp
+using Finance.Domain.Models.<EntityName>s;
+using Finance.Persistence.Configurations.Base;
+
+namespace Finance.Persistence.Configurations;
+
+public class <EntityName>Configuration : AuditedEntityConfiguration<<EntityName>, Guid>;
+```
+
+Use `EntityConfiguration` base if the entity does NOT use auditing.
+
+### 2b. Register DbSet
+
+**File:** `FinanceBackEnd/src/Finance.Persistence/FinanceDbContext.cs`
+
+```csharp
+public DbSet<<EntityName>> <EntityName>s { get; set; }
+```
+
+### 2c. Create & apply migration
+
+```powershell
+cd FinanceBackEnd
+dotnet ef migrations add Add<EntityName> --project src/Finance.Migrations --startup-project src/Finance.Api
+dotnet ef database update --project src/Finance.Migrations --startup-project src/Finance.Api
+```
+
+---
+
+## Step 3 — DTO
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Dtos/<EntityName>s/<EntityName>Dto.cs`
+
+```csharp
+using Finance.Application.Dtos.Base;
+
+namespace Finance.Application.Dtos.<EntityName>s;
+
+public record <EntityName>Dto : Dto<Guid>
+{
+    // expose properties; use nested DTOs for navigation properties
+}
+```
+
+---
+
+## Step 4 — Commands (Write Side)
+
+### 4a. Base command + validator
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Commands/<EntityName>s/_Base/Upsert<EntityName>BaseCommand.cs`
+
+```csharp
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Domain.Models.<EntityName>s;
+using FluentValidation;
+
+namespace Finance.Application.Commands.<EntityName>s.Base;
+
+public abstract class Upsert<EntityName>BaseCommand : IContextAwareCommand<FinanceDispatchContext, DataResult<<EntityName>>>
+{
+    // shared properties for Create and Update
+    internal FinanceDispatchContext Context { get; private set; } = new();
+    public void SetContext(FinanceDispatchContext context) => Context = context;
+}
+
+public abstract class Upsert<EntityName>BaseCommandValidator<TCommand> : AbstractValidator<TCommand>
+    where TCommand : Upsert<EntityName>BaseCommand
+{
+    protected Upsert<EntityName>BaseCommandValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().WithMessage("Name is required.");
+    }
+}
+```
+
+### 4b. Create command
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Commands/<EntityName>s/Create<EntityName>Command.cs`
+
+```csharp
+using CQRSDispatch;
+using Finance.Application.Commands.Base;
+using Finance.Application.Commands.<EntityName>s.Base;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.<EntityName>s;
+using Finance.Persistence;
+
+namespace Finance.Application.Commands.<EntityName>s;
+
+public class Create<EntityName>CommandHandler : BaseCommandHandler<Create<EntityName>Command, <EntityName>>
+{
+    private readonly IRepository<<EntityName>, Guid> _repository;
+
+    public Create<EntityName>CommandHandler(FinanceDbContext db, IRepository<<EntityName>, Guid> repository) : base(db)
+    {
+        _repository = repository;
+    }
+
+    public override async Task<DataResult<<EntityName>>> ExecuteAsync(Create<EntityName>Command command, CancellationToken cancellationToken)
+    {
+        command.ThrowIfNotValid(new Create<EntityName>CommandValidator());
+
+        var entity = new <EntityName>
+        {
+            // map command properties
+        };
+
+        await _repository.AddAsync(entity, cancellationToken);
+        return DataResult<<EntityName>>.Success(entity);
+    }
+}
+
+public class Create<EntityName>Command : Upsert<EntityName>BaseCommand;
+public class Create<EntityName>CommandValidator : Upsert<EntityName>BaseCommandValidator<Create<EntityName>Command>;
+```
+
+### 4c. Update command
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Commands/<EntityName>s/Update<EntityName>Command.cs`
+
+Same pattern as Create. Handler loads the existing entity by Id, calls `entity.Update(...)`, saves, and returns it.
+
+### 4d. Delete command
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Commands/<EntityName>s/Delete<EntityName>sCommand.cs`
+
+Inherit from `DeleteEntityCommand` or `DeleteEntityOwnerCommand` if ownership enforcement is needed.
+
+### 4e. Activate / Deactivate (optional)
+
+Inherit from `BaseActivateCommandHandler` / `BaseDeactivateCommandHandler` for soft-delete toggle support.
+
+---
+
+## Step 5 — Queries (Read Side)
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Queries/<EntityName>s/`
+
+| File | Base class | Purpose |
+|------|-----------|---------|
+| `Get<EntityName>sQuery.cs` | `GetAllQuery<TEntity>` | List with optional filters |
+| `GetSingle<EntityName>Query.cs` | `GetSingleByIdQuery<TEntity>` | Single by Id |
+| `GetPaginated<EntityName>sQuery.cs` | `GetPaginatedQuery<TEntity>` | Paginated list |
+
+```csharp
+using CQRSDispatch;
+using Finance.Application.Commands.Base;
+using Finance.Application.Queries.Base;
+using Finance.Application.Repositories;
+using Finance.Application.Repositories.Base;
+using Finance.Domain.Models.<EntityName>s;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Queries.<EntityName>s;
+
+public class Get<EntityName>sQuery : GetAllQuery<<EntityName>>
+{
+    // optional filter properties (e.g. public string? Name { get; set; })
+}
+
+public class Get<EntityName>sQueryHandler : BaseCollectionQueryHandler<Get<EntityName>sQuery, <EntityName>>
+{
+    private readonly IRepository<<EntityName>, Guid> _repository;
+
+    public Get<EntityName>sQueryHandler(FinanceDbContext db, IRepository<<EntityName>, Guid> repository) : base(db)
+    {
+        _repository = repository;
+    }
+
+    public override async Task<DataResult<List<<EntityName>>>> ExecuteAsync(Get<EntityName>sQuery request, CancellationToken cancellationToken)
+    {
+        IQueryable<<EntityName>> query = _repository.GetDbSet()
+            // .Include(o => o.RelatedEntity)
+            .AsQueryable();
+
+        if (!request.IncludeDeactivated)
+            query = query.Where(o => !o.Deactivated);
+
+        // apply additional filters using FilterBy extension where possible
+
+        return DataResult<List<<EntityName>>>.Success(await query.ToListAsync(cancellationToken));
+    }
+}
+```
+
+---
+
+## Step 6 — Mapper
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Mapping/Mappers/<EntityName>Mapper.cs`
+
+```csharp
+using Finance.Application.Dtos.<EntityName>s;
+using Finance.Application.Mapping.Base;
+using Finance.Domain.Models.<EntityName>s;
+
+namespace Finance.Application.Mapping.Mappers;
+
+public class <EntityName>Mapper : BaseMapper<<EntityName>, <EntityName>Dto>, I<EntityName>Mapper
+{
+    public <EntityName>Mapper(IMappingService mappingService) : base(mappingService) { }
+}
+
+public interface I<EntityName>Mapper : IMapper<<EntityName>, <EntityName>Dto>;
+```
+
+Register the mapping profile in `MappingConfigExtensions.cs` if a custom profile is needed.
+
+---
+
+## Step 7 — Service Requests
+
+**Location:** `FinanceBackEnd/src/Finance.Application/Services/<EntityName>s/<EntityName>Requests.cs`
+
+```csharp
+namespace Finance.Application.Services.<EntityName>s;
+
+public sealed record Create<EntityName>Request(/* fields */);
+public sealed record Update<EntityName>Request(Guid Id, /* fields */);
+public sealed record Delete<EntityName>Request(Guid[] Ids);
+// Add SetOwner / DeleteOwner request types if resource ownership is used
+```
+
+---
+
+## Step 8 — API Controllers
+
+### 8a. Command controller
+
+**Location:** `FinanceBackEnd/src/Finance.Api/Controllers/Commands/<EntityName>CommandController.cs`
+
+```csharp
+using CQRSDispatch.Interfaces;
+using Finance.Api.Controllers.Base;
+using Finance.Application.Auth;
+using Finance.Application.Dtos.<EntityName>s;
+using Finance.Application.Mapping;
+using Finance.Application.Services.<EntityName>s;
+using Finance.Domain.Models.<EntityName>s;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Finance.Api.Controllers.Commands;
+
+[Route("api/<entity-route>")]
+public class <EntityName>CommandController(
+    IMappingService mapper,
+    IDispatcher<FinanceDispatchContext> dispatcher,
+    <EntityName>Service service)
+    : CommandController<
+        <EntityName>,
+        <EntityName>Permissions,
+        Create<EntityName>Request,
+        Update<EntityName>Request,
+        Delete<EntityName>Request,
+        Set<EntityName>OwnerRequest,
+        Delete<EntityName>OwnerRequest,
+        Guid,
+        <EntityName>Dto,
+        <EntityName>Service>(mapper, dispatcher, service)
+{
+}
+```
+
+### 8b. Query controller
+
+**Location:** `FinanceBackEnd/src/Finance.Api/Controllers/Queries/<EntityName>QueryController.cs`
+
+```csharp
+using CQRSDispatch.Interfaces;
+using Finance.Api.Controllers.Base;
+using Finance.Application.Auth;
+using Finance.Application.Mapping;
+using Finance.Application.Queries.<EntityName>s;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Finance.Api.Controllers.Queries;
+
+[Route("api/<entity-route>")]
+[Authorize(Policy = "AdminOrOwnerPolicy")]
+public class <EntityName>QueryController(IMappingService mapper, IDispatcher<FinanceDispatchContext> dispatcher)
+    : SecuredApiController
+{
+    [HttpGet]
+    public async Task<IActionResult> Get([FromQuery] Get<EntityName>sQuery request)
+    {
+        var result = await dispatcher.DispatchQueryAsync(request);
+        return Ok(result.Data);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById([FromQuery] GetSingle<EntityName>Query request)
+    {
+        var result = await dispatcher.DispatchQueryAsync(request);
+        return Ok(result.Data);
+    }
+
+    [HttpGet("paginated")]
+    public async Task<IActionResult> GetPaginated([FromQuery] GetPaginated<EntityName>sQuery request)
+    {
+        var result = await dispatcher.DispatchQueryAsync(request);
+        return Ok(result.Data);
+    }
+}
+```
+
+### 8c. Build check
+
+```powershell
+dotnet build FinanceBackEnd/src/Finance.Api
+```
+
+---
+
+## Step 9 — Unit Tests
+
+**Project:** `FinanceBackEnd/tests/Finance.Application.Tests`
+
+Global usings (`Usings.cs`) already declare `Xunit` and `Moq` — no extra imports needed for those.
+Use an in-memory `FinanceDbContext` with a unique database name per test class to keep tests isolated.
+
+---
+
+### 9a. Command handler tests
+
+**Location:** `tests/Finance.Application.Tests/Commands/<EntityName>s/Create<EntityName>CommandHandlerTests.cs`
+
+```csharp
+using Finance.Application.Commands.<EntityName>s;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.<EntityName>s;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Commands.<EntityName>s;
+
+public class Create<EntityName>CommandHandlerTests : IDisposable
+{
+    private readonly Mock<IRepository<<EntityName>, Guid>> _repository;
+    private readonly FinanceDbContext _dbContext;
+
+    public Create<EntityName>CommandHandlerTests()
+    {
+        _repository = new Mock<IRepository<<EntityName>, Guid>>();
+
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Create_HappyPath_AddsEntityAndReturnsSuccess()
+    {
+        var command = new Create<EntityName>Command { /* set required properties */ };
+
+        _repository
+            .Setup(r => r.AddAsync(It.IsAny<<EntityName>>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new Create<EntityName>CommandHandler(_dbContext, _repository.Object);
+
+        var result = await handler.ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        _repository.Verify(r => r.AddAsync(It.IsAny<<EntityName>>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WhenRequiredFieldMissing_ThrowsValidationException()
+    {
+        var command = new Create<EntityName>Command { /* leave required field empty */ };
+        var handler = new Create<EntityName>CommandHandler(_dbContext, _repository.Object);
+
+        await Assert.ThrowsAnyAsync<Exception>(() => handler.ExecuteAsync(command, default));
+    }
+}
+```
+
+Create a matching `Update<EntityName>CommandHandlerTests.cs` following the same pattern.
+
+---
+
+### 9b. Query handler tests
+
+**Location:** `tests/Finance.Application.Tests/Queries/<EntityName>s/<EntityName>QueryHandlerTests.cs`
+
+Use a real in-memory `FinanceDbContext` seeded with known data; mock only `IRepository<T>` to return `_dbContext.<EntityName>s` via `GetDbSet()`.
+
+```csharp
+using Finance.Application.Queries.<EntityName>s;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.<EntityName>s;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Queries.<EntityName>s;
+
+public class <EntityName>QueryHandlerTests : IDisposable
+{
+    private readonly FinanceDbContext _dbContext;
+
+    public <EntityName>QueryHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Get<EntityName>s_FiltersDeactivated_ReturnsOnlyActive()
+    {
+        await _dbContext.<EntityName>s.AddRangeAsync(
+            new <EntityName> { Id = Guid.NewGuid(), Deactivated = false /* ... */ },
+            new <EntityName> { Id = Guid.NewGuid(), Deactivated = true  /* ... */ }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var repository = new Mock<IRepository<<EntityName>, Guid>>();
+        repository.Setup(r => r.GetDbSet()).Returns(_dbContext.<EntityName>s);
+
+        var handler = new Get<EntityName>sQueryHandler(_dbContext, repository.Object);
+        var result = await handler.ExecuteAsync(new Get<EntityName>sQuery { IncludeDeactivated = false }, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.All(result.Data, e => Assert.False(e.Deactivated));
+    }
+}
+```
+
+---
+
+### 9c. Service tests (partial class pattern)
+
+The service test class is split into multiple files using `partial class`. Keep the fixture in a base file and each operation in its own file.
+
+**Base fixture** — `tests/Finance.Application.Tests/Services/<EntityName>s/_<EntityName>ServiceTests.cs`
+
+```csharp
+using CQRSDispatch.Interfaces;
+using Finance.Application.Auth;
+using Finance.Application.Services.<EntityName>s;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Finance.Application.Tests.Services.<EntityName>s;
+
+public partial class <EntityName>ServiceTests : IDisposable
+{
+    private readonly Mock<IDispatcher<FinanceDispatchContext>> _dispatcher;
+    private readonly FinanceDbContext _dbContext;
+    private readonly <EntityName>Service _sut;
+
+    public <EntityName>ServiceTests()
+    {
+        _dispatcher = new Mock<IDispatcher<FinanceDispatchContext>>();
+
+        var options = new DbContextOptionsBuilder<FinanceDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _dbContext = new FinanceDbContext(options, null);
+        _sut = new <EntityName>Service(_dispatcher.Object, _dbContext);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}
+```
+
+**Per-operation files** — e.g. `<EntityName>ServiceTests.Create.cs`
+
+```csharp
+using CQRSDispatch;
+using Finance.Application.Commands.<EntityName>s;
+using Finance.Application.Services.<EntityName>s;
+using Finance.Domain.Models.<EntityName>s;
+using Microsoft.AspNetCore.Http;
+
+namespace Finance.Application.Tests.Services.<EntityName>s;
+
+public partial class <EntityName>ServiceTests
+{
+    [Fact]
+    public async Task Create_WhenDispatchSucceeds_ReturnsSuccess()
+    {
+        var entity = new <EntityName> { Id = Guid.NewGuid() };
+        var request = new Create<EntityName>Request(/* fields */);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<<EntityName>>>(It.IsAny<Create<EntityName>Command>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<<EntityName>>.Success(entity));
+
+        var result = await _sut.Create(request);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(entity, result.Data);
+    }
+
+    [Fact]
+    public async Task Create_WhenDispatchFails_ReturnsFailure()
+    {
+        var request = new Create<EntityName>Request(/* fields */);
+
+        _dispatcher
+            .Setup(d => d.DispatchAsync<DataResult<<EntityName>>>(It.IsAny<Create<EntityName>Command>(), It.IsAny<HttpRequest?>()))
+            .ReturnsAsync(DataResult<<EntityName>>.Failure("error message"));
+
+        var result = await _sut.Create(request);
+
+        Assert.False(result.IsSuccess);
+    }
+}
+```
+
+Create equivalent files for `Update`, `Delete`, `Activate`, `Deactivate` as applicable.
+
+### 9d. Run tests
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests
+```
+
+---
+
+## Checklist
+
+- [ ] Domain entity created
+- [ ] EF config added + `DbSet` registered on `FinanceDbContext`
+- [ ] Migration created and applied
+- [ ] DTO created
+- [ ] Commands: Create, Update, Delete (+ Activate/Deactivate if needed)
+- [ ] Queries: GetAll, GetSingle, GetPaginated
+- [ ] Mapper + interface created
+- [ ] Service requests file created
+- [ ] Command controller added
+- [ ] Query controller added
+- [ ] `dotnet build` passes
+- [ ] Command handler tests added
+- [ ] Query handler tests added
+- [ ] Service tests added (partial class per operation)
+- [ ] `dotnet test` passes

--- a/.claude/commands/feature/finance-app.md
+++ b/.claude/commands/feature/finance-app.md
@@ -1,0 +1,163 @@
+# FinanceApp Feature — React Router SSR Frontend
+
+Step-by-step guide for wiring a new feature into the `FinanceFrontEnd/FinanceApp` application.
+This app uses React Router v7 with a server-side loader pattern (similar to Remix / Next.js).
+
+---
+
+## Step 1 — URL Registry
+
+**File:** `FinanceFrontEnd/FinanceApp/app/utils/urls.ts`
+
+Add an entry for each backend endpoint the feature needs:
+
+```ts
+<entityNamePlural>: {
+  get endpoint() {
+    return new BackendUrl(`${getApiBaseUrl()}/<entity-route>`);
+  },
+  get paginated() {
+    return new BackendUrl(`${getApiBaseUrl()}/<entity-route>/paginated`);
+  },
+},
+```
+
+---
+
+## Step 2 — Data Query Class
+
+**Location:** `FinanceFrontEnd/FinanceApp/app/data/queries/<EntityName>sQuery.ts`
+
+```ts
+import urls from "@/utils/urls";
+import { Agent } from "https";
+import { BaseQuery } from "@/data/base/BaseQuery";
+
+export class <EntityName>sQuery extends BaseQuery {
+  constructor(httpsAgent: Agent, accessToken: string) {
+    super(httpsAgent, accessToken, {
+      get: urls.<entityNamePlural>.endpoint,
+    });
+  }
+}
+```
+
+**File:** `FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts`
+
+Register the new query:
+
+1. Import at the top:
+   ```ts
+   import { <EntityName>sQuery } from "./queries/<EntityName>sQuery";
+   ```
+2. Add private field:
+   ```ts
+   private <EntityName>sQuery: <EntityName>sQuery;
+   ```
+3. Instantiate in the constructor:
+   ```ts
+   this.<EntityName>sQuery = new <EntityName>sQuery(httpsAgent, this.AccessToken);
+   ```
+4. Expose via getter:
+   ```ts
+   Get<EntityName>sQuery() { return this.<EntityName>sQuery; }
+   ```
+
+---
+
+## Step 3 — Route File
+
+**Location:** `FinanceFrontEnd/FinanceApp/app/routes/<entityNamePlural>.tsx`
+
+```tsx
+import { getBackendClient } from "@/data/getBackendClient";
+import <EntityName>s from "@/components/ui/<EntityName>s";
+import { LoaderFunctionArgs } from "react-router";
+import { requireAuth } from "@/services/auth/session.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+    const user = await requireAuth(request);
+
+    if (!user.accessToken) {
+        throw new Error("No access token available");
+    }
+
+    const client = await getBackendClient(user.accessToken!);
+
+    // fetch any data that the page component needs upfront
+    const items = await client.Get<EntityName>sQuery().get();
+
+    return { items };
+};
+
+export const meta = () => [
+    { title: "<Page Title>" },
+];
+
+export default <EntityName>s;
+```
+
+**File:** `FinanceFrontEnd/FinanceApp/app/routes.ts`
+
+Register the new route following the existing entries:
+
+```ts
+route("<path>", "<entityNamePlural>.tsx"),
+```
+
+---
+
+## Step 4 — UI Component
+
+**Location:** `FinanceFrontEnd/FinanceApp/app/components/ui/<EntityName>s/index.tsx`
+
+General conventions:
+- Use `useLoaderData<LoaderData>()` to access data from the loader
+- Use `PaginatedTable` with a typed `Column[]` array for lists
+- Use shadcn primitives (`Button`, `Input`, `Select`, etc.) for forms
+- Wire mutations via `fetch` to the proxy route (`/api/proxy` → `POST /api/<entity-route>`)
+
+Minimal structure:
+
+```tsx
+import React from 'react';
+import { useLoaderData } from 'react-router';
+
+interface LoaderData {
+  items: { id: string; /* ... */ }[];
+}
+
+const <EntityName>s: React.FC = () => {
+  const { items } = useLoaderData<LoaderData>();
+
+  return (
+    <div>
+      {/* render list / table / form */}
+    </div>
+  );
+};
+
+export default <EntityName>s;
+```
+
+---
+
+## Step 5 — Verify
+
+Run both checks from `FinanceFrontEnd/FinanceApp` and fix any errors before committing:
+
+```powershell
+npm run typecheck
+npm run lint
+```
+
+## Checklist
+
+- [ ] URL entry added in `utils/urls.ts`
+- [ ] Query class created in `data/queries/`
+- [ ] Query registered in `BackendClient.ts` (field + constructor + getter)
+- [ ] Route file created in `app/routes/`
+- [ ] Route registered in `app/routes.ts`
+- [ ] UI component created in `app/components/ui/<EntityName>s/`
+- [ ] `npm run typecheck` passes with no errors
+- [ ] `npm run lint` passes with no errors

--- a/.claude/commands/feature/funds-app.md
+++ b/.claude/commands/feature/funds-app.md
@@ -1,0 +1,220 @@
+# FinanceFunds Feature — Vite SPA Frontend
+
+Step-by-step guide for adding a new feature to `FinanceFrontEnd/FinanceFunds`.
+This app is a Vite + React SPA with Mantine UI, Auth0 authentication, and a direct `ApiClient` for backend calls.
+
+---
+
+## Step 1 — Types
+
+**Location:** `FinanceFrontEnd/FinanceFunds/src/services/types/<EntityName>Types.ts`
+
+```ts
+export interface <EntityName> {
+  id: string;
+  // ...
+}
+
+export interface <EntityName>Response {
+  data: <EntityName>;
+}
+
+export interface <EntityName>sResponse {
+  data: <EntityName>[];
+}
+
+export interface Create<EntityName>Request {
+  // fields required to create
+}
+
+export interface Update<EntityName>Request {
+  id: string;
+  // fields required to update
+}
+```
+
+---
+
+## Step 2 — Service
+
+**Location:** `FinanceFrontEnd/FinanceFunds/src/services/<EntityName>Service.ts`
+
+```ts
+import ApiClient from './ApiClient';
+import type {
+  Create<EntityName>Request,
+  <EntityName>,
+  <EntityName>Response,
+  <EntityName>sResponse,
+} from './types/<EntityName>Types';
+import SafeLogger from '@/utils/SafeLogger';
+
+const <EntityName>Service = {
+  getAll: async (): Promise<<EntityName>sResponse> => {
+    try {
+      return await ApiClient.get<<EntityName>sResponse>('/api/<entity-route>');
+    } catch (error) {
+      SafeLogger.error('Error fetching <entityNamePlural>:', error);
+      throw error;
+    }
+  },
+
+  getById: async (id: string): Promise<<EntityName>Response> => {
+    try {
+      return await ApiClient.get<<EntityName>Response>(`/api/<entity-route>/${id}`);
+    } catch (error) {
+      SafeLogger.error(`Error fetching <entityName> ${id}:`, error);
+      throw error;
+    }
+  },
+
+  create: async (data: Create<EntityName>Request): Promise<<EntityName>> => {
+    try {
+      return await ApiClient.post<<EntityName>>('/api/<entity-route>', data);
+    } catch (error) {
+      SafeLogger.error('Error creating <entityName>:', error);
+      throw error;
+    }
+  },
+
+  update: async (id: string, data: Partial<Create<EntityName>Request>): Promise<<EntityName>> => {
+    try {
+      return await ApiClient.put<<EntityName>>(`/api/<entity-route>/${id}`, data);
+    } catch (error) {
+      SafeLogger.error(`Error updating <entityName> ${id}:`, error);
+      throw error;
+    }
+  },
+
+  delete: async (id: string): Promise<void> => {
+    try {
+      await ApiClient.delete(`/api/<entity-route>/${id}`);
+    } catch (error) {
+      SafeLogger.error(`Error deleting <entityName> ${id}:`, error);
+      throw error;
+    }
+  },
+};
+
+export default <EntityName>Service;
+```
+
+**File:** `FinanceFrontEnd/FinanceFunds/src/services/index.ts`
+
+Export the new service:
+```ts
+export { default as <EntityName>Service } from './<EntityName>Service';
+```
+
+---
+
+## Step 3 — Create Modal (optional)
+
+**Location:** `FinanceFrontEnd/FinanceFunds/src/components/Create<EntityName>Modal.tsx`
+
+Follow the pattern of `CreateFundModal.tsx`:
+- Accept `opened` + `onClose` + `onCreated` props
+- Use Mantine `Modal`, `TextInput`, `NumberInput`, `Select`, `Button`
+- Call `<EntityName>Service.create(...)` on submit
+- Call `onCreated()` on success to trigger a parent refresh
+
+---
+
+## Step 4 — Page Component
+
+**Location:** `FinanceFrontEnd/FinanceFunds/src/pages/<EntityName>sDashboard.tsx`
+
+Conventions:
+- Use `useState` + `useEffect` for data loading
+- Use `useCallback` for stable handler references
+- Use `useMemo` for derived/display config values
+- Mantine components: `Card`, `Table`, `Stack`, `Group`, `Loader`, `Center`, `Button`, `ScrollArea`
+- TablerIcons for iconography
+- Call `SafeLogger.error(...)` instead of `console.error`
+
+Minimal structure:
+
+```tsx
+import { useState, useEffect, useCallback } from 'react';
+import { Title, Card, Table, Loader, Center, Button } from '@mantine/core';
+import <EntityName>Service from '@/services/<EntityName>Service';
+import SafeLogger from '@/utils/SafeLogger';
+import type { <EntityName> } from '@/services/types/<EntityName>Types';
+
+const <EntityName>sDashboard = () => {
+  const [items, setItems] = useState<<EntityName>[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadItems = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await <EntityName>Service.getAll();
+      setItems(response.data);
+    } catch (err) {
+      SafeLogger.error('Failed to load <entityNamePlural>', err);
+      setError('Failed to load <entityNamePlural>');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadItems(); }, [loadItems]);
+
+  if (loading) return <Center><Loader /></Center>;
+
+  return (
+    <Card>
+      <Title><EntityName>s</Title>
+      {/* Table / form */}
+    </Card>
+  );
+};
+
+export default <EntityName>sDashboard;
+```
+
+**File:** `FinanceFrontEnd/FinanceFunds/src/pages/index.ts`
+
+Export the new page:
+```ts
+export { default as <EntityName>sDashboard } from './<EntityName>sDashboard';
+```
+
+---
+
+## Step 5 — Register in App Router
+
+**File:** `FinanceFrontEnd/FinanceFunds/src/App.tsx`
+
+Add a route for the new page following the existing pattern:
+
+```tsx
+import { <EntityName>sDashboard } from '@/pages';
+
+// inside the Routes / router config:
+<Route path="/<entity-route>" element={<<EntityName>sDashboard />} />
+```
+
+Add a navigation link in `src/components/Navigation.tsx` if the page should appear in the sidebar.
+
+---
+
+## Step 6 — Verify
+
+Run both checks from `FinanceFrontEnd/FinanceFunds` and fix any errors before committing:
+
+```powershell
+npm run lint
+```
+
+## Checklist
+
+- [ ] Types file created in `services/types/`
+- [ ] Service created and exported from `services/index.ts`
+- [ ] Create modal added (if CRUD is needed)
+- [ ] Dashboard page created and exported from `pages/index.ts`
+- [ ] Route registered in `App.tsx`
+- [ ] Navigation link added (if applicable)
+- [ ] `npm run typecheck` passes with no errors
+- [ ] `npm run lint` passes with no errors

--- a/.claude/commands/infra/SKILL.md
+++ b/.claude/commands/infra/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: infra
+description: "Make infrastructure changes safely: create a branch first, apply changes in logically grouped commits, and push. Use when modifying docker-compose files, CI/CD workflows, Traefik config, Dockerfiles, or any file under infra/ or .github/workflows/."
+argument-hint: "<change description>  — describe the infrastructure change to make"
+---
+
+# Infra Changes Workflow
+
+Before touching any files, set up a branch. Then apply changes in logical batches, each with its own commit. Finally push.
+
+**Change requested:** $ARGUMENTS
+
+## Step 0 — Pre-flight checks
+
+Run the following checks before doing anything else. If any check fails, stop and inform the user — do not proceed.
+
+1. **Check for uncommitted or unstaged changes**:
+   ```
+   git status --porcelain
+   ```
+   If the output is non-empty, cancel with:
+   > "There are uncommitted or unstaged changes in the working tree. Please commit, stash, or discard them before proceeding with infra changes."
+
+2. **Ensure you are on `main`**:
+   ```
+   git branch --show-current
+   ```
+   If the current branch is not `main`, cancel with:
+   > "You are currently on branch `<branch>`, not `main`. Please switch to `main` before starting infra changes."
+
+3. **Pull the latest `main`**:
+   ```
+   git pull origin main
+   ```
+   Confirm the pull succeeded before continuing.
+
+## Step 1 — Create a branch
+
+Derive a short, descriptive branch name from the user's request using the prefix `infra/` (e.g. `infra/split-deploy-jobs`, `infra/traefik-ssl-config`).
+
+Run:
+```
+git checkout -b <branch-name>
+```
+
+Confirm the branch was created before proceeding.
+
+## Step 2 — Apply changes in logical batches
+
+Group the planned changes by concern. Each group becomes one commit. Typical groupings for this repo:
+
+- **CI/CD** — files under `.github/workflows/`
+- **Container config** — `Dockerfile`, `Dockerfile.prod`, `Dockerfile.migrate`
+- **Compose / infra** — files under `infra/` (docker-compose files, traefik config)
+- **Mixed** — if a change spans groups, split by layer (e.g. compose changes first, then workflow changes that depend on them)
+
+For each batch:
+1. Make the file edits.
+2. Stage only the files for that batch: `git add <files>`
+3. Commit with a concise imperative message: `git commit -m "<what and why>"`
+
+Do not mix unrelated files in a single commit.
+
+## Step 3 — Push the branch
+
+```
+git push -u origin <branch-name>
+```
+
+## Step 4 — Done
+
+Report to the user:
+- Branch name
+- Commit SHA(s) (from `git log --oneline origin/main..HEAD`)
+
+Run `/pr` to open the pull request when ready.

--- a/.claude/commands/pr/SKILL.md
+++ b/.claude/commands/pr/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pr
+description: "Handles the full Git Flow lifecycle: updates main, branches, and commits changes in logical batches."
+argument-hint: "<short slug>  — short description of the feature or fix (e.g., 'user-auth-api')"
+---
+
+# Git Flow & PR Management Skill
+
+**Description:** $ARGUMENTS
+
+## Workflow Steps
+
+1. **Sync Base:**
+   * Ensure GH CLI is installed and authenticated.
+   * Ensure the current branch is `main` (or the repository's default branch).
+   * Execute `git pull origin main` to ensure the local environment is up to date.
+
+2. **Branching:**
+   * Create a new branch using Git Flow naming conventions: `feature/[arg]`, `fix/[arg]`, `refactor/[arg]`, or `docs/[arg]`.
+   * Switch to the new branch immediately.
+
+3. **Atomic Commits:**
+   * Analyze staged/unstaged changes.
+   * Verify no ignored files are accidentally staged (`git status` should not show files that belong in `.gitignore`).
+   * Group related file changes into "logical batches" (e.g., all database migrations together, then all service logic). Treat `.gitignore` additions or updates as their own commit (repo config layer).
+   * Commit each batch with a concise, imperative message (e.g., "Add user schema", "Implement auth controller").
+
+4. **Open Pull Request:**
+   * Use GH CLI: `gh pr create --title "<title>" --body-file <temp-file>`.
+   * PR title must follow Conventional Commits: `type(scope): short description (issue #N)`.
+   * PR body must follow the template in `.github/PULL_REQUEST_TEMPLATE.md`:
+     * **Purpose** — one paragraph explaining _what_ and _why_.
+     * **Changes** — grouped by layer/category (e.g., `Repo Config`, `Infrastructure`, `Client Scaffold`, `Docs`). Each group is a `###` heading with bullet points.
+     * **Verification** — numbered steps a reviewer can follow to manually verify the change works.
+   * Write the body to a temp file and pass via `--body-file` to avoid shell escaping issues (backticks, special chars).
+
+## Constraints
+
+* **Branch Guard:** If the current branch is not `main`, alert the user and stop — continuing might be destructive.
+* **Safety Check:** If there are merge conflicts during the `git pull`, stop and alert the user.
+* **Batching Intelligence:** Do not commit all files at once if they touch different layers of the stack (e.g., keep `.css` changes separate from `.cs` or `.js` backend logic). Treat `.gitignore` additions or updates as their own commit (repo config layer).
+* **No Preamble:** Execute commands directly and report status only.

--- a/.claude/commands/security-review-backend/SKILL.md
+++ b/.claude/commands/security-review-backend/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: security-review-backend
+description: Analyze the backend architecture and data persistence layer to identify security vulnerabilities in the handling of financial information.
+---
+
+## Stack Context
+
+- **Language / Framework**: C# / ASP.NET Core Web API
+- **ORM**: Entity Framework Core with global query filters for ownership isolation
+- **Authentication**: Auth0 JWT — `user_id` / `sub` claim is the identity anchor
+- **Infrastructure**: PostgreSQL, Redis, Docker
+
+## Where to Look
+
+Focus your search on these file patterns:
+
+- `*Controller.cs` — authorization enforcement, model binding, input validation
+- `*Handler.cs` / `*Service.cs` — business logic, data access, ownership filters
+- `*Configuration.cs` / `*EntityTypeConfiguration.cs` — EF column mappings (field types, encryption)
+- `*DbContext.cs` — global query filters, ownership constraints
+- `appsettings*.json`, `Program.cs` — middleware pipeline, logging sinks, secret handling
+
+## Analysis Guidelines
+
+### Encryption at Rest
+
+- Identify numeric or text fields representing monetary values (e.g. `balance`, `amount`, `salary`) and verify they are not stored in plain text in the database.
+- Detect missing symmetric encryption (e.g. AES-256) for sensitive financial columns in EF configurations.
+
+### Identity Isolation (Auth0 Integration)
+
+- Verify that the `user_id` / `sub` from the Auth0 token is the sole link to financial records.
+- Ensure no tables directly associate personally identifiable data with balances without an abstraction layer.
+- Check that global EF query filters enforce ownership and cannot be bypassed (e.g. via `IgnoreQueryFilters()`).
+
+### Object-Level Authorization (BOLA)
+
+- Audit controllers and handlers to confirm every query filters strictly by the authenticated user's ID.
+- Flag any endpoint that accepts a user or resource ID from the request body or URL without re-validating ownership against the token claim.
+
+### Mass Assignment
+
+- Detect model binding that accepts raw domain entities or overly permissive DTOs, allowing callers to set fields like `UserId`, `Balance`, or `Role` directly.
+
+### Log and Exception Leakage
+
+- Verify that error-handling and logging routines do not capture or serialize objects containing financial amounts to server logs.
+- Check that exception middleware does not return stack traces or internal model data to API consumers.
+
+### Rate Limiting
+
+- Flag financial write endpoints (transfers, payments, balance updates) that lack rate limiting or idempotency controls.
+
+### Integrity Validation
+
+- Detect missing business-logic validations (e.g. allowing negative amounts where not permitted, or numeric overflow in financial calculations).
+- Check that decimal precision is enforced at the domain level, not only at the database column level.
+
+## Output Instructions
+
+For each risk found, report:
+
+| Field | Detail |
+|---|---|
+| **File** | Path to the affected file |
+| **Line** | Line number(s) |
+| **Description** | Technical description of the vulnerability |
+| **Priority** | Critical / High / Medium |
+| **Recommendation** | Suggested fix or mitigation |
+
+## Report File
+
+Save the report as a Markdown file under:
+
+```
+docs/security-audits/security-audit-{scope}-YYYY-MM-DD.md
+```
+
+- Use today's date in the filename.
+- `{scope}` identifies what was reviewed. Use `backend` for a general review or a more specific segment when the review is scoped (e.g. `backend-authentication`, `backend-persistence`, `backend-application-commands`, `backend-application-queries`, `backend-domain`).
+- If a file for today with the same scope already exists, append a counter (e.g. `-2`).

--- a/.claude/commands/security-review-frontend/SKILL.md
+++ b/.claude/commands/security-review-frontend/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: security-review-frontend
+description: Analyze frontend code to identify financial data leakage and session management vulnerabilities.
+---
+
+## Stack Context
+
+- **Frameworks**: React Router v7 (SSR, `FinanceApp`) and Vite SPA (FinanceFunds)
+- **Authentication**: Auth0 SDK (`@auth0/auth0-react`)
+- **HTTP client**: Axios or `fetch` with interceptors
+- **State**: React Context / component-local state
+
+## Where to Look
+
+Focus your search on these file/folder patterns:
+
+- `app/routes/` — route components, loaders, and actions (SSR data exposure)
+- `app/components/` — rendering of financial values and dynamic API content
+- `src/hooks/`, `src/context/` — token and state management
+- `src/api/`, `src/services/` — HTTP interceptors, request/response logging
+- `app/root.tsx`, `app/entry.server.tsx` — SSR serialization into HTML
+
+## Analysis Guidelines
+
+### Data Exposure in DOM / State
+
+- Detect whether financial amounts (`balance`, `total_income`) are stored in component state or context beyond the lifetime of the view that needs them.
+- Verify that sensitive data is not rendered in visible HTML attributes (`data-*`, `title`, `alt`).
+- In SSR routes (React Router loaders), check whether financial data returned from loaders is serialized into the initial HTML payload more broadly than necessary.
+
+### Local Storage Handling
+
+- Audit use of `localStorage` and `sessionStorage`. Flag any storage of balances, amounts, or access tokens that would be readable by XSS.
+- Verify that no financial data remains in browser storage or cache after logout.
+
+### Session Security (Auth0 Integration)
+
+- Review the Auth0 SDK configuration: ensure PKCE is used and `cacheLocation` is set to `memory`, not `localstorage`.
+- Verify that Access Token / ID Token values are never logged via `console.log` or included in error reporting payloads.
+
+### Injection Vulnerabilities (XSS)
+
+- Search for `dangerouslySetInnerHTML`, `innerHTML`, and `eval()`. Any use with API-sourced data (expense descriptions, category names, notes) is a critical risk.
+- Flag string interpolation into URLs or `href` attributes without sanitization.
+
+### Network / Console Exposure
+
+- Detect Axios interceptors or `fetch` wrappers that log full response bodies (which contain financial data) to the console without a production guard.
+- Verify that error boundaries and reporting tools (e.g. Sentry) are configured to scrub financial fields before transmission.
+
+### Content Security Policy
+
+- Check whether a `Content-Security-Policy` header or meta tag is configured to restrict script sources and mitigate XSS impact.
+
+## Output Instructions
+
+For each risk found, report:
+
+| Field | Detail |
+|---|---|
+| **Component / File** | Path to the affected file or component |
+| **Line** | Line number(s) |
+| **Impact** | Potential impact of the vulnerability |
+| **Priority** | Critical / High / Medium |
+| **Recommendation** | Suggested fix or mitigation |
+
+## Report File
+
+Save the report as a Markdown file under:
+
+```
+docs/security-audits/security-audit-{scope}-YYYY-MM-DD.md
+```
+
+- Use today's date in the filename.
+- `{scope}` identifies what was reviewed. Use `frontend` for a general review or a more specific segment when the review is scoped (e.g. `frontend-financeapp-routes`, `frontend-financefunds-auth`).
+- If a file for today with the same scope already exists, append a counter (e.g. `-2`).

--- a/.claude/commands/unit-tests/SKILL.md
+++ b/.claude/commands/unit-tests/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: unit-tests
+description: "Write backend unit tests for new or changed .NET code. Use when: adding tests for unstaged changes, writing tests for a specific file or set of files, covering a new handler, service, or domain type. Reads source files, infers test cases, writes xUnit tests following project conventions, then builds and runs to verify."
+argument-hint: "[file1 file2 ...]  — workspace-relative paths whose tests to write; omit to use all unstaged changes"
+---
+
+# Unit Test Implementation Workflow
+
+Workflow for writing xUnit tests for changed or specified backend source files, following the conventions of `Finance.Application.Tests`.
+
+## Reference Doc
+
+Read this file before starting (use the Read tool):
+
+```
+.github/docs/unit-testing.md
+```
+
+This doc covers base classes, in-memory DB setup, EF query filter seeding, dispatcher mocking, and known gotchas. **Do not proceed without reading it.**
+
+---
+
+## Step 1 — Identify target files
+
+### If paths are provided
+
+**Paths:** $ARGUMENTS
+
+Use the given paths as the target sources directly.
+
+### If no paths are provided
+
+Run:
+
+```powershell
+git diff --name-only HEAD
+git status --short
+```
+
+Filter to `.cs` files under `FinanceBackEnd/src/Finance.Application/` (Commands, Queries, Services). Ignore migration files, generated files, domain models, and EF configuration.
+
+---
+
+## Step 2 — Understand each source file
+
+For each source file:
+
+1. Read it fully.
+2. Identify:
+   - Class type: command handler, query handler, or service
+   - Constructor dependencies (what to mock vs inject)
+   - Whether it accesses `FinanceDbContext` directly
+   - Which entities it reads/writes and whether those have EF query filters (see `.github/docs/unit-testing.md`)
+   - Public methods / `ExecuteAsync` signature and return type
+3. Read the existing test file (if any) to avoid duplicating covered cases.
+
+---
+
+## Step 3 — Find the existing test file
+
+Test file location mirrors source location:
+
+| Source path | Test path |
+|---|---|
+| `src/Finance.Application/Commands/Funds/CreateFundCommandHandler.cs` | `tests/Finance.Application.Tests/Commands/Funds/CreateFundCommandHandlerTests.cs` |
+| `src/Finance.Application/Queries/Currencies/GetCurrencyQueryHandler.cs` | `tests/Finance.Application.Tests/Queries/Currencies/GetCurrencyQueryHandlerTests.cs` |
+| `src/Finance.Application/Services/CurrencyConversionService.cs` | `tests/Finance.Application.Tests/Services/CurrencyConversionServiceTests.cs` |
+
+If the test file exists, **add tests to it**. If not, create a new one.
+
+---
+
+## Step 4 — Plan test cases
+
+Think through:
+
+- **Happy path(s)**: the handler succeeds under normal conditions
+- **Validation / failure paths**: missing entity, invalid input → expected error or false result
+- **Boundary conditions**: empty collections, null values, zero amounts
+- **Filter/ownership paths**: entity not returned because permission not granted
+- **Behavioral assertions**: dispatcher called once vs. not at all (for caching, short-circuits)
+
+Write the list before coding.
+
+---
+
+## Step 5 — Write the tests
+
+### Class skeleton
+
+```csharp
+using Finance.Application.Tests.Queries.Base;
+
+namespace Finance.Application.Tests.Commands.<Module>;   // or Queries / Services
+
+public class XxxCommandHandlerTests : QueryHandlerBaseTests
+{
+    // mocks declared here
+    public XxxCommandHandlerTests() { /* set up mocks */ }
+
+    private XxxCommandHandler CreateHandler() => new(_dbContext, _mock.Object, ...);
+
+    [Fact]
+    public async Task MethodName_Condition_ExpectedOutcome() { ... }
+}
+```
+
+### Naming
+
+`MethodOrAction_Condition_ExpectedOutcome` — e.g. `Upload_WhenHelperReturnsNoRecords_ReturnsFailure`.
+
+### Key rules (from `.github/docs/unit-testing.md`)
+
+- Extend `QueryHandlerBaseTests` for **every** test class that touches `FinanceDbContext`.
+- Seed `Identity { SourceId = "IdentityNotFound" }` on the current user so EF query filters match.
+- Seed `*Permissions` rows for every entity that has an ownership filter or the query will return nothing.
+- For `IOLInvestment` tests: grant **both** `IOLInvestmentPermissions` and `IOLInvestmentAssetPermissions`.
+- `ConvertCollection` always calls the dispatcher — set up rates even for same-currency input.
+- Override `Dispose()` and call `base.Dispose()` first if the class holds an `IMemoryCache`.
+- Do not add code comments unless the logic is non-obvious.
+
+### Avoid
+
+- Don't add narrative comments (e.g. `// Arrange`, `// Act`, `// Assert`, `// Set up the handler`).
+- Don't test behavior already covered in the existing test file.
+- Don't add `using` directives for namespaces not directly referenced in the file.
+
+---
+
+## Step 6 — Build
+
+```powershell
+dotnet build FinanceBackEnd/tests/Finance.Application.Tests/Finance.Application.Tests.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary;ForceNoAlign
+```
+
+Fix every compiler error before running tests. Common errors:
+
+| Error | Fix |
+|---|---|
+| `IgnoreQueryFilters`/`CountAsync` not found | Add `using Microsoft.EntityFrameworkCore;` |
+| IDE0005 unused `using` | Remove the import |
+| Type not found | Check the correct namespace in the source file |
+
+---
+
+## Step 7 — Run tests
+
+Run only the newly written test classes first:
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests/ --filter "FullyQualifiedName~XxxTests" -v n
+```
+
+Then run the full suite to check for regressions:
+
+```powershell
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests/ -v q
+```
+
+Interpret failures:
+
+- **Empty collection / no results**: likely missing `*Permissions` seed.
+- **NullReferenceException in ConvertCollection**: missing dispatcher setup.
+- **Wrong numeric result**: check whether rate direction is buy vs. sell.
+
+Fix failures and re-run until all tests pass.
+
+---
+
+## Step 8 — Done
+
+Report:
+- Which test files were created or modified
+- How many tests were added and which pass
+- Any tests left failing and the known reason

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "Bash(uv run:*)",
+      "Bash(git checkout:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(dotnet build *)",
+      "Bash(dotnet test *)",
+      "dotnet build *",
+      "dotnet test *",
+      "WebSearch"
+    ]
+  }
+}

--- a/.github/skills/bug/SKILL.md
+++ b/.github/skills/bug/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: bug
+description: "Create a GitHub bug issue, branch, commit, and publish a fix branch for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping a bug fix, committing changes, publishing a fix branch."
+argument-hint: "<path1> [path2 ...]  — one or more workspace-relative paths whose changes to include"
+---
+
+# GitHub Bug Fix PR Workflow
+
+End-to-end workflow: inspect changes under the given path(s) or the whole workspace if no paths are provided, file a bug issue, create a fix branch, commit only those changes, push, and open a PR populated from the repo's PR template.
+
+## When to Use
+
+- Fixing a bug that touches one or more specific folders or files
+- Generating a GitHub issue + PR pair in one step
+- Any time the user says "create a bug PR for changes under <path>"
+- Works for any language or framework — backend, frontend, infrastructure, scripts, etc.
+
+## Required Inputs
+
+| Input | Example |
+|---|---|
+| One or more repo-relative paths | `src/api/` `app/components/` `infra/` |
+
+Multiple paths can be provided space-separated or as a list.
+
+## Procedure
+
+### 1 — Inspect changes
+
+**Paths:** $ARGUMENTS
+
+For each provided path run:
+
+```powershell
+git diff --stat HEAD -- <path>
+git diff HEAD -- <path>
+```
+
+Also run `git status` to see any untracked files under the paths.
+
+Use the diffs to understand:
+- Which files changed
+- What the change does (type fix, interface correction, refactor, etc.)
+- A concise one-line summary and a fuller description for the issue body
+
+### 2 — Create the GitHub bug issue
+
+Use the GH CLI. Derive the title and body from the diff analysis:
+
+```powershell
+gh issue create `
+  --title "<concise title describing the bug>" `
+  --body "<markdown body: Description / Affected files / Steps to reproduce / Expected behavior>" `
+  --label bug
+```
+
+Note the issue number returned (e.g. `#80`).
+
+### 3 — Create a fix branch
+
+Branch name convention: `fix/<short-slug>` derived from the issue title (lowercase, hyphens only).
+
+```powershell
+git checkout -b fix/<short-slug>
+```
+
+### 4 — Commit only the target paths
+
+Stage exclusively the files under the provided path(s):
+
+```powershell
+git add <path1> [<path2> ...]
+git commit -m "fix: <one-line summary>
+
+<Optional body paragraph>
+
+Closes #<issue-number>"
+```
+
+Do NOT stage files outside the paths the user specified.
+
+### 5 — Run lint before pushing
+
+If any of the changed files are frontend (TypeScript/TSX/JS under `FinanceFrontEnd/`), run lint from the relevant app directory and fix any errors before proceeding. Do **not** push if lint fails.
+
+```powershell
+# For FinanceApp changes:
+cd FinanceFrontEnd/FinanceApp; npm run lint
+
+# For FinanceFunds changes:
+cd FinanceFrontEnd/FinanceFunds; npm run lint
+```
+
+If `lint:fix` is available and there are auto-fixable errors, run it and amend the commit:
+
+```powershell
+npm run lint:fix
+git add <affected-files>
+git commit --amend --no-edit
+```
+
+### 6 — Publish the branch
+
+```powershell
+git push -u origin fix/<short-slug>
+```
+
+## Output
+
+Report to the user:
+- Issue URL
+- Branch name
+- Commit SHA (from `git log -1 --oneline`)
+
+Run `/pr` to open the pull request when ready.

--- a/.github/skills/docs/SKILL.md
+++ b/.github/skills/docs/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: docs
+description: "Create a GitHub docs issue, branch, commit, and publish a docs branch for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping documentation changes, committing doc updates, publishing a docs branch."
+argument-hint: "<path1> [path2 ...]  — one or more workspace-relative paths whose changes to include"
+---
+
+# GitHub Docs PR Workflow
+
+End-to-end workflow: inspect changes under the given path(s) or the whole workspace if no paths are provided, file a docs issue, create a docs branch, commit only those changes, push, and open a PR populated from the repo's PR template.
+
+## When to Use
+
+- Adding or updating documentation (README, guides, architecture docs, skill files, etc.)
+- Generating a GitHub issue + PR pair in one step for doc-only changes
+- Any time the user says "create a docs PR for changes under <path>"
+- Works for any documentation format — Markdown, ADRs, diagrams, comments, etc.
+
+## Required Inputs
+
+| Input | Example |
+|---|---|
+| One or more repo-relative paths | `.github/docs/` `docs/` `README.md` |
+
+Multiple paths can be provided space-separated or as a list.
+
+## Procedure
+
+### 1 — Inspect changes
+
+For each provided path run:
+
+```powershell
+git diff --stat HEAD -- <path>
+git diff HEAD -- <path>
+```
+
+Also run `git status` to see any untracked files under the paths.
+
+Use the diffs to understand:
+- Which files changed or were added
+- What the documentation covers (new guide, updated reference, corrected info, etc.)
+- A concise one-line summary and a fuller description for the issue body
+
+### 2 — Create the GitHub docs issue
+
+Use the GH CLI. Derive the title and body from the diff analysis:
+
+```powershell
+gh issue create `
+  --title "<concise title describing the documentation change>" `
+  --body "<markdown body: Description / Affected files / What was added or corrected>" `
+  --label documentation
+```
+
+Note the issue number returned (e.g. `#82`).
+
+### 3 — Create a docs branch
+
+Branch name convention: `docs/<short-slug>` derived from the issue title (lowercase, hyphens only).
+
+```powershell
+git checkout -b docs/<short-slug>
+```
+
+### 4 — Commit only the target paths
+
+Stage exclusively the files under the provided path(s):
+
+```powershell
+git add <path1> [<path2> ...]
+git commit -m "docs: <one-line summary>
+
+<Optional body paragraph>
+
+Closes #<issue-number>"
+```
+
+Do NOT stage files outside the paths the user specified.
+
+### 5 — Run lint before pushing
+
+If any of the changed files are frontend (TypeScript/TSX/JS under `FinanceFrontEnd/`), run lint from the relevant app directory and fix any errors before proceeding. Do **not** push if lint fails.
+
+```powershell
+# For FinanceApp changes:
+cd FinanceFrontEnd/FinanceApp; npm run lint
+
+# For FinanceFunds changes:
+cd FinanceFrontEnd/FinanceFunds; npm run lint
+```
+
+If `lint:fix` is available and there are auto-fixable errors, run it and amend the commit:
+
+```powershell
+npm run lint:fix
+git add <affected-files>
+git commit --amend --no-edit
+```
+
+### 6 — Publish the branch
+
+```powershell
+git push -u origin docs/<short-slug>
+```
+
+## Output
+
+Report to the user:
+- Issue URL
+- Branch name
+- Commit SHA (from `git log -1 --oneline`)
+
+Run `/pr` to open the pull request when ready.

--- a/.github/skills/feat/SKILL.md
+++ b/.github/skills/feat/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: feat
+description: "Create a GitHub feature issue, branch, commit, and publish a feature branch for staged or unstaged changes under one or more given paths, if no given paths then all the unstaged files should be used. Use when: shipping a new feature, committing changes, publishing a feature branch."
+argument-hint: "<path1> [path2 ...]  — one or more workspace-relative paths whose changes to include"
+---
+
+# GitHub Feature PR Workflow
+
+End-to-end workflow: inspect changes under the given path(s) or the whole workspace if no paths are provided, file a feature issue, create a feature branch, commit only those changes, push, and open a PR populated from the repo's PR template.
+
+## When to Use
+
+- Adding a new feature that touches one or more specific folders or files
+- Generating a GitHub issue + PR pair in one step
+- Any time the user says "create a feature PR for changes under <path>"
+- Works for any language or framework — backend, frontend, infrastructure, scripts, etc.
+
+## Required Inputs
+
+| Input | Example |
+|---|---|
+| One or more repo-relative paths | `src/api/` `app/components/` `infra/` |
+
+Multiple paths can be provided space-separated or as a list.
+
+## Procedure
+
+### 1 — Inspect changes
+
+For each provided path run:
+
+```powershell
+git diff --stat HEAD -- <path>
+git diff HEAD -- <path>
+```
+
+Also run `git status` to see any untracked files under the paths.
+
+Use the diffs to understand:
+- Which files changed or were added
+- What the feature does (new endpoint, new UI component, new service, etc.)
+- A concise one-line summary and a fuller description for the issue body
+
+### 2 — Create the GitHub feature issue
+
+Use the GH CLI. Derive the title and body from the diff analysis:
+
+```powershell
+gh issue create `
+  --title "<concise title describing the feature>" `
+  --body "<markdown body: Description / Affected files / Acceptance criteria>" `
+  --label enhancement
+```
+
+Note the issue number returned (e.g. `#81`).
+
+### 3 — Create a feature branch
+
+Branch name convention: `feature/<short-slug>` derived from the issue title (lowercase, hyphens only).
+
+```powershell
+git checkout -b feature/<short-slug>
+```
+
+### 4 — Commit only the target paths
+
+Stage exclusively the files under the provided path(s):
+
+```powershell
+git add <path1> [<path2> ...]
+git commit -m "feat: <one-line summary>
+
+<Optional body paragraph>
+
+Closes #<issue-number>"
+```
+
+Do NOT stage files outside the paths the user specified.
+
+### 5 — Run lint before pushing
+
+If any of the changed files are frontend (TypeScript/TSX/JS under `FinanceFrontEnd/`), run lint from the relevant app directory and fix any errors before proceeding. Do **not** push if lint fails.
+
+```powershell
+# For FinanceApp changes:
+cd FinanceFrontEnd/FinanceApp; npm run lint
+
+# For FinanceFunds changes:
+cd FinanceFrontEnd/FinanceFunds; npm run lint
+```
+
+If `lint:fix` is available and there are auto-fixable errors, run it and amend the commit:
+
+```powershell
+npm run lint:fix
+git add <affected-files>
+git commit --amend --no-edit
+```
+
+### 6 — Publish the branch
+
+```powershell
+git push -u origin feature/<short-slug>
+```
+
+## Output
+
+Report to the user:
+- Issue URL
+- Branch name
+- Commit SHA (from `git log -1 --oneline`)
+
+Run `/pr` to open the pull request when ready.

--- a/.github/skills/infra/SKILL.md
+++ b/.github/skills/infra/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: infra
+description: "Make infrastructure changes safely: create a branch first, apply changes in logically grouped commits, and push. Use when modifying docker-compose files, CI/CD workflows, Traefik config, Dockerfiles, or any file under infra/ or .github/workflows/."
+argument-hint: "<change description>  — describe the infrastructure change to make"
+---
+
+# Infra Changes Workflow
+
+Before touching any files, set up a branch. Then apply changes in logical batches, each with its own commit. Finally push.
+
+**Change requested:** $ARGUMENTS
+
+## Step 0 — Pre-flight checks
+
+Run the following checks before doing anything else. If any check fails, stop and inform the user — do not proceed.
+
+1. **Check for uncommitted or unstaged changes**:
+   ```
+   git status --porcelain
+   ```
+   If the output is non-empty, cancel with:
+   > "There are uncommitted or unstaged changes in the working tree. Please commit, stash, or discard them before proceeding with infra changes."
+
+2. **Ensure you are on `main`**:
+   ```
+   git branch --show-current
+   ```
+   If the current branch is not `main`, cancel with:
+   > "You are currently on branch `<branch>`, not `main`. Please switch to `main` before starting infra changes."
+
+3. **Pull the latest `main`**:
+   ```
+   git pull origin main
+   ```
+   Confirm the pull succeeded before continuing.
+
+## Step 1 — Create a branch
+
+Derive a short, descriptive branch name from the user's request using the prefix `infra/` (e.g. `infra/split-deploy-jobs`, `infra/traefik-ssl-config`).
+
+Run:
+```
+git checkout -b <branch-name>
+```
+
+Confirm the branch was created before proceeding.
+
+## Step 2 — Apply changes in logical batches
+
+Group the planned changes by concern. Each group becomes one commit. Typical groupings for this repo:
+
+- **CI/CD** — files under `.github/workflows/`
+- **Container config** — `Dockerfile`, `Dockerfile.prod`, `Dockerfile.migrate`
+- **Compose / infra** — files under `infra/` (docker-compose files, traefik config)
+- **Mixed** — if a change spans groups, split by layer (e.g. compose changes first, then workflow changes that depend on them)
+
+For each batch:
+1. Make the file edits.
+2. Stage only the files for that batch: `git add <files>`
+3. Commit with a concise imperative message: `git commit -m "<what and why>"`
+
+Do not mix unrelated files in a single commit.
+
+## Step 3 — Push the branch
+
+```
+git push -u origin <branch-name>
+```
+
+## Step 4 — Done
+
+Report to the user:
+- Branch name
+- Commit SHA(s) (from `git log --oneline origin/main..HEAD`)
+
+Run `/pr` to open the pull request when ready.

--- a/.github/skills/pr/SKILL.md
+++ b/.github/skills/pr/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pr
+description: "Handles the full Git Flow lifecycle: updates main, branches, and commits changes in logical batches."
+argument-hint: "<short slug>  — short description of the feature or fix (e.g., 'user-auth-api')"
+---
+
+# Git Flow & PR Management Skill
+
+**Description:** $ARGUMENTS
+
+## Workflow Steps
+
+1. **Sync Base:**
+   * Ensure GH CLI is installed and authenticated.
+   * Ensure the current branch is `main` (or the repository's default branch).
+   * Execute `git pull origin main` to ensure the local environment is up to date.
+
+2. **Branching:**
+   * Create a new branch using Git Flow naming conventions: `feature/[arg]`, `fix/[arg]`, `refactor/[arg]`, or `docs/[arg]`.
+   * Switch to the new branch immediately.
+
+3. **Atomic Commits:**
+   * Analyze staged/unstaged changes.
+   * Verify no ignored files are accidentally staged (`git status` should not show files that belong in `.gitignore`).
+   * Group related file changes into "logical batches" (e.g., all database migrations together, then all service logic). Treat `.gitignore` additions or updates as their own commit (repo config layer).
+   * Commit each batch with a concise, imperative message (e.g., "Add user schema", "Implement auth controller").
+
+4. **Open Pull Request:**
+   * Use GH CLI: `gh pr create --title "<title>" --body-file <temp-file>`.
+   * PR title must follow Conventional Commits: `type(scope): short description (issue #N)`.
+   * PR body must follow the template in `.github/PULL_REQUEST_TEMPLATE.md`:
+     * **Purpose** — one paragraph explaining _what_ and _why_.
+     * **Changes** — grouped by layer/category (e.g., `Repo Config`, `Infrastructure`, `Client Scaffold`, `Docs`). Each group is a `###` heading with bullet points.
+     * **Verification** — numbered steps a reviewer can follow to manually verify the change works.
+   * Write the body to a temp file and pass via `--body-file` to avoid shell escaping issues (backticks, special chars).
+
+## Constraints
+
+* **Branch Guard:** If the current branch is not `main`, alert the user and stop — continuing might be destructive.
+* **Safety Check:** If there are merge conflicts during the `git pull`, stop and alert the user.
+* **Batching Intelligence:** Do not commit all files at once if they touch different layers of the stack (e.g., keep `.css` changes separate from `.cs` or `.js` backend logic). Treat `.gitignore` additions or updates as their own commit (repo config layer).
+* **No Preamble:** Execute commands directly and report status only.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*
 **/.env
 **/.env.*
+!/.claude/
 !/.github/
 !/.scripts/
 !/FinanceFrontEnd/
@@ -8,6 +9,8 @@
 !/.infra/
 !/docs/
 /.infra/funds/dataprotection/**
+!CLAUDE.md
+!AGENTS.md
 
 /docs/*
 !/docs/architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# Finanzas — Agent Reference
+
+## What This Project Is
+
+Finanzas is a personal finance web application. It tracks movements, funds, incomes, debits, credit cards, investments, and subscriptions per authenticated user. All financial data is strictly isolated per user via EF Core global query filters tied to Auth0 identity.
+
+---
+
+## Repository Layout
+
+```
+FinanceBackEnd/            ← ASP.NET Core Web API (.NET)
+FinanceFrontEnd/
+  FinanceApp/              ← React Router v7 SSR app (main UI)
+  FinanceFunds/            ← Vite SPA (funds + exchange rates)
+.infra/local/              ← Docker Compose stacks (infra, FinanceApp, FinanceFunds)
+.bin/powershell/           ← Start scripts
+.github/docs/              ← Developer reference docs (CQRS, query filters, unit testing, local dev)
+docs/                      ← Architecture docs, security audits, performance notes
+.claude/commands/          ← Claude Code slash commands
+.github/skills/            ← GitHub Copilot chat skills
+```
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Backend | C# / ASP.NET Core Web API, EF Core, PostgreSQL, Redis, Auth0 JWT, OpenTelemetry |
+| FinanceApp | React Router v7 (SSR), Tailwind CSS, shadcn/ui, Axios, Auth0 (server-side), Redis sessions |
+| FinanceFunds | React 19 SPA, Vite, Mantine v8, Auth0 SDK (client-side), native fetch |
+
+---
+
+## Architecture
+
+Detailed docs live in `docs/architecture/`:
+
+- [`docs/architecture/backend-dotnet.md`](docs/architecture/backend-dotnet.md) — solution structure, CQRS, EF Core, auth, API layer
+- [`docs/architecture/frontend-financeapp.md`](docs/architecture/frontend-financeapp.md) — SSR routing, session, proxy, UI conventions
+- [`docs/architecture/frontend-financefunds.md`](docs/architecture/frontend-financefunds.md) — SPA routing, Auth0 SDK, API client, services
+
+Developer pattern references:
+
+- [`.github/docs/cqrs-pattern.md`](.github/docs/cqrs-pattern.md) — command/query result types, dispatcher, base classes
+- [`.github/docs/finance-query-filters.md`](.github/docs/finance-query-filters.md) — EF Core global query filters and ownership model
+- [`.github/docs/unit-testing.md`](.github/docs/unit-testing.md) — test conventions, base classes, seeding
+- [`.github/docs/local-dev-environment.md`](.github/docs/local-dev-environment.md) — ports, Docker stacks, env files, known gotchas
+
+---
+
+## Build Commands
+
+### Backend
+
+```powershell
+dotnet build FinanceBackEnd/src/Finance.Api
+dotnet test FinanceBackEnd/tests/Finance.Application.Tests
+dotnet ef migrations add <Name> --project FinanceBackEnd/src/Finance.Migrations --startup-project FinanceBackEnd/src/Finance.Api
+dotnet ef database update --project FinanceBackEnd/src/Finance.Migrations --startup-project FinanceBackEnd/src/Finance.Api
+```
+
+### FinanceApp (React Router SSR) — port 5100
+
+```powershell
+cd FinanceFrontEnd/FinanceApp
+npm run dev
+npm run build
+npm run typecheck
+npm run lint
+```
+
+### FinanceFunds (Vite SPA) — port 5200
+
+```powershell
+cd FinanceFrontEnd/FinanceFunds
+npm run dev
+npm run build
+npm run lint
+```
+
+---
+
+## Coding Conventions
+
+- Write self-documenting code with clear names. Prefer refactoring unclear code into well-named methods over adding explanatory comments.
+- Only add comments for: complex algorithms, non-obvious business rules, public API XML docs, workarounds. Never for obvious code.
+- Comments explain *why*, not *what* — the code shows what.
+
+---
+
+## Code Changes Protocol
+
+1. **Review before implementing** — search and read relevant files, understand existing patterns, identify impacts, ask if requirements are ambiguous.
+2. **Propose before doing** — present your findings and proposed approach before making changes; wait for confirmation.
+3. **Exception** — implement directly only when explicitly told to ("just do it"), when the change is trivial (typo, formatting), or when you have already reviewed and proposed in the same conversation.
+
+---
+
+## Dev Environment
+
+- Never run `git commit`, `git push`, or `git rebase` unless explicitly instructed.
+- See [`.github/docs/local-dev-environment.md`](.github/docs/local-dev-environment.md) for Docker stacks, env file locations, and the localhost/IPv6 gotcha.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Finanzas — Claude Code Instructions
+
+See [AGENTS.md](AGENTS.md) for full project context: what the project does, repo layout, tech stack, architecture references, build commands, coding conventions, and code changes protocol.
+
+## Workflow Skills
+
+Project-specific skills live in `.claude/commands/`:
+
+| Skill | When to use |
+|---|---|
+| `/feature` | Implementing a new full-stack feature (entity → backend → frontend) |
+| `/unit-tests` | Writing backend xUnit tests for new or changed .NET code |
+| `/bug-fix` | Creating a GitHub bug issue, committing, and pushing the fix branch |
+| `/docs` | Creating a GitHub docs issue, committing, and pushing the docs branch |
+| `/feat` | Creating a GitHub feature issue, committing, and pushing the feature branch |
+| `/pr` | Opening the pull request once a branch is pushed |
+| `/infra` | Making infrastructure changes (compose, CI, Dockerfiles) on a branch |
+| `/security-review-backend` | Security audit of the .NET backend |
+| `/security-review-frontend` | Security audit of the React frontends |


### PR DESCRIPTION
# Why
The project had no agent configuration committed to the repository. Claude Code commands were missing entirely, and the GitHub Copilot skills had stale names (`gh-*-pr` pattern) with no sync between the two agents skill sets.

## What is the solution?
Added AGENTS.md with full project context as the single source of truth for all agents. Added CLAUDE.md pointing to AGENTS.md and listing Claude Code slash commands. Added .claude/commands/ with all project skills adapted for Claude Code. Renamed .github/skills/gh-*-pr/ directories to bug/, docs/, feat/ for consistency. Added .github/skills/infra/ and .github/skills/pr/ to keep both agents in sync. Removed automatic PR creation from bug, docs, feat, and infra skills -- PR opening is now the responsibility of the dedicated /pr skill.

## What areas of the site does it impact?
Developer tooling only -- no application code changed.

### Repo Config
- .gitignore -- un-ignores .claude/, AGENTS.md, CLAUDE.md

### Agent Configuration
- AGENTS.md -- project reference for all agents (architecture, tech stack, build commands, conventions)
- CLAUDE.md -- Claude Code-specific: skill table

### Claude Code Skills (.claude/commands/)
- bug/, docs/, feat/ -- issue + branch + commit + push (no PR)
- feature/ -- full-stack feature implementation guide
- infra/ -- infra changes workflow
- pr/ -- PR creation (branching + commits + gh pr create)
- security-review-backend/, security-review-frontend/
- unit-tests/

### GitHub Copilot Skills (.github/skills/)
- Renamed gh-bug-fix-pr/ to bug/, gh-docs-pr/ to docs/, gh-feature-pr/ to feat/
- Added infra/ and pr/ to match Claude commands
