### PR TITLE
fix(tooling): remove duplicate dotnet permission entries from Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,8 +11,6 @@
       "Bash(git commit:*)",
       "Bash(dotnet build *)",
       "Bash(dotnet test *)",
-      "dotnet build *",
-      "dotnet test *",
       "WebSearch"
     ]
   }


### PR DESCRIPTION
# Why
`.claude/settings.json` contained two duplicate permission entries — `"dotnet build *"` and `"dotnet test *"` — alongside their already-correct `Bash(...)` equivalents. This caused redundant entries in the allowlist.

## What is the solution?
Removed the two bare string entries (`"dotnet build *"`, `"dotnet test *"`) that were duplicates of the existing `"Bash(dotnet build *)"` and `"Bash(dotnet test *)"` entries.

## What areas of the site does it impact?
Claude Code harness permission configuration only. No application code is affected.

## Test scenarios

```gherkin
Scenario: Claude Code runs dotnet commands without duplicate prompts
  Given the updated .claude/settings.json is in effect
  When Claude runs "dotnet build" or "dotnet test"
  Then the command is auto-approved without a permission prompt
  And no duplicate entries appear in the allowlist
```

## Other Notes
No functional change — the effective permission set is identical. This is purely a config cleanup.