### PR TITLE
feat(credit-cards): scope import templates to cards with many-to-many association

### DIFF
--- a/.claude/commands/commit/SKILL.md
+++ b/.claude/commands/commit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: commit
+description: "Commit staged or unstaged changes in logical batches without creating branches or PRs. Use when: you have changes ready to commit on the current branch and want them grouped by layer."
+argument-hint: "[path1 path2 ...]  — optional paths to restrict which changes are committed; defaults to all unstaged/staged changes"
+---
+
+# Commit Changes in Logical Batches
+
+Analyze all pending changes (or those under the given paths) and commit them in logical groups — one commit per layer of the stack. No branch creation, no PR, no pushing.
+
+## Paths
+
+$ARGUMENTS
+
+If no paths are provided, include all staged and unstaged changes visible in `git status`.
+
+## Procedure
+
+### 1 — Inspect changes
+
+Run the following to understand what has changed:
+
+```powershell
+git status
+git diff --stat HEAD
+```
+
+If paths were provided, restrict analysis to those paths:
+
+```powershell
+git diff --stat HEAD -- <path1> [<path2> ...]
+```
+
+Also note any untracked files that should be included.
+
+### 2 — Safety check
+
+Verify no secrets, `.env` files, or files that belong in `.gitignore` are about to be staged.  
+If any are found, warn the user and exclude them.
+
+### 3 — Group into logical batches
+
+Assign each changed file to exactly one batch based on its layer. Use this priority order:
+
+| Batch | What belongs here |
+|---|---|
+| **Repo / DevEx** | `.claude/`, `.github/`, `.gitignore`, root config files (`.editorconfig`, `*.sln`) |
+| **Infrastructure** | `docker-compose*`, `Dockerfile*`, CI workflows, `infra/` |
+| **Dependencies** | `*.csproj`, `package.json`, `package-lock.json`, `*.lock` |
+| **Domain / Config** | Domain models, enums, config classes, constants |
+| **Backend Logic** | Services, handlers, helpers, repositories, commands, queries |
+| **API / Controllers** | Controllers, DTOs, mappers, API-level filters |
+| **Frontend** | Any file under `FinanceFrontEnd/` |
+| **Tests** | Any file under `*.Tests/` or `**/*Tests*` |
+| **Docs** | `*.md`, `docs/` |
+
+Files that span multiple concerns should go in the most specific batch (e.g., a controller that also adds a DTO goes in **API / Controllers**).
+
+### 4 — Commit each batch
+
+For each batch (skip empty ones), stage and commit:
+
+```powershell
+git add <files-in-batch>
+git commit -m "<type>(<scope>): <imperative summary>"
+```
+
+Commit message rules:
+- Use Conventional Commits: `feat`, `fix`, `refactor`, `chore`, `test`, `docs`
+- Scope is the layer or module (e.g., `pdf-import`, `statement-config`, `frontend`)
+- Summary is imperative, lowercase, no period, ≤72 chars
+- No trailing attributions (`Co-Authored-By`, `Generated with`, etc.)
+
+### 5 — Report
+
+After all commits, run:
+
+```powershell
+git log --oneline -10
+```
+
+Report each commit SHA and message so the user can see what was created.
+
+## Constraints
+
+- **Never** stage files outside the provided paths (if paths were given).
+- **Never** amend existing commits — always create new ones.
+- **Never** push — that is the caller's responsibility.
+- **Never** skip hooks (`--no-verify`).
+- If a commit hook fails, fix the underlying issue and retry.
+- **No Preamble:** Execute commands directly and report status only.

--- a/.claude/commands/pr/SKILL.md
+++ b/.claude/commands/pr/SKILL.md
@@ -10,22 +10,29 @@ argument-hint: "<short slug>  — short description of the feature or fix (e.g.,
 
 ## Workflow Steps
 
-1. **Sync Base:**
+1. **Detect Starting Point:**
    * Ensure GH CLI is installed and authenticated.
-   * Ensure the current branch is `main` (or the repository's default branch).
-   * Execute `git pull origin main` to ensure the local environment is up to date.
+   * Check the current branch.
+   * **If on `main`:** proceed with the full flow (steps 2–5).
+   * **If on a non-main branch:** run `gh pr view` to check whether a PR already exists for this branch.
+     * If a PR exists: alert the user with the PR URL and stop.
+     * If no PR exists: skip steps 2–3, go directly to step 4 (commits) then step 5 (open PR).
 
-2. **Branching:**
+2. **Sync Base** _(main-start only)_**:**
+   * Execute `git pull origin main` to ensure the local environment is up to date.
+   * If there are merge conflicts, stop and alert the user.
+
+3. **Branching** _(main-start only)_**:**
    * Create a new branch using Git Flow naming conventions: `feature/[arg]`, `fix/[arg]`, `refactor/[arg]`, or `docs/[arg]`.
    * Switch to the new branch immediately.
 
-3. **Atomic Commits:**
+4. **Atomic Commits:**
    * Analyze staged/unstaged changes.
    * Verify no ignored files are accidentally staged (`git status` should not show files that belong in `.gitignore`).
    * Group related file changes into "logical batches" (e.g., all database migrations together, then all service logic). Treat `.gitignore` additions or updates as their own commit (repo config layer).
    * Commit each batch with a concise, imperative message (e.g., "Add user schema", "Implement auth controller").
 
-4. **Open Pull Request:**
+5. **Open Pull Request:**
    * Use GH CLI: `gh pr create --title "<title>" --body-file <temp-file>`.
    * PR title must follow Conventional Commits: `type(scope): short description (issue #N)`.
    * PR body must follow the template in `.github/PULL_REQUEST_TEMPLATE.md`:
@@ -36,7 +43,7 @@ argument-hint: "<short slug>  — short description of the feature or fix (e.g.,
 
 ## Constraints
 
-* **Branch Guard:** If the current branch is not `main`, alert the user and stop — continuing might be destructive.
-* **Safety Check:** If there are merge conflicts during the `git pull`, stop and alert the user.
+* **Branch Guard:** If on a non-main branch and a PR already exists, alert the user with the PR URL and stop.
+* **Safety Check:** If there are merge conflicts during `git pull`, stop and alert the user.
 * **Batching Intelligence:** Do not commit all files at once if they touch different layers of the stack (e.g., keep `.css` changes separate from `.cs` or `.js` backend logic). Treat `.gitignore` additions or updates as their own commit (repo config layer).
 * **No Preamble:** Execute commands directly and report status only.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,7 @@
       "Bash(git add:*)",
       "Bash(git branch:*)",
       "Bash(git checkout:*)",
+      "Bash(git commit *)",
       "Bash(uv run:*)",
       "Edit",
       "PowerShell(cd *)",
@@ -19,15 +20,14 @@
       "PowerShell(git add:*)",
       "PowerShell(git branch:*)",
       "PowerShell(git checkout:*)",
+      "PowerShell(git commit *)",
       "PowerShell(uv run:*)",
       "Read",
       "WebSearch",
       "Write"
     ],
     "ask": [
-      "Bash(git commit*)",
       "Bash(git push*)",
-      "PowerShell(git commit*)",
       "PowerShell(git push*)"
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,8 @@
       "Bash(git commit:*)",
       "Bash(dotnet build *)",
       "Bash(dotnet test *)",
+      "Bash(dotnet ef migrations add *)",
+      "Bash(dotnet ef migrations remove *)",
       "WebSearch"
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,12 +8,15 @@
       "Bash(git checkout:*)",
       "Bash(git branch:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)",
       "Bash(dotnet build *)",
       "Bash(dotnet test *)",
       "Bash(dotnet ef migrations add *)",
       "Bash(dotnet ef migrations remove *)",
       "WebSearch"
+    ],
+    "ask": [
+      "Bash(git commit*)",
+      "Bash(git push*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,23 +1,34 @@
 {
   "permissions": {
     "allow": [
-      "Read",
-      "Write",
-      "Edit",
       "Bash(cd *)",
-      "Bash(uv run:*)",
-      "Bash(git checkout:*)",
-      "Bash(git branch:*)",
-      "Bash(git add:*)",
       "Bash(dotnet build *)",
-      "Bash(dotnet test *)",
       "Bash(dotnet ef migrations add *)",
       "Bash(dotnet ef migrations remove *)",
-      "WebSearch"
+      "Bash(dotnet test *)",
+      "Bash(git add:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(uv run:*)",
+      "Edit",
+      "PowerShell(cd *)",
+      "PowerShell(dotnet build *)",
+      "PowerShell(dotnet ef migrations add *)",
+      "PowerShell(dotnet ef migrations remove *)",
+      "PowerShell(dotnet test *)",
+      "PowerShell(git add:*)",
+      "PowerShell(git branch:*)",
+      "PowerShell(git checkout:*)",
+      "PowerShell(uv run:*)",
+      "Read",
+      "WebSearch",
+      "Write"
     ],
     "ask": [
       "Bash(git commit*)",
-      "Bash(git push*)"
+      "Bash(git push*)",
+      "PowerShell(git commit*)",
+      "PowerShell(git push*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
       "Read",
       "Write",
       "Edit",
+      "Bash(cd *)",
       "Bash(uv run:*)",
       "Bash(git checkout:*)",
       "Bash(git branch:*)",

--- a/.github/workflows/codeql-remix.yml
+++ b/.github/workflows/codeql-remix.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: FinanceFrontEnd/FinanceApp
-      run: npm ci
+      run: npm install
 
     - name: Build (Remix)
       working-directory: FinanceFrontEnd/FinanceApp

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Install dependencies (FinanceApp)
         working-directory: FinanceFrontEnd/FinanceApp
         run: |
-          npm ci
+          npm install
 
       - name: Install dependencies (FinanceFunds)
         working-directory: FinanceFrontEnd/FinanceFunds
         run: |
-          npm ci
+          npm install
 
       - name: Focused no-console lint (FinanceApp)
         working-directory: FinanceFrontEnd/FinanceApp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,9 @@ npm run lint
 - Only add comments for: complex algorithms, non-obvious business rules, public API XML docs, workarounds. Never for obvious code.
 - Comments explain *why*, not *what* — the code shows what.
 - Never use `#pragma warning disable` — fix the underlying issue instead.
+- Always reuse existing UI components instead of falling back to raw HTML elements. Check imports already in the file, then look in these two locations before writing any markup:
+  - `app/components/ui/shadcn/` — `Button`, `Input`, `Label`, `Separator`, `Textarea`, `Table/*`, `Carousel/*`, `Pagination`
+  - `app/components/ui/utils/` — `Checkbox`, `Picker` (select/dropdown), `Uploader` (file upload with toast), `InputControl`, `Modal/*`, `ActionButton`, `BankCurrencySelector`, `Table` (simple data+columns), `FetchTable` (data or URL, empty state, totals, collapsible), `PaginatedTable` (paginated + CRUD)
 
 ### Backend: Folder Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,20 @@ npm run lint
 - Only add comments for: complex algorithms, non-obvious business rules, public API XML docs, workarounds. Never for obvious code.
 - Comments explain *why*, not *what* — the code shows what.
 
+### Backend: Folder Structure
+
+Folders are organised **category first, then domain**: `Commands/CreditCards/`, `Specifications/CreditCards/`, `Queries/CreditCards/`, etc.
+
+Auth specifications (role/identity checks) live in `Auth/`. Business-rule specifications live in `Specifications/<Domain>/` and are registered via `AddSpecifications()` in `ServiceExtensions`.
+
+### Backend: Command Error Handling
+
+The desired pattern is the **envelope approach**: command handlers return `DataResult<TEntity>` (or `DataResult.Failure("reason")` for expected failures), and controllers unwrap the envelope and map to the appropriate HTTP status code.
+
+`CommandController` follows this correctly — it checks `result.IsSuccess` and returns `BadRequest(result.ErrorMessage)` on failure.
+
+`ApiBaseCUDCommandController` is a **known inconsistency**: it calls `DispatchCommandAsync` and always returns `Ok()`, ignoring the result. Until that controller is fixed, handlers behind it must `throw` to abort a request (use `UnauthorizedAccessException` for permission failures, `InvalidOperationException` for business rule violations). Do not silently swallow failures by adjusting the record and proceeding.
+
 ---
 
 ## Code Changes Protocol
@@ -95,6 +109,7 @@ npm run lint
 1. **Review before implementing** — search and read relevant files, understand existing patterns, identify impacts, ask if requirements are ambiguous.
 2. **Propose before doing** — present your findings and proposed approach before making changes; wait for confirmation.
 3. **Exception** — implement directly only when explicitly told to ("just do it"), when the change is trivial (typo, formatting), or when you have already reviewed and proposed in the same conversation.
+4. **Document new patterns** — when exploration reveals a pattern not yet in this file (architectural convention, error handling approach, naming rule, etc.), confirm with the user whether it is the desired pattern before adopting it, then add it here.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ npm run lint
 - Write self-documenting code with clear names. Prefer refactoring unclear code into well-named methods over adding explanatory comments.
 - Only add comments for: complex algorithms, non-obvious business rules, public API XML docs, workarounds. Never for obvious code.
 - Comments explain *why*, not *what* — the code shows what.
+- Never use `#pragma warning disable` — fix the underlying issue instead.
 
 ### Backend: Folder Structure
 

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Base/ApiBaseCUDCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Base/ApiBaseCUDCommandController.cs
@@ -23,7 +23,7 @@ public abstract class ApiBaseCUDCommandController<
     where TDeleteCommand : ICommand
 {
     [HttpPost]
-    public async Task<IActionResult> Create(TCreateCommand command)
+    public virtual async Task<IActionResult> Create(TCreateCommand command)
         => await ExecuteAsync(command);
 
     [HttpPut]

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Base/ApiBaseCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Base/ApiBaseCommandController.cs
@@ -19,7 +19,9 @@ public abstract class ApiBaseCommandController<TEntity, TId, TDto>(IMappingServi
 {
     protected async override Task<IActionResult> ExecuteAsync(ICommand command)
     {
-        await Dispatcher.DispatchCommandAsync(command);
+        var result = await Dispatcher.DispatchCommandAsync(command);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
         return Ok();
     }
 

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardCommandController.cs
@@ -2,6 +2,7 @@ using CQRSDispatch.Interfaces;
 using Finance.Api.Controllers.Base;
 using Finance.Api.Controllers.Requests;
 using Finance.Application.Auth;
+using Finance.Application.Commands.CreditCards;
 using Finance.Application.Dtos.CreditCards;
 using Finance.Application.Mapping;
 using Finance.Application.Services;
@@ -29,4 +30,16 @@ public class CreditCardCommandController(
         CreditCardDto,
         CreditCardService>(mapper, dispatcher, creditCardService)
 {
+    [HttpPatch("{id}/default-import-template")]
+    public async Task<IActionResult> SetDefaultImportTemplate(Guid id, [FromBody] SetDefaultImportTemplateRequest request)
+    {
+        await ExecuteAsync(new SetCreditCardDefaultImportTemplateCommand
+        {
+            CreditCardId = id,
+            TemplateId = request.TemplateId,
+        });
+        return Ok();
+    }
 }
+
+public record SetDefaultImportTemplateRequest(Guid? TemplateId);

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementCommandController.cs
@@ -18,4 +18,18 @@ public class CreditCardStatementCommandController(IMappingService mapper, IDispa
     CreateCreditCardStatementCommand,
     UpdateCreditCardStatementCommand,
     DeleteCreditCardStatementCommand
-    >(mapper, dispatcher);
+    >(mapper, dispatcher)
+{
+    [HttpPost("import")]
+    public async Task<IActionResult> Import(IFormFile file, string templateId, string statementId)
+    {
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = file,
+            TemplateId = new Guid(templateId),
+            StatementId = new Guid(statementId),
+        };
+        await ExecuteAsync(command);
+        return Ok();
+    }
+}

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementCommandController.cs
@@ -1,3 +1,4 @@
+using CQRSDispatch;
 using CQRSDispatch.Interfaces;
 using Finance.Api.Controllers.Base;
 using Finance.Application.Auth;
@@ -20,8 +21,16 @@ public class CreditCardStatementCommandController(IMappingService mapper, IDispa
     DeleteCreditCardStatementCommand
     >(mapper, dispatcher)
 {
+    public override async Task<IActionResult> Create(CreateCreditCardStatementCommand command)
+    {
+        var result = await Dispatcher.DispatchAsync<DataResult<CreditCardStatement>>(command);
+        if (!result.IsSuccess)
+            return BadRequest(result.ErrorMessage);
+        return Ok(MappingService.Map<CreditCardStatementDto>(result.Data!));
+    }
+
     [HttpPost("import")]
-    public async Task<IActionResult> Import(IFormFile file, string templateId, string statementId)
+    public async Task<IActionResult> Import(IFormFile file, [FromForm] string templateId, [FromForm] string statementId)
     {
         var command = new ImportCreditCardStatementTransactionsCommand
         {
@@ -29,7 +38,6 @@ public class CreditCardStatementCommandController(IMappingService mapper, IDispa
             TemplateId = new Guid(templateId),
             StatementId = new Guid(statementId),
         };
-        await ExecuteAsync(command);
-        return Ok();
+        return await ExecuteAsync(command);
     }
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementCommandController.cs
@@ -6,6 +6,7 @@ using Finance.Application.Commands.CreditCards;
 using Finance.Application.Dtos.CreditCards;
 using Finance.Application.Mapping;
 using Finance.Domain.Models.CreditCards;
+using Finance.Helpers.ExcelHelper;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Finance.Api.Controllers.Commands;
@@ -39,5 +40,12 @@ public class CreditCardStatementCommandController(IMappingService mapper, IDispa
             StatementId = new Guid(statementId),
         };
         return await ExecuteAsync(command);
+    }
+
+    [HttpPost("pdf-diagnose")]
+    public IActionResult PdfDiagnose(IFormFile file)
+    {
+        var result = new StatementImportPdfHelper().Diagnose(file);
+        return Ok(result);
     }
 }

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementImportTemplateCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementImportTemplateCommandController.cs
@@ -20,4 +20,19 @@ public class CreditCardStatementImportTemplateCommandController(
         CreditCardStatementImportTemplateDto,
         CreateCreditCardStatementImportTemplateCommand,
         UpdateCreditCardStatementImportTemplateCommand,
-        DeleteCreditCardStatementImportTemplateCommand>(mapper, dispatcher);
+        DeleteCreditCardStatementImportTemplateCommand>(mapper, dispatcher)
+{
+    [HttpPost("{templateId}/associate")]
+    public async Task<IActionResult> Associate(Guid templateId, [FromBody] AssociateCreditCardImportTemplateBody body)
+    {
+        var command = new AssociateCreditCardImportTemplateCommand
+        {
+            TemplateId = templateId,
+            CreditCardId = body.CreditCardId,
+        };
+        await Dispatcher.DispatchCommandAsync(command);
+        return Ok();
+    }
+}
+
+public record AssociateCreditCardImportTemplateBody(Guid CreditCardId);

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementImportTemplateCommandController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Commands/CreditCardStatementImportTemplateCommandController.cs
@@ -1,0 +1,23 @@
+using CQRSDispatch.Interfaces;
+using Finance.Api.Controllers.Base;
+using Finance.Application.Auth;
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Dtos.CreditCards;
+using Finance.Application.Mapping;
+using Finance.Domain.Models.CreditCards;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Finance.Api.Controllers.Commands;
+
+[Route("api/credit-card-statement-import-templates")]
+[Authorize(Policy = "AdminOrOwnerPolicy")]
+public class CreditCardStatementImportTemplateCommandController(
+    IMappingService mapper, IDispatcher<FinanceDispatchContext> dispatcher)
+    : ApiBaseCUDCommandController<
+        CreditCardStatementImportTemplate,
+        Guid,
+        CreditCardStatementImportTemplateDto,
+        CreateCreditCardStatementImportTemplateCommand,
+        UpdateCreditCardStatementImportTemplateCommand,
+        DeleteCreditCardStatementImportTemplateCommand>(mapper, dispatcher);

--- a/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CreditCardStatementImportTemplateQueryController.cs
+++ b/FinanceBackEnd/src/Finance.Api/Controllers/Queries/CreditCardStatementImportTemplateQueryController.cs
@@ -1,0 +1,22 @@
+using CQRSDispatch.Interfaces;
+using Finance.Api.Controllers.Base;
+using Finance.Application.Auth;
+using Finance.Application.Dtos.CreditCards;
+using Finance.Application.Mapping;
+using Finance.Application.Queries.CreditCards;
+using Finance.Domain.Models.CreditCards;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Finance.Api.Controllers.Queries;
+
+[Route("api/credit-card-statement-import-templates")]
+[Authorize(Policy = "AdminOrOwnerPolicy")]
+public class CreditCardStatementImportTemplateQueryController(
+    IMappingService mapper, IDispatcher<FinanceDispatchContext> dispatcher)
+    : ApiBaseQueryController<CreditCardStatementImportTemplate, Guid, CreditCardStatementImportTemplateDto>(mapper, dispatcher)
+{
+    [HttpGet]
+    public async Task<IActionResult> Get([FromQuery] GetCreditCardStatementImportTemplatesQuery request)
+        => await ExecuteAsync(request!);
+}

--- a/FinanceBackEnd/src/Finance.Api/Core/Config/ConfigExtensions.cs
+++ b/FinanceBackEnd/src/Finance.Api/Core/Config/ConfigExtensions.cs
@@ -35,6 +35,10 @@ public static class ConfigExtensions
 
         services.AddEntityServices();
 
+        services.AddApplicationSecurityServices();
+
+        services.AddSpecifications();
+
         services.AddSagaServices();
 
         services.AddScoped<IExcelHelper<IOLInvestment>, IOLInvestmentExcelHelper>();

--- a/FinanceBackEnd/src/Finance.Application/Auth/IsAdminUser.cs
+++ b/FinanceBackEnd/src/Finance.Application/Auth/IsAdminUser.cs
@@ -1,0 +1,33 @@
+using Finance.Domain.Enums;
+using Finance.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Auth;
+
+public class IsAdminUser(IHttpContextAccessor httpContextAccessor, FinanceDbContext db)
+{
+    private (bool IsAdmin, Guid? UserId)? _cache;
+
+    public async Task<(bool IsAdmin, Guid? UserId)> IsSatisfiedAsync(CancellationToken ct = default)
+    {
+        if (_cache.HasValue) return _cache.Value;
+
+        var identitySourceId = httpContextAccessor.HttpContext?.User?.Identity?.Name;
+        if (string.IsNullOrEmpty(identitySourceId))
+        {
+            _cache = (false, null);
+            return _cache.Value;
+        }
+
+        var user = await db.User
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .Include(u => u.Identities)
+            .Include(u => u.Roles)
+            .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == identitySourceId), ct);
+
+        _cache = (user?.Roles.Any(r => r.Id == RoleEnum.Admin) ?? false, user?.Id);
+        return _cache.Value;
+    }
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/AssociateCreditCardImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/AssociateCreditCardImportTemplateCommand.cs
@@ -1,0 +1,44 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Commands.Base;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class AssociateCreditCardImportTemplateCommandHandler : BaseResponselessHandler<AssociateCreditCardImportTemplateCommand>
+{
+    public AssociateCreditCardImportTemplateCommandHandler(FinanceDbContext db) : base(db) { }
+
+    public override async Task<CommandResult> ExecuteAsync(
+        AssociateCreditCardImportTemplateCommand command, CancellationToken cancellationToken)
+    {
+        var template = await DbContext.CreditCardStatementImportTemplate
+            .IgnoreQueryFilters()
+            .Include(t => t.CreditCards)
+            .FirstOrDefaultAsync(t => t.Id == command.TemplateId, cancellationToken);
+
+        if (template is null)
+            return CommandResult.Failure($"Template not found: {command.TemplateId}");
+
+        if (template.CreditCards.Any(c => c.Id == command.CreditCardId))
+            return CommandResult.Success();
+
+        var creditCard = await DbContext.CreditCard
+            .FirstOrDefaultAsync(c => c.Id == command.CreditCardId, cancellationToken);
+
+        if (creditCard is null)
+            return CommandResult.Failure($"Credit card not found: {command.CreditCardId}");
+
+        template.CreditCards.Add(creditCard);
+        await DbContext.SaveChangesAsync(cancellationToken);
+
+        return CommandResult.Success();
+    }
+}
+
+public class AssociateCreditCardImportTemplateCommand : ICommand
+{
+    public Guid TemplateId { get; set; }
+    public Guid CreditCardId { get; set; }
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
@@ -50,7 +50,7 @@ public class CreateCreditCardStatementImportTemplateCommandHandler
         {
             Name = command.Name,
             IsSystem = command.IsSystem,
-            UserId = userId,
+            UserId = command.IsSystem ? null : userId,
             ConfigJson = command.ConfigJson,
         };
 

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
@@ -1,9 +1,11 @@
+using CQRSDispatch;
 using System.ComponentModel.DataAnnotations;
+using Finance.Application.Auth;
 using Finance.Application.Base.Handlers;
+using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Repositories;
 using Finance.Domain.Models.CreditCards;
 using Finance.Persistence;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 namespace Finance.Application.Commands.CreditCards;
@@ -12,35 +14,37 @@ public class CreateCreditCardStatementImportTemplateCommandHandler
     : BaseCreateCommandHandler<CreateCreditCardStatementImportTemplateCommand, CreditCardStatementImportTemplate, Guid>
 {
     private readonly FinanceDbContext _db;
-    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IsAdminUser _isAdminUser;
+    private readonly CanSetSystemFlag _canSetSystemFlag;
 
     public CreateCreditCardStatementImportTemplateCommandHandler(
         IRepository<CreditCardStatementImportTemplate, Guid> repository,
         FinanceDbContext db,
-        IHttpContextAccessor httpContextAccessor)
+        IsAdminUser isAdminUser,
+        CanSetSystemFlag canSetSystemFlag)
         : base(repository, db)
     {
         _db = db;
-        _httpContextAccessor = httpContextAccessor;
+        _isAdminUser = isAdminUser;
+        _canSetSystemFlag = canSetSystemFlag;
+    }
+
+    public override async Task<DataResult<CreditCardStatementImportTemplate>> ExecuteAsync(
+        CreateCreditCardStatementImportTemplateCommand command, CancellationToken cancellationToken = default)
+    {
+        if (command.IsSystem)
+        {
+            var check = await _canSetSystemFlag.IsSatisfiedAsync(cancellationToken);
+            if (!check.IsSuccess)
+                return DataResult<CreditCardStatementImportTemplate>.Failure(check.ErrorMessage!);
+        }
+        return await base.ExecuteAsync(command, cancellationToken);
     }
 
     protected override async Task<CreditCardStatementImportTemplate> BuildRecord(
         CreateCreditCardStatementImportTemplateCommand command, CancellationToken cancellationToken)
     {
-        Guid? userId = null;
-        if (!command.IsSystem)
-        {
-            var identitySourceId = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
-            if (!string.IsNullOrEmpty(identitySourceId))
-            {
-                var user = await _db.User
-                    .IgnoreQueryFilters()
-                    .AsNoTracking()
-                    .Include(u => u.Identities)
-                    .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == identitySourceId), cancellationToken);
-                userId = user?.Id;
-            }
-        }
+        var (_, userId) = await _isAdminUser.IsSatisfiedAsync(cancellationToken);
 
         var template = new CreditCardStatementImportTemplate
         {

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
@@ -42,13 +42,23 @@ public class CreateCreditCardStatementImportTemplateCommandHandler
             }
         }
 
-        return new CreditCardStatementImportTemplate
+        var template = new CreditCardStatementImportTemplate
         {
             Name = command.Name,
             IsSystem = command.IsSystem,
             UserId = userId,
             ConfigJson = command.ConfigJson,
         };
+
+        if (command.CreditCardId.HasValue)
+        {
+            var creditCard = await _db.CreditCard
+                .FirstOrDefaultAsync(c => c.Id == command.CreditCardId.Value, cancellationToken);
+            if (creditCard != null)
+                template.CreditCards.Add(creditCard);
+        }
+
+        return template;
     }
 }
 
@@ -62,4 +72,6 @@ public class CreateCreditCardStatementImportTemplateCommand : BaseCreateCommand<
 
     [Required]
     public string ConfigJson { get; set; } = string.Empty;
+
+    public Guid? CreditCardId { get; set; }
 }

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommand.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel.DataAnnotations;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class CreateCreditCardStatementImportTemplateCommandHandler
+    : BaseCreateCommandHandler<CreateCreditCardStatementImportTemplateCommand, CreditCardStatementImportTemplate, Guid>
+{
+    private readonly FinanceDbContext _db;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CreateCreditCardStatementImportTemplateCommandHandler(
+        IRepository<CreditCardStatementImportTemplate, Guid> repository,
+        FinanceDbContext db,
+        IHttpContextAccessor httpContextAccessor)
+        : base(repository, db)
+    {
+        _db = db;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    protected override async Task<CreditCardStatementImportTemplate> BuildRecord(
+        CreateCreditCardStatementImportTemplateCommand command, CancellationToken cancellationToken)
+    {
+        Guid? userId = null;
+        if (!command.IsSystem)
+        {
+            var identitySourceId = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+            if (!string.IsNullOrEmpty(identitySourceId))
+            {
+                var user = await _db.User
+                    .IgnoreQueryFilters()
+                    .AsNoTracking()
+                    .Include(u => u.Identities)
+                    .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == identitySourceId), cancellationToken);
+                userId = user?.Id;
+            }
+        }
+
+        return new CreditCardStatementImportTemplate
+        {
+            Name = command.Name,
+            IsSystem = command.IsSystem,
+            UserId = userId,
+            ConfigJson = command.ConfigJson,
+        };
+    }
+}
+
+public class CreateCreditCardStatementImportTemplateCommand : BaseCreateCommand<CreditCardStatementImportTemplate>
+{
+    [Required]
+    [StringLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    public bool IsSystem { get; set; }
+
+    [Required]
+    public string ConfigJson { get; set; } = string.Empty;
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementCommand.cs
@@ -8,7 +8,7 @@ namespace Finance.Application.Commands.CreditCards;
 public sealed class DeleteCreditCardStatementCommand : BaseDeleteCommand<Guid>;
 
 public sealed class DeleteCreditCardStatementCommandHandler(IEntityService<CreditCardStatement, Guid> service)
-    : BaseDeleteCommandHandler<CreditCardStatement, Guid>(service);
+    : BaseDeleteCommandHandler<DeleteCreditCardStatementCommand, CreditCardStatement, Guid>(service);
 
 public sealed class DeleteCreditCardStatementCommandValidator(IRepository<CreditCardStatement, Guid> repository)
     : BaseDeleteCommandValidator<DeleteCreditCardStatementCommand, CreditCardStatement, Guid>(repository);

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementCommand.cs
@@ -1,14 +1,47 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
 using Finance.Application.Base.Handlers;
 using Finance.Application.Repositories;
-using Finance.Application.Services;
 using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Finance.Application.Commands.CreditCards;
 
 public sealed class DeleteCreditCardStatementCommand : BaseDeleteCommand<Guid>;
 
-public sealed class DeleteCreditCardStatementCommandHandler(IEntityService<CreditCardStatement, Guid> service)
-    : BaseDeleteCommandHandler<DeleteCreditCardStatementCommand, CreditCardStatement, Guid>(service);
+public sealed class DeleteCreditCardStatementCommandHandler(FinanceDbContext db)
+    : ICommandHandler<DeleteCreditCardStatementCommand>
+{
+    public async Task<CommandResult> ExecuteAsync(DeleteCreditCardStatementCommand command, CancellationToken cancellationToken = default)
+    {
+        foreach (var id in command.Ids)
+        {
+            var statement = await db.CreditCardStatement
+                .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+
+            if (statement == null) continue;
+
+            var linkedTransactionIds = await db.CreditCardStatementTransaction
+                .Where(st => st.StatementId == id && st.CreditCardTransactionId != null)
+                .Select(st => st.CreditCardTransactionId!.Value)
+                .ToListAsync(cancellationToken);
+
+            await db.CreditCardTransaction
+                .Where(t => linkedTransactionIds.Contains(t.Id))
+                .ExecuteUpdateAsync(s => s.SetProperty(t => t.Deactivated, true), cancellationToken);
+
+            await db.CreditCardPayment
+                .Where(p => p.StatementId == id)
+                .ExecuteUpdateAsync(s => s.SetProperty(p => p.Deactivated, true), cancellationToken);
+
+            statement.Deactivated = true;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+        return CommandResult.Success();
+    }
+}
 
 public sealed class DeleteCreditCardStatementCommandValidator(IRepository<CreditCardStatement, Guid> repository)
     : BaseDeleteCommandValidator<DeleteCreditCardStatementCommand, CreditCardStatement, Guid>(repository);

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementImportTemplateCommand.cs
@@ -1,0 +1,16 @@
+using Finance.Application.Base.Handlers;
+using Finance.Application.Repositories;
+using Finance.Application.Services;
+using Finance.Domain.Models.CreditCards;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public sealed class DeleteCreditCardStatementImportTemplateCommand : BaseDeleteCommand<Guid>;
+
+public sealed class DeleteCreditCardStatementImportTemplateCommandHandler(
+    IEntityService<CreditCardStatementImportTemplate, Guid> service)
+    : BaseDeleteCommandHandler<CreditCardStatementImportTemplate, Guid>(service);
+
+public sealed class DeleteCreditCardStatementImportTemplateCommandValidator(
+    IRepository<CreditCardStatementImportTemplate, Guid> repository)
+    : BaseDeleteCommandValidator<DeleteCreditCardStatementImportTemplateCommand, CreditCardStatementImportTemplate, Guid>(repository);

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/DeleteCreditCardStatementImportTemplateCommand.cs
@@ -9,7 +9,7 @@ public sealed class DeleteCreditCardStatementImportTemplateCommand : BaseDeleteC
 
 public sealed class DeleteCreditCardStatementImportTemplateCommandHandler(
     IEntityService<CreditCardStatementImportTemplate, Guid> service)
-    : BaseDeleteCommandHandler<CreditCardStatementImportTemplate, Guid>(service);
+    : BaseDeleteCommandHandler<DeleteCreditCardStatementImportTemplateCommand, CreditCardStatementImportTemplate, Guid>(service);
 
 public sealed class DeleteCreditCardStatementImportTemplateCommandValidator(
     IRepository<CreditCardStatementImportTemplate, Guid> repository)

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
@@ -22,8 +22,17 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
             .FirstOrDefaultAsync(t => t.Id == command.TemplateId, cancellationToken)
             ?? throw new Exception($"Import template not found: {command.TemplateId}");
 
-        var config = JsonSerializer.Deserialize<StatementImportConfig>(template.ConfigJson)
+        var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var config = JsonSerializer.Deserialize<StatementImportConfig>(template.ConfigJson, jsonOptions)
             ?? throw new Exception("Invalid template configuration");
+
+        if (config.DefaultCurrencyId == Guid.Empty)
+        {
+            using var doc = JsonDocument.Parse(template.ConfigJson);
+            if (doc.RootElement.TryGetProperty("config", out var configEl))
+                config = JsonSerializer.Deserialize<StatementImportConfig>(configEl.GetRawText(), jsonOptions)
+                    ?? config;
+        }
 
         var statement = await DbContext.CreditCardStatement
             .Include(s => s.CreditCard)

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
@@ -7,6 +7,7 @@ using Finance.Persistence;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Finance.Application.Commands.CreditCards;
 
@@ -22,17 +23,13 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
             .FirstOrDefaultAsync(t => t.Id == command.TemplateId, cancellationToken)
             ?? throw new Exception($"Import template not found: {command.TemplateId}");
 
-        var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        };
         var config = JsonSerializer.Deserialize<StatementImportConfig>(template.ConfigJson, jsonOptions)
             ?? throw new Exception("Invalid template configuration");
-
-        if (config.DefaultCurrencyId == Guid.Empty)
-        {
-            using var doc = JsonDocument.Parse(template.ConfigJson);
-            if (doc.RootElement.TryGetProperty("config", out var configEl))
-                config = JsonSerializer.Deserialize<StatementImportConfig>(configEl.GetRawText(), jsonOptions)
-                    ?? config;
-        }
 
         var statement = await DbContext.CreditCardStatement
             .Include(s => s.CreditCard)
@@ -44,7 +41,7 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
         if (rows.Length == 0) return CommandResult.Failure("No rows found in the uploaded file.");
 
         var existingTxs = await DbContext.CreditCardTransaction
-            .Where(t => t.CreditCardId == statement.CreditCardId)
+            .Where(t => t.CreditCardId == statement.CreditCardId && !t.Deactivated)
             .Select(t => new { t.Timestamp, t.Concept, Amount = (decimal)t.Amount })
             .ToArrayAsync(cancellationToken);
 
@@ -64,7 +61,7 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
                 TransactionType = CreditCardTransactionType.Purchase,
                 Concept = row.Concept,
                 Amount = row.Amount,
-                CurrencyId = config.DefaultCurrencyId,
+                CurrencyId = row.CurrencyId,
             };
             DbContext.CreditCardTransaction.Add(tx);
 
@@ -75,7 +72,7 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
                 PostedDate = row.Date,
                 Amount = row.Amount,
                 Description = row.Concept,
-                CurrencyId = config.DefaultCurrencyId,
+                CurrencyId = row.CurrencyId,
             });
         }
 

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
@@ -73,6 +73,17 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
             await DbContext.SaveChangesAsync(cancellationToken);
         }
 
+        var templateForLink = await DbContext.CreditCardStatementImportTemplate
+            .IgnoreQueryFilters()
+            .Include(t => t.CreditCards)
+            .FirstAsync(t => t.Id == command.TemplateId, cancellationToken);
+
+        if (!templateForLink.CreditCards.Any(c => c.Id == statement.CreditCardId))
+        {
+            templateForLink.CreditCards.Add(statement.CreditCard!);
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
         return CommandResult.Success();
     }
 }
@@ -87,6 +98,7 @@ public class ImportCreditCardStatementTransactionsCommand : ICommand
 public class StatementImportConfig
 {
     public int SkipRows { get; set; } = 1;
+    public int SkipLastRows { get; set; } = 0;
     public int DateColumn { get; set; } = 0;
     public string DateFormat { get; set; } = "d/M/yyyy";
     public int ConceptColumn { get; set; } = 1;

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
@@ -1,0 +1,98 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Commands.Base;
+using Finance.Domain.Models.CreditCards;
+using Finance.Helpers.ExcelHelper;
+using Finance.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponselessHandler<ImportCreditCardStatementTransactionsCommand>
+{
+    public ImportCreditCardStatementTransactionsCommandHandler(FinanceDbContext db) : base(db) { }
+
+    public override async Task<CommandResult> ExecuteAsync(
+        ImportCreditCardStatementTransactionsCommand command, CancellationToken cancellationToken)
+    {
+        var template = await DbContext.CreditCardStatementImportTemplate
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == command.TemplateId, cancellationToken)
+            ?? throw new Exception($"Import template not found: {command.TemplateId}");
+
+        var config = JsonSerializer.Deserialize<StatementImportConfig>(template.ConfigJson)
+            ?? throw new Exception("Invalid template configuration");
+
+        var statement = await DbContext.CreditCardStatement
+            .Include(s => s.CreditCard)
+            .FirstOrDefaultAsync(s => s.Id == command.StatementId, cancellationToken)
+            ?? throw new Exception($"Statement not found: {command.StatementId}");
+
+        var helper = new StatementImportExcelHelper();
+        var rows = helper.Read(command.File, config).ToArray();
+        if (rows.Length == 0) return CommandResult.Failure("No rows found in the uploaded file.");
+
+        var existingTxs = await DbContext.CreditCardTransaction
+            .Where(t => t.CreditCardId == statement.CreditCardId)
+            .Select(t => new { t.Timestamp, t.Concept, Amount = (decimal)t.Amount })
+            .ToArrayAsync(cancellationToken);
+
+        var existingSet = existingTxs
+            .Select(t => (t.Timestamp.Date, t.Concept, t.Amount))
+            .ToHashSet();
+
+        foreach (var row in rows)
+        {
+            if (existingSet.Contains((row.Date.Date, row.Concept, row.Amount)))
+                continue;
+
+            var tx = new CreditCardTransaction
+            {
+                CreditCardId = statement.CreditCardId,
+                Timestamp = row.Date,
+                TransactionType = CreditCardTransactionType.Purchase,
+                Concept = row.Concept,
+                Amount = row.Amount,
+                CurrencyId = config.DefaultCurrencyId,
+            };
+            DbContext.CreditCardTransaction.Add(tx);
+            await DbContext.SaveChangesAsync(cancellationToken);
+
+            var statementTx = new CreditCardStatementTransaction
+            {
+                StatementId = statement.Id,
+                CreditCardTransactionId = tx.Id,
+                PostedDate = row.Date,
+                Amount = row.Amount,
+                Description = row.Concept,
+                CurrencyId = config.DefaultCurrencyId,
+            };
+            DbContext.CreditCardStatementTransaction.Add(statementTx);
+            await DbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return CommandResult.Success();
+    }
+}
+
+public class ImportCreditCardStatementTransactionsCommand : ICommand
+{
+    public IFormFile File { get; set; } = default!;
+    public Guid TemplateId { get; set; }
+    public Guid StatementId { get; set; }
+}
+
+public class StatementImportConfig
+{
+    public int SkipRows { get; set; } = 1;
+    public int DateColumn { get; set; } = 0;
+    public string DateFormat { get; set; } = "d/M/yyyy";
+    public int ConceptColumn { get; set; } = 1;
+    public int AmountColumn { get; set; } = 2;
+    public Guid DefaultCurrencyId { get; set; }
+    public string DecimalSeparator { get; set; } = ",";
+    public string ThousandsSeparator { get; set; } = ".";
+    public bool AmountNegate { get; set; } = false;
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
@@ -36,9 +36,28 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
             .FirstOrDefaultAsync(s => s.Id == command.StatementId, cancellationToken)
             ?? throw new Exception($"Statement not found: {command.StatementId}");
 
-        var helper = new StatementImportExcelHelper();
-        var rows = helper.Read(command.File, config).ToArray();
-        if (rows.Length == 0) return CommandResult.Failure("No rows found in the uploaded file.");
+        var extension = Path.GetExtension(command.File.FileName).ToLowerInvariant();
+        IEnumerable<StatementImportRow> rawRows = extension == ".pdf" || config.SourceType == SourceType.Pdf
+            ? new StatementImportPdfHelper().Read(command.File, config)
+            : new StatementImportExcelHelper().Read(command.File, config);
+
+        var rows = rawRows.ToArray();
+        if (rows.Length == 0)
+        {
+            if (extension == ".pdf" || config.SourceType == SourceType.Pdf)
+            {
+                var diag = new StatementImportPdfHelper().Diagnose(command.File);
+                var sample = diag.Pages
+                    .Skip(config.SkipPages)
+                    .Take(1)
+                    .SelectMany(p => p.Lines.Take(15))
+                    .Select(l => $"[{string.Join(", ", l.Words.Select(w => $"{w.Text}@x{w.XCenter:F2}"))}]");
+                return CommandResult.Failure(
+                    $"No rows found. Pages={diag.PageCount}, skipPages={config.SkipPages}. " +
+                    $"First lines of page {config.SkipPages + 1}: {string.Join(" | ", sample)}");
+            }
+            return CommandResult.Failure("No rows found in the uploaded file.");
+        }
 
         var existingTxs = await DbContext.CreditCardTransaction
             .Where(t => t.CreditCardId == statement.CreditCardId && !t.Deactivated)

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/ImportCreditCardStatementTransactionsCommand.cs
@@ -58,9 +58,8 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
                 CurrencyId = config.DefaultCurrencyId,
             };
             DbContext.CreditCardTransaction.Add(tx);
-            await DbContext.SaveChangesAsync(cancellationToken);
 
-            var statementTx = new CreditCardStatementTransaction
+            DbContext.CreditCardStatementTransaction.Add(new CreditCardStatementTransaction
             {
                 StatementId = statement.Id,
                 CreditCardTransactionId = tx.Id,
@@ -68,10 +67,10 @@ public class ImportCreditCardStatementTransactionsCommandHandler : BaseResponsel
                 Amount = row.Amount,
                 Description = row.Concept,
                 CurrencyId = config.DefaultCurrencyId,
-            };
-            DbContext.CreditCardStatementTransaction.Add(statementTx);
-            await DbContext.SaveChangesAsync(cancellationToken);
+            });
         }
+
+        await DbContext.SaveChangesAsync(cancellationToken);
 
         var templateForLink = await DbContext.CreditCardStatementImportTemplate
             .IgnoreQueryFilters()
@@ -95,16 +94,3 @@ public class ImportCreditCardStatementTransactionsCommand : ICommand
     public Guid StatementId { get; set; }
 }
 
-public class StatementImportConfig
-{
-    public int SkipRows { get; set; } = 1;
-    public int SkipLastRows { get; set; } = 0;
-    public int DateColumn { get; set; } = 0;
-    public string DateFormat { get; set; } = "d/M/yyyy";
-    public int ConceptColumn { get; set; } = 1;
-    public int AmountColumn { get; set; } = 2;
-    public Guid DefaultCurrencyId { get; set; }
-    public string DecimalSeparator { get; set; } = ",";
-    public string ThousandsSeparator { get; set; } = ".";
-    public bool AmountNegate { get; set; } = false;
-}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/SetCreditCardDefaultImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/SetCreditCardDefaultImportTemplateCommand.cs
@@ -1,0 +1,40 @@
+using CQRSDispatch;
+using CQRSDispatch.Interfaces;
+using Finance.Application.Commands.Base;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class SetCreditCardDefaultImportTemplateCommandHandler : BaseResponselessHandler<SetCreditCardDefaultImportTemplateCommand>
+{
+    private readonly IRepository<CreditCard, Guid> _creditCardRepository;
+
+    public SetCreditCardDefaultImportTemplateCommandHandler(
+        FinanceDbContext db,
+        IRepository<CreditCard, Guid> creditCardRepository)
+        : base(db)
+    {
+        _creditCardRepository = creditCardRepository;
+    }
+
+    public override async Task<CommandResult> ExecuteAsync(
+        SetCreditCardDefaultImportTemplateCommand command, CancellationToken cancellationToken)
+    {
+        var creditCard = await _creditCardRepository.GetByIdAsync(command.CreditCardId, cancellationToken)
+            ?? throw new Exception($"Credit card not found: {command.CreditCardId}");
+
+        creditCard.DefaultImportTemplateId = command.TemplateId;
+        await _creditCardRepository.UpdateAsync(creditCard, cancellationToken);
+        await _creditCardRepository.PersistAsync(cancellationToken);
+
+        return CommandResult.Success();
+    }
+}
+
+public class SetCreditCardDefaultImportTemplateCommand : ICommand
+{
+    public Guid CreditCardId { get; set; }
+    public Guid? TemplateId { get; set; }
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommand.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Repositories;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+
+namespace Finance.Application.Commands.CreditCards;
+
+public class UpdateCreditCardStatementImportTemplateCommandHandler(
+    IRepository<CreditCardStatementImportTemplate, Guid> repository,
+    FinanceDbContext db)
+    : BaseUpdateCommandHandler<CreditCardStatementImportTemplate, Guid, UpdateCreditCardStatementImportTemplateCommand>(
+        repository, db)
+{
+    protected override Task<CreditCardStatementImportTemplate> UpdateRecord(
+        UpdateCreditCardStatementImportTemplateCommand command,
+        CreditCardStatementImportTemplate record,
+        CancellationToken cancellationToken)
+    {
+        record.Name = command.Name;
+        record.IsSystem = command.IsSystem;
+        record.ConfigJson = command.ConfigJson;
+        return Task.FromResult(record);
+    }
+}
+
+public class UpdateCreditCardStatementImportTemplateCommand
+    : BaseUpdateCommand<CreditCardStatementImportTemplate, Guid>
+{
+    [Required]
+    [StringLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    public bool IsSystem { get; set; }
+
+    [Required]
+    public string ConfigJson { get; set; } = string.Empty;
+}

--- a/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommand.cs
@@ -1,5 +1,7 @@
+using CQRSDispatch;
 using System.ComponentModel.DataAnnotations;
 using Finance.Application.Base.Handlers;
+using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Repositories;
 using Finance.Domain.Models.CreditCards;
 using Finance.Persistence;
@@ -8,18 +10,31 @@ namespace Finance.Application.Commands.CreditCards;
 
 public class UpdateCreditCardStatementImportTemplateCommandHandler(
     IRepository<CreditCardStatementImportTemplate, Guid> repository,
-    FinanceDbContext db)
+    FinanceDbContext db,
+    CanSetSystemFlag canSetSystemFlag)
     : BaseUpdateCommandHandler<CreditCardStatementImportTemplate, Guid, UpdateCreditCardStatementImportTemplateCommand>(
         repository, db)
 {
+    public override async Task<DataResult<CreditCardStatementImportTemplate>> ExecuteAsync(
+        UpdateCreditCardStatementImportTemplateCommand command, CancellationToken cancellationToken = default)
+    {
+        if (command.IsSystem)
+        {
+            var check = await canSetSystemFlag.IsSatisfiedAsync(cancellationToken);
+            if (!check.IsSuccess)
+                return DataResult<CreditCardStatementImportTemplate>.Failure(check.ErrorMessage!);
+        }
+        return await base.ExecuteAsync(command, cancellationToken);
+    }
+
     protected override Task<CreditCardStatementImportTemplate> UpdateRecord(
         UpdateCreditCardStatementImportTemplateCommand command,
         CreditCardStatementImportTemplate record,
         CancellationToken cancellationToken)
     {
         record.Name = command.Name;
-        record.IsSystem = command.IsSystem;
         record.ConfigJson = command.ConfigJson;
+        record.IsSystem = command.IsSystem;
         return Task.FromResult(record);
     }
 }

--- a/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseCreateCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseCreateCommand.cs
@@ -8,7 +8,8 @@ using FluentValidation;
 
 namespace Finance.Application.Base.Handlers;
 
-public abstract class BaseCreateCommand<TEntity> : ICommand;
+public abstract class BaseCreateCommand<TEntity> : ICommand<DataResult<TEntity>>
+    where TEntity : class;
 
 public abstract class BaseCreateCommandHandler<TCommand, TEntity, TId>(
     IRepository<TEntity, TId> repository,
@@ -32,6 +33,7 @@ public abstract class BaseCreateCommandHandler<TCommand, TEntity, TId>(
 }
 
 public abstract class BaseCreateCommandValidator<TCommand, TEntity> : AbstractValidator<TCommand>
+    where TEntity : class
     where TCommand : BaseCreateCommand<TEntity>
 {
     protected BaseCreateCommandValidator()

--- a/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseDeleteCommand.cs
+++ b/FinanceBackEnd/src/Finance.Application/Commands/_Base/BaseDeleteCommand.cs
@@ -12,13 +12,14 @@ public class BaseDeleteCommand<TId> : ICommand
     public TId[] Ids { get; set; } = [];
 }
 
-public class BaseDeleteCommandHandler<TEntity, TId>(IEntityService<TEntity, TId> service)
-    : ICommandHandler<BaseDeleteCommand<TId>>
+public class BaseDeleteCommandHandler<TCommand, TEntity, TId>(IEntityService<TEntity, TId> service)
+    : ICommandHandler<TCommand>
+    where TCommand : BaseDeleteCommand<TId>
     where TEntity : Entity<TId>
 {
     protected IEntityService<TEntity, TId> Service { get => service; }
 
-    public virtual async Task<CommandResult> ExecuteAsync(BaseDeleteCommand<TId> command, CancellationToken cancellationToken = default)
+    public virtual async Task<CommandResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
     {
         await Service.DeleteAsync(command.Ids, cancellationToken);
         return CommandResult.Success();

--- a/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardDto.cs
+++ b/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardDto.cs
@@ -12,4 +12,5 @@ public record CreditCardDto : Dto<Guid>
     public CreditCardStatementDto CreditCardStatement { get; set; } = default!;
     public int RecordCount { get; set; } = 0;
     public string Name { get; set; } = string.Empty;
+    public Guid? DefaultImportTemplateId { get; set; }
 }

--- a/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardStatementImportTemplateDto.cs
+++ b/FinanceBackEnd/src/Finance.Application/Dtos/CreditCards/CreditCardStatementImportTemplateDto.cs
@@ -1,0 +1,13 @@
+using Finance.Application.Dtos.Base;
+
+namespace Finance.Application.Dtos.CreditCards;
+
+public record CreditCardStatementImportTemplateDto : Dto<Guid>
+{
+    public CreditCardStatementImportTemplateDto() { }
+
+    public string Name { get; set; } = string.Empty;
+    public bool IsSystem { get; set; }
+    public Guid? UserId { get; set; }
+    public string ConfigJson { get; set; } = string.Empty;
+}

--- a/FinanceBackEnd/src/Finance.Application/Extensions/ServiceExtensions.cs
+++ b/FinanceBackEnd/src/Finance.Application/Extensions/ServiceExtensions.cs
@@ -1,4 +1,6 @@
+using Finance.Application.Auth;
 using Finance.Application.Commands.Users;
+using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Services;
 using Finance.Application.Services.Interfaces;
 using Finance.Domain.Models.Auth;
@@ -10,6 +12,18 @@ namespace Finance.Application.Extensions;
 
 public static class SagaServiceExtensions
 {
+    public static IServiceCollection AddApplicationSecurityServices(this IServiceCollection services)
+    {
+        services.RegisterScopedService<IsAdminUser>();
+        return services;
+    }
+
+    public static IServiceCollection AddSpecifications(this IServiceCollection services)
+    {
+        services.RegisterScopedService<CanSetSystemFlag>();
+        return services;
+    }
+
     public static IServiceCollection AddSagaServices(this IServiceCollection services)
     {
         services.RegisterScopedService<CurrencyConversionService>();

--- a/FinanceBackEnd/src/Finance.Application/Finance.Application.csproj
+++ b/FinanceBackEnd/src/Finance.Application/Finance.Application.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="PdfPig" Version="0.1.9" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.10" />
     <PackageReference Include="System.Text.Encodings.Web" Version="9.0.5" />
     <PackageReference Include="System.Text.Json" Version="9.0.5" />

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
@@ -4,14 +4,27 @@ public class StatementImportConfig
 {
     public int SkipRows { get; set; } = 1;
     public int SkipLastRows { get; set; } = 0;
-    public int DateColumn { get; set; } = 0;
-    public string DateFormat { get; set; } = "d/M/yyyy";
-    public int ConceptColumn { get; set; } = 1;
-    public int AmountColumn { get; set; } = 2;
-    public Guid DefaultCurrencyId { get; set; }
     public string DecimalSeparator { get; set; } = ",";
     public string ThousandsSeparator { get; set; } = ".";
     public bool AmountNegate { get; set; } = false;
-    public int? InstallmentsColumn { get; set; }
+    public List<ColumnConfig> Columns { get; set; } = [];
+}
+
+public class ColumnConfig
+{
+    public int Index { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public ColumnType Type { get; set; }
+    public string? DateFormat { get; set; }
+    public Guid? CurrencyId { get; set; }
     public string? InstallmentsPattern { get; set; }
+}
+
+public enum ColumnType
+{
+    Text,
+    Date,
+    Concept,
+    Installment,
+    Amount
 }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
@@ -1,18 +1,30 @@
 namespace Finance.Helpers.ExcelHelper;
 
+public enum SourceType { Tabular, Pdf }
+
 public class StatementImportConfig
 {
+    public SourceType SourceType { get; set; } = SourceType.Tabular;
     public int SkipRows { get; set; } = 1;
     public int SkipLastRows { get; set; } = 0;
+    public int SkipPages { get; set; } = 0;
     public string DecimalSeparator { get; set; } = ",";
     public string ThousandsSeparator { get; set; } = ".";
     public bool AmountNegate { get; set; } = false;
+    // UTC offset of the dates in the source file (e.g. -3 for Argentina).
+    // Dates are stored as local-midnight expressed in UTC so the calendar date
+    // is unambiguous even when DB/serialization converts to server local time.
+    public double UtcOffsetHours { get; set; } = 0;
     public List<ColumnConfig> Columns { get; set; } = [];
 }
 
 public class ColumnConfig
 {
+    // Tabular (CSV/XLSX): 0-based column index
     public int Index { get; set; }
+    // PDF: relative x bounds as fraction of page width (0–1)
+    public double? XMin { get; set; }
+    public double? XMax { get; set; }
     public string Name { get; set; } = string.Empty;
     public ColumnType Type { get; set; }
     public string? DateFormat { get; set; }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
@@ -1,0 +1,15 @@
+namespace Finance.Helpers.ExcelHelper;
+
+public class StatementImportConfig
+{
+    public int SkipRows { get; set; } = 1;
+    public int SkipLastRows { get; set; } = 0;
+    public int DateColumn { get; set; } = 0;
+    public string DateFormat { get; set; } = "d/M/yyyy";
+    public int ConceptColumn { get; set; } = 1;
+    public int AmountColumn { get; set; } = 2;
+    public Guid DefaultCurrencyId { get; set; }
+    public string DecimalSeparator { get; set; } = ",";
+    public string ThousandsSeparator { get; set; } = ".";
+    public bool AmountNegate { get; set; } = false;
+}

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportConfig.cs
@@ -12,4 +12,6 @@ public class StatementImportConfig
     public string DecimalSeparator { get; set; } = ",";
     public string ThousandsSeparator { get; set; } = ".";
     public bool AmountNegate { get; set; } = false;
+    public int? InstallmentsColumn { get; set; }
+    public string? InstallmentsPattern { get; set; }
 }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using ExcelDataReader;
 using Microsoft.AspNetCore.Http;
 
@@ -21,40 +22,56 @@ public class StatementImportExcelHelper
 
         var dataset = reader.AsDataSet();
         var sheet = dataset.Tables[0];
-        var rows = new List<StatementImportRow>();
 
+        var dateCol = config.Columns.FirstOrDefault(c => c.Type == ColumnType.Date);
+        var conceptCol = config.Columns.FirstOrDefault(c => c.Type == ColumnType.Concept);
+        var installmentCol = config.Columns.FirstOrDefault(c => c.Type == ColumnType.Installment);
+        var amountCols = config.Columns.Where(c => c.Type == ColumnType.Amount).ToList();
+
+        var rows = new List<StatementImportRow>();
         var lastRow = sheet.Rows.Count - config.SkipLastRows;
+
         for (int r = config.SkipRows; r < lastRow; r++)
         {
             var row = sheet.Rows[r];
-            var dateRaw = row[config.DateColumn]?.ToString();
-            var conceptRaw = row[config.ConceptColumn]?.ToString();
-            var amountRaw = row[config.AmountColumn]?.ToString();
+
+            var dateRaw = dateCol != null ? row[dateCol.Index]?.ToString() : null;
+            var conceptRaw = conceptCol != null ? row[conceptCol.Index]?.ToString() : null;
 
             if (string.IsNullOrWhiteSpace(dateRaw) && string.IsNullOrWhiteSpace(conceptRaw))
                 continue;
 
-            var date = ParseDate(dateRaw, config.DateFormat);
-            var amount = ParseDecimal(amountRaw, config.DecimalSeparator, config.ThousandsSeparator);
-            if (config.AmountNegate) amount = -amount;
-
+            var date = ParseDate(dateRaw, dateCol?.DateFormat ?? "d/M/yyyy");
             var concept = conceptRaw ?? string.Empty;
-            if (config.InstallmentsColumn.HasValue)
+
+            if (installmentCol != null)
             {
-                var installments = row[config.InstallmentsColumn.Value]?.ToString()?.Trim();
+                var installments = row[installmentCol.Index]?.ToString()?.Trim();
                 var isValid = !string.IsNullOrWhiteSpace(installments)
-                    && (config.InstallmentsPattern is null
-                        || System.Text.RegularExpressions.Regex.IsMatch(installments, config.InstallmentsPattern));
+                    && (installmentCol.InstallmentsPattern is null
+                        || Regex.IsMatch(installments, installmentCol.InstallmentsPattern));
                 if (isValid)
                     concept = $"{concept} ({installments})";
             }
 
-            rows.Add(new StatementImportRow
+            foreach (var amountCol in amountCols)
             {
-                Date = date,
-                Concept = concept,
-                Amount = amount,
-            });
+                var amountRaw = row[amountCol.Index]?.ToString();
+                if (string.IsNullOrWhiteSpace(amountRaw)) continue;
+
+                var amount = ParseDecimal(amountRaw, config.DecimalSeparator, config.ThousandsSeparator);
+                if (amount == 0) continue;
+
+                if (config.AmountNegate) amount = -amount;
+
+                rows.Add(new StatementImportRow
+                {
+                    Date = date,
+                    Concept = concept,
+                    Amount = amount,
+                    CurrencyId = amountCol.CurrencyId ?? Guid.Empty,
+                });
+            }
         }
 
         return rows;
@@ -69,7 +86,6 @@ public class StatementImportExcelHelper
             System.Globalization.DateTimeStyles.None, out var parsed))
             return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
 
-        // Fallback: try common formats
         if (DateTime.TryParse(raw, out var fallback))
             return DateTime.SpecifyKind(fallback, DateTimeKind.Utc);
 
@@ -100,4 +116,5 @@ public record StatementImportRow
     public DateTime Date { get; init; }
     public string Concept { get; init; } = string.Empty;
     public decimal Amount { get; init; }
+    public Guid CurrencyId { get; init; }
 }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
@@ -1,5 +1,4 @@
 using ExcelDataReader;
-using Finance.Application.Commands.CreditCards;
 using Microsoft.AspNetCore.Http;
 
 namespace Finance.Helpers.ExcelHelper;

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
@@ -24,7 +24,8 @@ public class StatementImportExcelHelper
         var sheet = dataset.Tables[0];
         var rows = new List<StatementImportRow>();
 
-        for (int r = config.SkipRows; r < sheet.Rows.Count; r++)
+        var lastRow = sheet.Rows.Count - config.SkipLastRows;
+        for (int r = config.SkipRows; r < lastRow; r++)
         {
             var row = sheet.Rows[r];
             var dateRaw = row[config.DateColumn]?.ToString();

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
@@ -1,0 +1,92 @@
+using ExcelDataReader;
+using Finance.Application.Commands.CreditCards;
+using Microsoft.AspNetCore.Http;
+
+namespace Finance.Helpers.ExcelHelper;
+
+public class StatementImportExcelHelper
+{
+    public IEnumerable<StatementImportRow> Read(IFormFile file, StatementImportConfig config)
+    {
+        if (file == null || file.Length == 0)
+            throw new Exception("File not selected");
+
+        var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+        if (extension != ".xls" && extension != ".xlsx" && extension != ".csv")
+            throw new Exception("Unsupported file format. Use .xls, .xlsx, or .csv");
+
+        using var stream = file.OpenReadStream();
+        using var reader = extension == ".csv"
+            ? ExcelReaderFactory.CreateCsvReader(stream)
+            : ExcelReaderFactory.CreateReader(stream);
+
+        var dataset = reader.AsDataSet();
+        var sheet = dataset.Tables[0];
+        var rows = new List<StatementImportRow>();
+
+        for (int r = config.SkipRows; r < sheet.Rows.Count; r++)
+        {
+            var row = sheet.Rows[r];
+            var dateRaw = row[config.DateColumn]?.ToString();
+            var conceptRaw = row[config.ConceptColumn]?.ToString();
+            var amountRaw = row[config.AmountColumn]?.ToString();
+
+            if (string.IsNullOrWhiteSpace(dateRaw) && string.IsNullOrWhiteSpace(conceptRaw))
+                continue;
+
+            var date = ParseDate(dateRaw, config.DateFormat);
+            var amount = ParseDecimal(amountRaw, config.DecimalSeparator, config.ThousandsSeparator);
+            if (config.AmountNegate) amount = -amount;
+
+            rows.Add(new StatementImportRow
+            {
+                Date = date,
+                Concept = conceptRaw ?? string.Empty,
+                Amount = amount,
+            });
+        }
+
+        return rows;
+    }
+
+    private static DateTime ParseDate(string? raw, string format)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return DateTime.UtcNow;
+
+        if (DateTime.TryParseExact(raw, format,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out var parsed))
+            return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+
+        // Fallback: try common formats
+        if (DateTime.TryParse(raw, out var fallback))
+            return DateTime.SpecifyKind(fallback, DateTimeKind.Utc);
+
+        return DateTime.UtcNow;
+    }
+
+    private static decimal ParseDecimal(string? raw, string decimalSeparator, string thousandsSeparator)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return 0;
+
+        var sanitized = raw
+            .Replace("$", string.Empty)
+            .Replace("%", string.Empty)
+            .Replace(thousandsSeparator, string.Empty)
+            .Replace(decimalSeparator, ".")
+            .Trim();
+
+        return decimal.TryParse(sanitized,
+            System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var result)
+            ? result
+            : 0;
+    }
+}
+
+public record StatementImportRow
+{
+    public DateTime Date { get; init; }
+    public string Concept { get; init; } = string.Empty;
+    public decimal Amount { get; init; }
+}

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
@@ -38,10 +38,21 @@ public class StatementImportExcelHelper
             var amount = ParseDecimal(amountRaw, config.DecimalSeparator, config.ThousandsSeparator);
             if (config.AmountNegate) amount = -amount;
 
+            var concept = conceptRaw ?? string.Empty;
+            if (config.InstallmentsColumn.HasValue)
+            {
+                var installments = row[config.InstallmentsColumn.Value]?.ToString()?.Trim();
+                var isValid = !string.IsNullOrWhiteSpace(installments)
+                    && (config.InstallmentsPattern is null
+                        || System.Text.RegularExpressions.Regex.IsMatch(installments, config.InstallmentsPattern));
+                if (isValid)
+                    concept = $"{concept} ({installments})";
+            }
+
             rows.Add(new StatementImportRow
             {
                 Date = date,
-                Concept = conceptRaw ?? string.Empty,
+                Concept = concept,
                 Amount = amount,
             });
         }

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportExcelHelper.cs
@@ -41,7 +41,7 @@ public class StatementImportExcelHelper
             if (string.IsNullOrWhiteSpace(dateRaw) && string.IsNullOrWhiteSpace(conceptRaw))
                 continue;
 
-            var date = ParseDate(dateRaw, dateCol?.DateFormat ?? "d/M/yyyy");
+            var date = ParseDate(dateRaw, dateCol?.DateFormat ?? "d/M/yyyy", config.UtcOffsetHours);
             var concept = conceptRaw ?? string.Empty;
 
             if (installmentCol != null)
@@ -77,14 +77,14 @@ public class StatementImportExcelHelper
         return rows;
     }
 
-    private static DateTime ParseDate(string? raw, string format)
+    private static DateTime ParseDate(string? raw, string format, double utcOffsetHours)
     {
         if (string.IsNullOrWhiteSpace(raw)) return DateTime.UtcNow;
 
         if (DateTime.TryParseExact(raw, format,
             System.Globalization.CultureInfo.InvariantCulture,
             System.Globalization.DateTimeStyles.None, out var parsed))
-            return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+            return new DateTimeOffset(parsed, TimeSpan.FromHours(utcOffsetHours)).UtcDateTime;
 
         if (DateTime.TryParse(raw, out var fallback))
             return DateTime.SpecifyKind(fallback, DateTimeKind.Utc);

--- a/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportPdfHelper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Helpers/ExcelHelper/StatementImportPdfHelper.cs
@@ -1,0 +1,205 @@
+using Microsoft.AspNetCore.Http;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+
+namespace Finance.Helpers.ExcelHelper;
+
+public class StatementImportPdfHelper
+{
+    private const double LineYTolerance = 4.0;
+
+    public IEnumerable<StatementImportRow> Read(IFormFile file, StatementImportConfig config)
+    {
+        if (file == null || file.Length == 0)
+            throw new Exception("File not selected");
+
+        var dateCol = config.Columns.FirstOrDefault(c => c.Type == ColumnType.Date);
+        var conceptCol = config.Columns.FirstOrDefault(c => c.Type == ColumnType.Concept);
+        var amountCols = config.Columns.Where(c => c.Type == ColumnType.Amount).ToList();
+
+        var rows = new List<StatementImportRow>();
+
+        using var stream = file.OpenReadStream();
+        using var document = PdfDocument.Open(stream);
+
+        for (int pageNum = config.SkipPages + 1; pageNum <= document.NumberOfPages; pageNum++)
+        {
+            var page = document.GetPage(pageNum);
+            var pageWidth = page.Width;
+            var lines = GroupIntoLines(page.GetWords());
+
+            foreach (var line in lines)
+            {
+                if (dateCol == null) continue;
+                var dateText = ExtractColumnText(line, dateCol, pageWidth);
+                if (!TryParseDate(dateText, dateCol.DateFormat ?? "dd/MM/yy", config.UtcOffsetHours, out var date))
+                    continue;
+
+                var concept = conceptCol != null
+                    ? ExtractColumnText(line, conceptCol, pageWidth)
+                    : string.Empty;
+
+                if (string.IsNullOrWhiteSpace(concept))
+                    continue;
+
+                foreach (var amountCol in amountCols)
+                {
+                    var amountText = ExtractColumnText(line, amountCol, pageWidth);
+                    if (string.IsNullOrWhiteSpace(amountText)) continue;
+
+                    var amount = ParseDecimal(amountText, config.DecimalSeparator, config.ThousandsSeparator);
+                    if (amount == 0) continue;
+
+                    if (config.AmountNegate) amount = -amount;
+
+                    rows.Add(new StatementImportRow
+                    {
+                        Date = date,
+                        Concept = concept,
+                        Amount = amount,
+                        CurrencyId = amountCol.CurrencyId ?? Guid.Empty,
+                    });
+                }
+            }
+        }
+
+        return rows;
+    }
+
+    public PdfDiagnosticResult Diagnose(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            throw new Exception("File not selected");
+
+        using var stream = file.OpenReadStream();
+        using var document = PdfDocument.Open(stream);
+
+        var pages = new List<PdfDiagnosticPage>();
+        for (int pageNum = 1; pageNum <= document.NumberOfPages; pageNum++)
+        {
+            var page = document.GetPage(pageNum);
+            var w = page.Width;
+            var h = page.Height;
+            var lines = GroupIntoLines(page.GetWords());
+
+            var diagLines = lines.Select(line => new PdfDiagnosticLine
+            {
+                Text = string.Join(" ", line.Select(word => word.Text)),
+                Words = line.Select(word => new PdfDiagnosticWord
+                {
+                    Text = word.Text,
+                    XCenter = Math.Round(word.BoundingBox.Centroid.X / w, 4),
+                    YCenter = Math.Round(word.BoundingBox.Centroid.Y / h, 4),
+                    XMin = Math.Round(word.BoundingBox.Left / w, 4),
+                    XMax = Math.Round(word.BoundingBox.Right / w, 4),
+                }).ToList(),
+            }).ToList();
+
+            pages.Add(new PdfDiagnosticPage { PageNumber = pageNum, Width = w, Height = h, Lines = diagLines });
+        }
+
+        return new PdfDiagnosticResult { PageCount = document.NumberOfPages, Pages = pages };
+    }
+
+    // Groups words into lines by proximity of their y-centers (PDF y=0 is bottom).
+    // Returns lines sorted top-to-bottom (descending y).
+    private static List<List<Word>> GroupIntoLines(IEnumerable<Word> words)
+    {
+        var sorted = words
+            .OrderByDescending(w => w.BoundingBox.Centroid.Y)
+            .ToList();
+
+        var lines = new List<List<Word>>();
+        foreach (var word in sorted)
+        {
+            var wordY = word.BoundingBox.Centroid.Y;
+            var matched = lines.FirstOrDefault(line =>
+                Math.Abs(wordY - line[0].BoundingBox.Centroid.Y) <= LineYTolerance);
+
+            if (matched != null)
+                matched.Add(word);
+            else
+                lines.Add([word]);
+        }
+
+        foreach (var line in lines)
+            line.Sort((a, b) => a.BoundingBox.Left.CompareTo(b.BoundingBox.Left));
+
+        return lines;
+    }
+
+    private static string ExtractColumnText(List<Word> line, ColumnConfig col, double pageWidth)
+    {
+        if (col.XMin == null || col.XMax == null) return string.Empty;
+        var xMin = col.XMin.Value * pageWidth;
+        var xMax = col.XMax.Value * pageWidth;
+
+        var words = line
+            .Where(w => w.BoundingBox.Centroid.X >= xMin && w.BoundingBox.Centroid.X <= xMax)
+            .OrderBy(w => w.BoundingBox.Left);
+
+        return string.Join(" ", words.Select(w => w.Text)).Trim();
+    }
+
+    private static bool TryParseDate(string? raw, string format, double utcOffsetHours, out DateTime date)
+    {
+        date = default;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        if (DateTime.TryParseExact(raw, format,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out var parsed))
+        {
+            date = new DateTimeOffset(parsed, TimeSpan.FromHours(utcOffsetHours)).UtcDateTime;
+            return true;
+        }
+        return false;
+    }
+
+    private static decimal ParseDecimal(string? raw, string decimalSeparator, string thousandsSeparator)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return 0;
+
+        var sanitized = raw
+            .Replace("$", string.Empty)
+            .Replace("%", string.Empty)
+            .Replace(thousandsSeparator, string.Empty)
+            .Replace(decimalSeparator, ".")
+            .Trim();
+
+        return decimal.TryParse(sanitized,
+            System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var result)
+            ? result
+            : 0;
+    }
+}
+
+public record PdfDiagnosticResult
+{
+    public int PageCount { get; init; }
+    public List<PdfDiagnosticPage> Pages { get; init; } = [];
+}
+
+public record PdfDiagnosticPage
+{
+    public int PageNumber { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public List<PdfDiagnosticLine> Lines { get; init; } = [];
+}
+
+public record PdfDiagnosticLine
+{
+    public string Text { get; init; } = string.Empty;
+    public List<PdfDiagnosticWord> Words { get; init; } = [];
+}
+
+public record PdfDiagnosticWord
+{
+    public string Text { get; init; } = string.Empty;
+    public double XCenter { get; init; }
+    public double YCenter { get; init; }
+    public double XMin { get; init; }
+    public double XMax { get; init; }
+}

--- a/FinanceBackEnd/src/Finance.Application/Mapping/Mappers/CreditCardStatementImportTemplateMapper.cs
+++ b/FinanceBackEnd/src/Finance.Application/Mapping/Mappers/CreditCardStatementImportTemplateMapper.cs
@@ -1,0 +1,15 @@
+using Finance.Application.Dtos.CreditCards;
+using Finance.Application.Mapping.Base;
+using Finance.Domain.Models.CreditCards;
+
+namespace Finance.Application.Mapping.Mappers;
+
+public class CreditCardStatementImportTemplateMapper
+    : BaseMapper<CreditCardStatementImportTemplate, CreditCardStatementImportTemplateDto>,
+      ICreditCardStatementImportTemplateMapper
+{
+    public CreditCardStatementImportTemplateMapper(IMappingService mappingService) : base(mappingService) { }
+}
+
+public interface ICreditCardStatementImportTemplateMapper
+    : IMapper<CreditCardStatementImportTemplate, CreditCardStatementImportTemplateDto>;

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
@@ -35,9 +35,16 @@ public class GetCreditCardStatementImportTemplatesQueryHandler : BaseCollectionQ
             .IgnoreQueryFilters()
             .AsQueryable();
 
-        query = user != null
-            ? query.Where(t => t.IsSystem || t.UserId == user.Id)
-            : query.Where(t => t.IsSystem);
+        if (request.CreditCardId.HasValue)
+        {
+            query = query.Where(t => t.IsSystem || t.CreditCards.Any(c => c.Id == request.CreditCardId.Value));
+        }
+        else
+        {
+            query = user != null
+                ? query.Where(t => t.IsSystem || t.UserId == user.Id)
+                : query.Where(t => t.IsSystem);
+        }
 
         var results = await query
             .OrderBy(t => t.IsSystem ? 0 : 1)
@@ -48,4 +55,7 @@ public class GetCreditCardStatementImportTemplatesQueryHandler : BaseCollectionQ
     }
 }
 
-public class GetCreditCardStatementImportTemplatesQuery : GetAllQuery<CreditCardStatementImportTemplate>;
+public class GetCreditCardStatementImportTemplatesQuery : GetAllQuery<CreditCardStatementImportTemplate>
+{
+    public Guid? CreditCardId { get; set; }
+}

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
@@ -23,13 +23,13 @@ public class GetCreditCardStatementImportTemplatesQueryHandler : BaseCollectionQ
     {
         var identitySourceId = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
 
-        var user = string.IsNullOrEmpty(identitySourceId)
-            ? null
-            : await DbContext.User
+        var user = !string.IsNullOrEmpty(identitySourceId)
+            ? await DbContext.User
                 .IgnoreQueryFilters()
                 .AsNoTracking()
                 .Include(u => u.Identities)
-                .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == identitySourceId), cancellationToken);
+                .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == identitySourceId), cancellationToken)
+            : null;
 
         var query = DbContext.CreditCardStatementImportTemplate
             .IgnoreQueryFilters()

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
@@ -33,6 +33,7 @@ public class GetCreditCardStatementImportTemplatesQueryHandler : BaseCollectionQ
 
         var query = DbContext.CreditCardStatementImportTemplate
             .IgnoreQueryFilters()
+            .Where(t => !t.Deactivated)
             .AsQueryable();
 
         if (request.CreditCardId.HasValue)

--- a/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
+++ b/FinanceBackEnd/src/Finance.Application/Queries/CreditCards/GetCreditCardStatementImportTemplatesQuery.cs
@@ -1,0 +1,51 @@
+using CQRSDispatch;
+using Finance.Application.Base.Handlers;
+using Finance.Application.Queries.Base;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Application.Queries.CreditCards;
+
+public class GetCreditCardStatementImportTemplatesQueryHandler : BaseCollectionQueryHandler<GetCreditCardStatementImportTemplatesQuery, CreditCardStatementImportTemplate>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public GetCreditCardStatementImportTemplatesQueryHandler(FinanceDbContext db, IHttpContextAccessor httpContextAccessor)
+        : base(db)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public override async Task<DataResult<List<CreditCardStatementImportTemplate>>> ExecuteAsync(
+        GetCreditCardStatementImportTemplatesQuery request, CancellationToken cancellationToken)
+    {
+        var identitySourceId = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+
+        var user = string.IsNullOrEmpty(identitySourceId)
+            ? null
+            : await DbContext.User
+                .IgnoreQueryFilters()
+                .AsNoTracking()
+                .Include(u => u.Identities)
+                .FirstOrDefaultAsync(u => u.Identities.Any(i => i.SourceId == identitySourceId), cancellationToken);
+
+        var query = DbContext.CreditCardStatementImportTemplate
+            .IgnoreQueryFilters()
+            .AsQueryable();
+
+        query = user != null
+            ? query.Where(t => t.IsSystem || t.UserId == user.Id)
+            : query.Where(t => t.IsSystem);
+
+        var results = await query
+            .OrderBy(t => t.IsSystem ? 0 : 1)
+            .ThenBy(t => t.Name)
+            .ToListAsync(cancellationToken);
+
+        return DataResult<List<CreditCardStatementImportTemplate>>.Success(results);
+    }
+}
+
+public class GetCreditCardStatementImportTemplatesQuery : GetAllQuery<CreditCardStatementImportTemplate>;

--- a/FinanceBackEnd/src/Finance.Application/Repositories/CreditCardStatementImportTemplateRepository.cs
+++ b/FinanceBackEnd/src/Finance.Application/Repositories/CreditCardStatementImportTemplateRepository.cs
@@ -1,0 +1,8 @@
+using Finance.Application.Repositories.Base;
+using Finance.Domain.Models.CreditCards;
+using Finance.Persistence;
+
+namespace Finance.Application.Repositories;
+
+public class CreditCardStatementImportTemplateRepository(FinanceDbContext dbContext)
+    : BaseRepository<CreditCardStatementImportTemplate, Guid>(dbContext);

--- a/FinanceBackEnd/src/Finance.Application/Repositories/_Base/BaseRepository.cs
+++ b/FinanceBackEnd/src/Finance.Application/Repositories/_Base/BaseRepository.cs
@@ -113,7 +113,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
 
     public virtual async Task DeleteAsync(TEntity entity, CancellationToken cancellationToken, bool persist = true)
     {
-        dbSet.Remove(entity);
+        entity.Deactivated = true;
         if (persist) await dbContext.SaveChangesAsync(cancellationToken);
     }
 

--- a/FinanceBackEnd/src/Finance.Application/Specifications/CreditCards/CanSetSystemFlag.cs
+++ b/FinanceBackEnd/src/Finance.Application/Specifications/CreditCards/CanSetSystemFlag.cs
@@ -1,0 +1,15 @@
+using CQRSDispatch;
+using Finance.Application.Auth;
+
+namespace Finance.Application.Specifications.CreditCards;
+
+public class CanSetSystemFlag(IsAdminUser isAdminUser)
+{
+    public async Task<CommandResult> IsSatisfiedAsync(CancellationToken ct = default)
+    {
+        var (isAdmin, _) = await isAdminUser.IsSatisfiedAsync(ct);
+        return isAdmin
+            ? CommandResult.Success()
+            : CommandResult.Failure("Only admins can set the system flag on templates.");
+    }
+}

--- a/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCard.cs
+++ b/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCard.cs
@@ -15,6 +15,7 @@ public class CreditCard : Entity<Guid>
     public virtual CreditCardIssuer? CreditCardIssuer { get; set; }
     public Guid? DefaultImportTemplateId { get; set; }
     public virtual CreditCardStatementImportTemplate? DefaultImportTemplate { get; set; }
+    public virtual ICollection<CreditCardStatementImportTemplate> ImportTemplates { get; set; } = [];
     public virtual ICollection<CreditCardTransaction> Transactions { get; set; } = [];
     public virtual ICollection<CreditCardStatement> Statements { get; set; } = [];
 

--- a/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCard.cs
+++ b/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCard.cs
@@ -13,6 +13,8 @@ public class CreditCard : Entity<Guid>
     public virtual CreditCardStatement? CurrentStatement { get; set; }
     public Guid? CreditCardIssuerId { get; set; }
     public virtual CreditCardIssuer? CreditCardIssuer { get; set; }
+    public Guid? DefaultImportTemplateId { get; set; }
+    public virtual CreditCardStatementImportTemplate? DefaultImportTemplate { get; set; }
     public virtual ICollection<CreditCardTransaction> Transactions { get; set; } = [];
     public virtual ICollection<CreditCardStatement> Statements { get; set; } = [];
 

--- a/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardStatementImportTemplate.cs
+++ b/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardStatementImportTemplate.cs
@@ -10,4 +10,5 @@ public class CreditCardStatementImportTemplate : AuditedEntity<Guid>
     public Guid? UserId { get; set; }
     public virtual User? User { get; set; }
     public string ConfigJson { get; set; } = string.Empty;
+    public virtual ICollection<CreditCard> CreditCards { get; set; } = [];
 }

--- a/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardStatementImportTemplate.cs
+++ b/FinanceBackEnd/src/Finance.Domain/Models/CreditCards/CreditCardStatementImportTemplate.cs
@@ -1,0 +1,13 @@
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.Base;
+
+namespace Finance.Domain.Models.CreditCards;
+
+public class CreditCardStatementImportTemplate : AuditedEntity<Guid>
+{
+    public string Name { get; set; } = string.Empty;
+    public bool IsSystem { get; set; }
+    public Guid? UserId { get; set; }
+    public virtual User? User { get; set; }
+    public string ConfigJson { get; set; } = string.Empty;
+}

--- a/FinanceBackEnd/src/Finance.Migrations/20260608054941_AddCreditCardStatementImportTemplate.Designer.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260608054941_AddCreditCardStatementImportTemplate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Finance.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Finance.Domain.Migrations
 {
     [DbContext(typeof(FinanceDbContext))]
-    partial class FinanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608054941_AddCreditCardStatementImportTemplate")]
+    partial class AddCreditCardStatementImportTemplate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -574,9 +577,6 @@ namespace Finance.Domain.Migrations
                     b.Property<bool>("Deactivated")
                         .HasColumnType("boolean");
 
-                    b.Property<Guid?>("DefaultImportTemplateId")
-                        .HasColumnType("uuid");
-
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
@@ -590,8 +590,6 @@ namespace Finance.Domain.Migrations
                     b.HasIndex("CreditCardIssuerId");
 
                     b.HasIndex("CurrentStatementId");
-
-                    b.HasIndex("DefaultImportTemplateId");
 
                     b.HasIndex("BankId", "Name");
 
@@ -682,45 +680,6 @@ namespace Finance.Domain.Migrations
                     b.HasIndex("CreditCardId", "ClosureDate");
 
                     b.ToTable("CreditCardStatement");
-                });
-
-            modelBuilder.Entity("Finance.Domain.Models.CreditCards.CreditCardStatementImportTemplate", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("ConfigJson")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<bool>("Deactivated")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsSystem")
-                        .HasColumnType("boolean");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("IsSystem", "UserId");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("CreditCardStatementImportTemplate");
                 });
 
             modelBuilder.Entity("Finance.Domain.Models.CreditCards.CreditCardStatementAdjustment", b =>
@@ -1865,18 +1824,11 @@ namespace Finance.Domain.Migrations
                         .HasForeignKey("CurrentStatementId")
                         .OnDelete(DeleteBehavior.Restrict);
 
-                    b.HasOne("Finance.Domain.Models.CreditCards.CreditCardStatementImportTemplate", "DefaultImportTemplate")
-                        .WithMany()
-                        .HasForeignKey("DefaultImportTemplateId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.Navigation("Bank");
 
                     b.Navigation("CreditCardIssuer");
 
                     b.Navigation("CurrentStatement");
-
-                    b.Navigation("DefaultImportTemplate");
                 });
 
             modelBuilder.Entity("Finance.Domain.Models.CreditCards.CreditCardPayment", b =>

--- a/FinanceBackEnd/src/Finance.Migrations/20260608054941_AddCreditCardStatementImportTemplate.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260608054941_AddCreditCardStatementImportTemplate.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Finance.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCreditCardStatementImportTemplate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "DefaultImportTemplateId",
+                table: "CreditCard",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CreditCardStatementImportTemplate",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    IsSystem = table.Column<bool>(type: "boolean", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ConfigJson = table.Column<string>(type: "text", nullable: false),
+                    Deactivated = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CreditCardStatementImportTemplate", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CreditCardStatementImportTemplate_User_UserId",
+                        column: x => x.UserId,
+                        principalTable: "User",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CreditCard_DefaultImportTemplateId",
+                table: "CreditCard",
+                column: "DefaultImportTemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CreditCardStatementImportTemplate_IsSystem_UserId",
+                table: "CreditCardStatementImportTemplate",
+                columns: ["IsSystem", "UserId"]);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CreditCardStatementImportTemplate_UserId",
+                table: "CreditCardStatementImportTemplate",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CreditCard_CreditCardStatementImportTemplate_DefaultImportTemplateId",
+                table: "CreditCard",
+                column: "DefaultImportTemplateId",
+                principalTable: "CreditCardStatementImportTemplate",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CreditCard_CreditCardStatementImportTemplate_DefaultImportTemplateId",
+                table: "CreditCard");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CreditCard_DefaultImportTemplateId",
+                table: "CreditCard");
+
+            migrationBuilder.DropTable(
+                name: "CreditCardStatementImportTemplate");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultImportTemplateId",
+                table: "CreditCard");
+        }
+    }
+}

--- a/FinanceBackEnd/src/Finance.Migrations/20260608064835_AddCreditCardImportTemplateAssociation.Designer.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260608064835_AddCreditCardImportTemplateAssociation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Finance.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Finance.Domain.Migrations
 {
     [DbContext(typeof(FinanceDbContext))]
-    partial class FinanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608064835_AddCreditCardImportTemplateAssociation")]
+    partial class AddCreditCardImportTemplateAssociation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FinanceBackEnd/src/Finance.Migrations/20260608064835_AddCreditCardImportTemplateAssociation.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260608064835_AddCreditCardImportTemplateAssociation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/FinanceBackEnd/src/Finance.Migrations/20260608064835_AddCreditCardImportTemplateAssociation.cs
+++ b/FinanceBackEnd/src/Finance.Migrations/20260608064835_AddCreditCardImportTemplateAssociation.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Finance.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCreditCardImportTemplateAssociation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CreditCardImportTemplate",
+                columns: table => new
+                {
+                    CreditCardsId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ImportTemplatesId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CreditCardImportTemplate", x => new { x.CreditCardsId, x.ImportTemplatesId });
+                    table.ForeignKey(
+                        name: "FK_CreditCardImportTemplate_CreditCardStatementImportTemplate_~",
+                        column: x => x.ImportTemplatesId,
+                        principalTable: "CreditCardStatementImportTemplate",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CreditCardImportTemplate_CreditCard_CreditCardsId",
+                        column: x => x.CreditCardsId,
+                        principalTable: "CreditCard",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CreditCardImportTemplate_ImportTemplatesId",
+                table: "CreditCardImportTemplate",
+                column: "ImportTemplatesId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CreditCardImportTemplate");
+        }
+    }
+}

--- a/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardConfiguration.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardConfiguration.cs
@@ -37,6 +37,13 @@ public class CreditCardConfiguration : IEntityTypeConfiguration<CreditCard>
             .OnDelete(DeleteBehavior.Restrict);
 
         builder
+            .HasOne(c => c.DefaultImportTemplate)
+            .WithMany()
+            .HasForeignKey(c => c.DefaultImportTemplateId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder
             .HasIndex(c => new { c.BankId, c.Name });
     }
 }

--- a/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardStatementImportTemplateConfiguration.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardStatementImportTemplateConfiguration.cs
@@ -23,6 +23,10 @@ public class CreditCardStatementImportTemplateConfiguration : IEntityTypeConfigu
             .IsRequired(false)
             .OnDelete(DeleteBehavior.SetNull);
 
+        builder.HasMany(t => t.CreditCards)
+            .WithMany(c => c.ImportTemplates)
+            .UsingEntity(j => j.ToTable("CreditCardImportTemplate"));
+
         builder.HasIndex(t => new { t.IsSystem, t.UserId });
     }
 }

--- a/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardStatementImportTemplateConfiguration.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/Configurations/CreditCardStatementImportTemplateConfiguration.cs
@@ -1,0 +1,28 @@
+using Finance.Domain.Models.CreditCards;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Finance.Persistence.Configurations;
+
+public class CreditCardStatementImportTemplateConfiguration : IEntityTypeConfiguration<CreditCardStatementImportTemplate>
+{
+    public void Configure(EntityTypeBuilder<CreditCardStatementImportTemplate> builder)
+    {
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(t => t.ConfigJson)
+            .IsRequired();
+
+        builder.HasOne(t => t.User)
+            .WithMany()
+            .HasForeignKey(t => t.UserId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(t => new { t.IsSystem, t.UserId });
+    }
+}

--- a/FinanceBackEnd/src/Finance.Persistence/FinanceDbContext.cs
+++ b/FinanceBackEnd/src/Finance.Persistence/FinanceDbContext.cs
@@ -30,6 +30,7 @@ public class FinanceDbContext : DbContext
     public DbSet<CreditCardIssuer> CreditCardIssuer => Set<CreditCardIssuer>();
     public DbSet<CreditCard> CreditCard => Set<CreditCard>();
     public DbSet<CreditCardStatement> CreditCardStatement => Set<CreditCardStatement>();
+    public DbSet<CreditCardStatementImportTemplate> CreditCardStatementImportTemplate => Set<CreditCardStatementImportTemplate>();
     public DbSet<CreditCardStatementTransaction> CreditCardStatementTransaction => Set<CreditCardStatementTransaction>();
     public DbSet<CreditCardTransaction> CreditCardTransaction => Set<CreditCardTransaction>();
     public DbSet<CreditCardPayment> CreditCardPayment => Set<CreditCardPayment>();

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommandHandlerTests.cs
@@ -1,0 +1,140 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+using System.Security.Principal;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class CreateCreditCardStatementImportTemplateCommandHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IRepository<CreditCardStatementImportTemplate, Guid>> _repository;
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+
+    public CreateCreditCardStatementImportTemplateCommandHandlerTests()
+    {
+        _repository = new Mock<IRepository<CreditCardStatementImportTemplate, Guid>>();
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
+    }
+
+    private CreateCreditCardStatementImportTemplateCommandHandler CreateHandler() =>
+        new(_repository.Object, _dbContext, _httpContextAccessor.Object);
+
+    private void SetupIdentity(string? name)
+    {
+        var identity = new Mock<IIdentity>();
+        identity.Setup(i => i.Name).Returns(name);
+        var principal = new Mock<ClaimsPrincipal>();
+        principal.Setup(p => p.Identity).Returns(identity.Object);
+        var ctx = new Mock<HttpContext>();
+        ctx.Setup(c => c.User).Returns(principal.Object);
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(ctx.Object);
+    }
+
+    [Fact]
+    public async Task Create_WithIsSystemTrue_CreatesTemplateWithNullUserId()
+    {
+        var command = new CreateCreditCardStatementImportTemplateCommand
+        {
+            Name = "System Template",
+            IsSystem = true,
+            ConfigJson = "{}",
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("System Template", result.Data.Name);
+        Assert.True(result.Data.IsSystem);
+        Assert.Null(result.Data.UserId);
+        _repository.Verify(
+            r => r.AddAsync(It.IsAny<CreditCardStatementImportTemplate>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WithUserIdentity_SetsUserId()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = "IdentityNotFound" }],
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        SetupIdentity("IdentityNotFound");
+
+        var command = new CreateCreditCardStatementImportTemplateCommand
+        {
+            Name = "My Template",
+            IsSystem = false,
+            ConfigJson = "{}",
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Data.IsSystem);
+        Assert.Equal(user.Id, result.Data.UserId);
+    }
+
+    [Fact]
+    public async Task Create_WithNoHttpContext_CreatesTemplateWithNullUserId()
+    {
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+
+        var command = new CreateCreditCardStatementImportTemplateCommand
+        {
+            Name = "Anon Template",
+            IsSystem = false,
+            ConfigJson = "{}",
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Data.UserId);
+    }
+
+    [Fact]
+    public async Task Create_WithUnknownIdentity_CreatesTemplateWithNullUserId()
+    {
+        SetupIdentity("unknown-user-id");
+
+        var command = new CreateCreditCardStatementImportTemplateCommand
+        {
+            Name = "Unknown User Template",
+            IsSystem = false,
+            ConfigJson = "{}",
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Data.UserId);
+    }
+
+    [Fact]
+    public async Task Create_SetsConfigJsonFromCommand()
+    {
+        var configJson = "{\"skipRows\":2}";
+        var command = new CreateCreditCardStatementImportTemplateCommand
+        {
+            Name = "Config Test",
+            IsSystem = true,
+            ConfigJson = configJson,
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.Equal(configJson, result.Data.ConfigJson);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommandHandlerTests.cs
@@ -1,5 +1,7 @@
+using Finance.Application.Auth;
 using Finance.Application.Commands.CreditCards;
 using Finance.Application.Repositories;
+using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Tests.Queries.Base;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.CreditCards;
@@ -21,8 +23,11 @@ public class CreateCreditCardStatementImportTemplateCommandHandlerTests : QueryH
         _httpContextAccessor = new Mock<IHttpContextAccessor>();
     }
 
-    private CreateCreditCardStatementImportTemplateCommandHandler CreateHandler() =>
-        new(_repository.Object, _dbContext, _httpContextAccessor.Object);
+    private CreateCreditCardStatementImportTemplateCommandHandler CreateHandler()
+    {
+        var isAdmin = new IsAdminUser(_httpContextAccessor.Object, _dbContext);
+        return new(_repository.Object, _dbContext, isAdmin, new CanSetSystemFlag(isAdmin));
+    }
 
     private void SetupIdentity(string? name)
     {

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/CreateCreditCardStatementImportTemplateCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Finance.Application.Commands.CreditCards;
 using Finance.Application.Repositories;
 using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Enums;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.CreditCards;
 using Finance.Domain.Models.Identities;
@@ -29,6 +30,25 @@ public class CreateCreditCardStatementImportTemplateCommandHandlerTests : QueryH
         return new(_repository.Object, _dbContext, isAdmin, new CanSetSystemFlag(isAdmin));
     }
 
+    private async Task SetupAdminAsync()
+    {
+        var sourceId = Guid.NewGuid().ToString();
+        var adminRole = await _dbContext.Role.FindAsync(RoleEnum.Admin)
+                        ?? new Role { Id = RoleEnum.Admin, Name = "Admin" };
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "admin",
+            FirstName = "A",
+            LastName = "B",
+            Identities = [new Identity { SourceId = sourceId }],
+            Roles = [adminRole],
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+        SetupIdentity(sourceId);
+    }
+
     private void SetupIdentity(string? name)
     {
         var identity = new Mock<IIdentity>();
@@ -43,6 +63,8 @@ public class CreateCreditCardStatementImportTemplateCommandHandlerTests : QueryH
     [Fact]
     public async Task Create_WithIsSystemTrue_CreatesTemplateWithNullUserId()
     {
+        await SetupAdminAsync();
+
         var command = new CreateCreditCardStatementImportTemplateCommand
         {
             Name = "System Template",
@@ -130,6 +152,8 @@ public class CreateCreditCardStatementImportTemplateCommandHandlerTests : QueryH
     [Fact]
     public async Task Create_SetsConfigJsonFromCommand()
     {
+        await SetupAdminAsync();
+
         var configJson = "{\"skipRows\":2}";
         var command = new CreateCreditCardStatementImportTemplateCommand
         {

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/ImportCreditCardStatementTransactionsCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/ImportCreditCardStatementTransactionsCommandHandlerTests.cs
@@ -72,13 +72,14 @@ public class ImportCreditCardStatementTransactionsCommandHandlerTests : QueryHan
         var config = new StatementImportConfig
         {
             SkipRows = 1,
-            DateColumn = 0,
-            DateFormat = "d/M/yyyy",
-            ConceptColumn = 1,
-            AmountColumn = 2,
-            DefaultCurrencyId = Guid.Parse(CurrencyConstants.PesoId),
             DecimalSeparator = ",",
             ThousandsSeparator = ".",
+            Columns =
+            [
+                new() { Index = 0, Name = "Fecha", Type = ColumnType.Date, DateFormat = "d/M/yyyy" },
+                new() { Index = 1, Name = "Concepto", Type = ColumnType.Concept },
+                new() { Index = 2, Name = "Monto", Type = ColumnType.Amount, CurrencyId = Guid.Parse(CurrencyConstants.PesoId) },
+            ],
         };
         var template = new CreditCardStatementImportTemplate
         {

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/ImportCreditCardStatementTransactionsCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/ImportCreditCardStatementTransactionsCommandHandlerTests.cs
@@ -1,0 +1,219 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Finance.Domain.SpecialTypes;
+using Finance.Persistence.Constants;
+using FinanceBackEnd.Finance.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using System.Text;
+using System.Text.Json;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class ImportCreditCardStatementTransactionsCommandHandlerTests : QueryHandlerBaseTests
+{
+    static ImportCreditCardStatementTransactionsCommandHandlerTests()
+    {
+        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+    }
+
+    private ImportCreditCardStatementTransactionsCommandHandler CreateHandler() =>
+        new(_dbContext);
+
+    private static IFormFile BuildCsvFile(string content, string fileName = "test.csv")
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var stream = new MemoryStream(bytes);
+        var file = new Mock<IFormFile>();
+        file.Setup(f => f.FileName).Returns(fileName);
+        file.Setup(f => f.Length).Returns(stream.Length);
+        file.Setup(f => f.OpenReadStream()).Returns(stream);
+        return file.Object;
+    }
+
+    private async Task<(CreditCard creditCard, CreditCardStatement statement, CreditCardStatementImportTemplate template)> SeedRequiredData()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = "IdentityNotFound" }],
+        };
+        await _dbContext.User.AddAsync(user);
+
+        var creditCard = new CreditCard { Id = Guid.NewGuid(), Name = "Visa" };
+        await _dbContext.CreditCard.AddAsync(creditCard);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.CreditCardPermissions.Add(new CreditCardPermissions
+        {
+            ResourceId = creditCard.Id,
+            Resource = creditCard,
+            UserId = user.Id,
+            User = user,
+            PermissionLevels = [PermissionLevelEnum.Owner],
+        });
+
+        var statement = new CreditCardStatement
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = creditCard.Id,
+            ClosureDate = new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc),
+            ExpiringDate = new DateTime(2025, 7, 10, 0, 0, 0, DateTimeKind.Utc),
+        };
+        await _dbContext.CreditCardStatement.AddAsync(statement);
+
+        var config = new StatementImportConfig
+        {
+            SkipRows = 1,
+            DateColumn = 0,
+            DateFormat = "d/M/yyyy",
+            ConceptColumn = 1,
+            AmountColumn = 2,
+            DefaultCurrencyId = Guid.Parse(CurrencyConstants.PesoId),
+            DecimalSeparator = ",",
+            ThousandsSeparator = ".",
+        };
+        var template = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Template",
+            IsSystem = true,
+            ConfigJson = JsonSerializer.Serialize(config),
+        };
+        await _dbContext.CreditCardStatementImportTemplate.AddAsync(template);
+        await _dbContext.SaveChangesAsync();
+
+        return (creditCard, statement, template);
+    }
+
+    [Fact]
+    public async Task Import_WithValidCsvFile_CreatesTransactionsAndStatementTransactions()
+    {
+        var (_, statement, template) = await SeedRequiredData();
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,1500\r\n5/6/2025,Uber,300";
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = BuildCsvFile(csv),
+            TemplateId = template.Id,
+            StatementId = statement.Id,
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        var txs = _dbContext.CreditCardTransaction.IgnoreQueryFilters()
+            .Where(t => t.CreditCardId == statement.CreditCardId).ToList();
+        Assert.Equal(2, txs.Count);
+        var stmtTxs = _dbContext.CreditCardStatementTransaction.IgnoreQueryFilters()
+            .Where(st => st.StatementId == statement.Id).ToList();
+        Assert.Equal(2, stmtTxs.Count);
+    }
+
+    [Fact]
+    public async Task Import_WhenTemplateNotFound_ThrowsException()
+    {
+        var (_, statement, _) = await SeedRequiredData();
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = BuildCsvFile("Date,Concept,Amount\r\n1/6/2025,Netflix,1500"),
+            TemplateId = Guid.NewGuid(),
+            StatementId = statement.Id,
+        };
+
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
+    }
+
+    [Fact]
+    public async Task Import_WhenStatementNotFound_ThrowsException()
+    {
+        var (_, _, template) = await SeedRequiredData();
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = BuildCsvFile("Date,Concept,Amount\r\n1/6/2025,Netflix,1500"),
+            TemplateId = template.Id,
+            StatementId = Guid.NewGuid(),
+        };
+
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
+    }
+
+    [Fact]
+    public async Task Import_WhenFileHasNoDataRows_ReturnsFailure()
+    {
+        var (_, statement, template) = await SeedRequiredData();
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = BuildCsvFile("Date,Concept,Amount"),
+            TemplateId = template.Id,
+            StatementId = statement.Id,
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Import_WithDuplicateExistingTransaction_SkipsDuplicate()
+    {
+        var (creditCard, statement, template) = await SeedRequiredData();
+
+        var existingTx = new CreditCardTransaction
+        {
+            Id = Guid.NewGuid(),
+            CreditCardId = creditCard.Id,
+            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            Concept = "Netflix",
+            Amount = 1500m,
+            TransactionType = CreditCardTransactionType.Purchase,
+            CurrencyId = Guid.Parse(CurrencyConstants.PesoId),
+        };
+        _dbContext.CreditCardTransaction.Add(existingTx);
+        await _dbContext.SaveChangesAsync();
+
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,1500\r\n5/6/2025,Uber,300";
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = BuildCsvFile(csv),
+            TemplateId = template.Id,
+            StatementId = statement.Id,
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        var importedTxs = _dbContext.CreditCardTransaction.IgnoreQueryFilters()
+            .Where(t => t.CreditCardId == creditCard.Id && t.Id != existingTx.Id).ToList();
+        Assert.Single(importedTxs);
+        Assert.Equal("Uber", importedTxs[0].Concept);
+    }
+
+    [Fact]
+    public async Task Import_SetsCorrectTransactionFields()
+    {
+        var (_, statement, template) = await SeedRequiredData();
+        var csv = "Date,Concept,Amount\r\n15/6/2025,Supermercado,4500";
+        var command = new ImportCreditCardStatementTransactionsCommand
+        {
+            File = BuildCsvFile(csv),
+            TemplateId = template.Id,
+            StatementId = statement.Id,
+        };
+
+        await CreateHandler().ExecuteAsync(command, default);
+
+        var tx = _dbContext.CreditCardTransaction.IgnoreQueryFilters()
+            .Single(t => t.CreditCardId == statement.CreditCardId);
+        Assert.Equal(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc), tx.Timestamp);
+        Assert.Equal("Supermercado", tx.Concept);
+        Assert.Equal(new Money(4500m), tx.Amount);
+        Assert.Equal(CreditCardTransactionType.Purchase, tx.TransactionType);
+        Assert.Equal(Guid.Parse(CurrencyConstants.PesoId), tx.CurrencyId);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/ImportCreditCardStatementTransactionsCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/ImportCreditCardStatementTransactionsCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using Finance.Application.Commands.CreditCards;
 using Finance.Application.Tests.Queries.Base;
+using Finance.Helpers.ExcelHelper;
 using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.CreditCards;
 using Finance.Domain.Models.Identities;

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/SetCreditCardDefaultImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/SetCreditCardDefaultImportTemplateCommandHandlerTests.cs
@@ -1,0 +1,86 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.CreditCards;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class SetCreditCardDefaultImportTemplateCommandHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IRepository<CreditCard, Guid>> _creditCardRepository;
+
+    public SetCreditCardDefaultImportTemplateCommandHandlerTests()
+    {
+        _creditCardRepository = new Mock<IRepository<CreditCard, Guid>>();
+    }
+
+    private SetCreditCardDefaultImportTemplateCommandHandler CreateHandler() =>
+        new(_dbContext, _creditCardRepository.Object);
+
+    [Fact]
+    public async Task Set_WhenCreditCardExists_UpdatesDefaultTemplateId()
+    {
+        var templateId = Guid.NewGuid();
+        var creditCard = new CreditCard { Id = Guid.NewGuid(), Name = "Visa" };
+
+        _creditCardRepository
+            .Setup(r => r.GetByIdAsync(creditCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(creditCard);
+
+        var command = new SetCreditCardDefaultImportTemplateCommand
+        {
+            CreditCardId = creditCard.Id,
+            TemplateId = templateId,
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(templateId, creditCard.DefaultImportTemplateId);
+        _creditCardRepository.Verify(r => r.UpdateAsync(creditCard, It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+        _creditCardRepository.Verify(r => r.PersistAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Set_WithNullTemplateId_ClearsDefaultTemplate()
+    {
+        var creditCard = new CreditCard
+        {
+            Id = Guid.NewGuid(),
+            Name = "Mastercard",
+            DefaultImportTemplateId = Guid.NewGuid(),
+        };
+
+        _creditCardRepository
+            .Setup(r => r.GetByIdAsync(creditCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(creditCard);
+
+        var command = new SetCreditCardDefaultImportTemplateCommand
+        {
+            CreditCardId = creditCard.Id,
+            TemplateId = null,
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(creditCard.DefaultImportTemplateId);
+    }
+
+    [Fact]
+    public async Task Set_WhenCreditCardNotFound_ThrowsException()
+    {
+        var cardId = Guid.NewGuid();
+        _creditCardRepository
+            .Setup(r => r.GetByIdAsync(cardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CreditCard?)null);
+
+        var command = new SetCreditCardDefaultImportTemplateCommand
+        {
+            CreditCardId = cardId,
+            TemplateId = Guid.NewGuid(),
+        };
+
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommandHandlerTests.cs
@@ -3,29 +3,64 @@ using Finance.Application.Commands.CreditCards;
 using Finance.Application.Repositories;
 using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Enums;
+using Finance.Domain.Models.Auth;
 using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
 using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+using System.Security.Principal;
 
 namespace Finance.Application.Tests.Commands.CreditCards;
 
 public class UpdateCreditCardStatementImportTemplateCommandHandlerTests : QueryHandlerBaseTests
 {
     private readonly Mock<IRepository<CreditCardStatementImportTemplate, Guid>> _repository;
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
 
     public UpdateCreditCardStatementImportTemplateCommandHandlerTests()
     {
         _repository = new Mock<IRepository<CreditCardStatementImportTemplate, Guid>>();
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
     }
 
     private UpdateCreditCardStatementImportTemplateCommandHandler CreateHandler()
     {
-        var isAdmin = new IsAdminUser(Mock.Of<IHttpContextAccessor>(), _dbContext);
+        var isAdmin = new IsAdminUser(_httpContextAccessor.Object, _dbContext);
         return new(_repository.Object, _dbContext, new CanSetSystemFlag(isAdmin));
+    }
+
+    private async Task SetupAdminAsync()
+    {
+        var sourceId = Guid.NewGuid().ToString();
+        var adminRole = await _dbContext.Role.FindAsync(RoleEnum.Admin)
+                        ?? new Role { Id = RoleEnum.Admin, Name = "Admin" };
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "admin",
+            FirstName = "A",
+            LastName = "B",
+            Identities = [new Identity { SourceId = sourceId }],
+            Roles = [adminRole],
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+
+        var identity = new Mock<IIdentity>();
+        identity.Setup(i => i.Name).Returns(sourceId);
+        var principal = new Mock<ClaimsPrincipal>();
+        principal.Setup(p => p.Identity).Returns(identity.Object);
+        var ctx = new Mock<HttpContext>();
+        ctx.Setup(c => c.User).Returns(principal.Object);
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(ctx.Object);
     }
 
     [Fact]
     public async Task Update_WhenTemplateExists_UpdatesFieldsAndReturnsSuccess()
     {
+        await SetupAdminAsync();
+
         var existing = new CreditCardStatementImportTemplate
         {
             Id = Guid.NewGuid(),

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommandHandlerTests.cs
@@ -1,0 +1,101 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Application.Repositories;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.CreditCards;
+
+namespace Finance.Application.Tests.Commands.CreditCards;
+
+public class UpdateCreditCardStatementImportTemplateCommandHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IRepository<CreditCardStatementImportTemplate, Guid>> _repository;
+
+    public UpdateCreditCardStatementImportTemplateCommandHandlerTests()
+    {
+        _repository = new Mock<IRepository<CreditCardStatementImportTemplate, Guid>>();
+    }
+
+    private UpdateCreditCardStatementImportTemplateCommandHandler CreateHandler() =>
+        new(_repository.Object, _dbContext);
+
+    [Fact]
+    public async Task Update_WhenTemplateExists_UpdatesFieldsAndReturnsSuccess()
+    {
+        var existing = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Old Name",
+            IsSystem = false,
+            ConfigJson = "{\"skipRows\":1}",
+        };
+
+        _repository
+            .Setup(r => r.GetByIdAsync(existing.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var command = new UpdateCreditCardStatementImportTemplateCommand
+        {
+            Id = existing.Id,
+            Name = "New Name",
+            IsSystem = true,
+            ConfigJson = "{\"skipRows\":2}",
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("New Name", result.Data.Name);
+        Assert.True(result.Data.IsSystem);
+        Assert.Equal("{\"skipRows\":2}", result.Data.ConfigJson);
+        _repository.Verify(r => r.UpdateAsync(It.IsAny<CreditCardStatementImportTemplate>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Once);
+        _repository.Verify(r => r.PersistAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Update_WhenTemplateNotFound_ThrowsException()
+    {
+        var id = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CreditCardStatementImportTemplate?)null);
+
+        var command = new UpdateCreditCardStatementImportTemplateCommand
+        {
+            Id = id,
+            Name = "X",
+            IsSystem = false,
+            ConfigJson = "{}",
+        };
+
+        await Assert.ThrowsAsync<Exception>(() => CreateHandler().ExecuteAsync(command, default));
+    }
+
+    [Fact]
+    public async Task Update_PreservesUnchangedProperties()
+    {
+        var userId = Guid.NewGuid();
+        var existing = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Original",
+            IsSystem = false,
+            UserId = userId,
+            ConfigJson = "{}",
+        };
+
+        _repository
+            .Setup(r => r.GetByIdAsync(existing.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var command = new UpdateCreditCardStatementImportTemplateCommand
+        {
+            Id = existing.Id,
+            Name = "Updated",
+            IsSystem = false,
+            ConfigJson = "{}",
+        };
+
+        var result = await CreateHandler().ExecuteAsync(command, default);
+
+        Assert.Equal(userId, result.Data.UserId);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommandHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Commands/CreditCards/UpdateCreditCardStatementImportTemplateCommandHandlerTests.cs
@@ -1,7 +1,10 @@
+using Finance.Application.Auth;
 using Finance.Application.Commands.CreditCards;
 using Finance.Application.Repositories;
+using Finance.Application.Specifications.CreditCards;
 using Finance.Application.Tests.Queries.Base;
 using Finance.Domain.Models.CreditCards;
+using Microsoft.AspNetCore.Http;
 
 namespace Finance.Application.Tests.Commands.CreditCards;
 
@@ -14,8 +17,11 @@ public class UpdateCreditCardStatementImportTemplateCommandHandlerTests : QueryH
         _repository = new Mock<IRepository<CreditCardStatementImportTemplate, Guid>>();
     }
 
-    private UpdateCreditCardStatementImportTemplateCommandHandler CreateHandler() =>
-        new(_repository.Object, _dbContext);
+    private UpdateCreditCardStatementImportTemplateCommandHandler CreateHandler()
+    {
+        var isAdmin = new IsAdminUser(Mock.Of<IHttpContextAccessor>(), _dbContext);
+        return new(_repository.Object, _dbContext, new CanSetSystemFlag(isAdmin));
+    }
 
     [Fact]
     public async Task Update_WhenTemplateExists_UpdatesFieldsAndReturnsSuccess()

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/StatementImportExcelHelperTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/StatementImportExcelHelperTests.cs
@@ -11,16 +11,20 @@ public class StatementImportExcelHelperTests
         System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
     }
 
+    private static readonly Guid TestCurrencyId = Guid.NewGuid();
+
     private static StatementImportConfig DefaultConfig() => new()
     {
         SkipRows = 1,
-        DateColumn = 0,
-        DateFormat = "d/M/yyyy",
-        ConceptColumn = 1,
-        AmountColumn = 2,
         DecimalSeparator = ",",
         ThousandsSeparator = ".",
         AmountNegate = false,
+        Columns =
+        [
+            new() { Index = 0, Name = "Fecha", Type = ColumnType.Date, DateFormat = "d/M/yyyy" },
+            new() { Index = 1, Name = "Concepto", Type = ColumnType.Concept },
+            new() { Index = 2, Name = "Monto", Type = ColumnType.Amount, CurrencyId = TestCurrencyId },
+        ],
     };
 
     private static IFormFile BuildCsvFile(string content, string fileName = "test.csv")

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/StatementImportExcelHelperTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/StatementImportExcelHelperTests.cs
@@ -1,0 +1,153 @@
+using Finance.Application.Commands.CreditCards;
+using Finance.Helpers.ExcelHelper;
+using Microsoft.AspNetCore.Http;
+using System.Text;
+
+namespace Finance.Application.Tests.Helpers;
+
+public class StatementImportExcelHelperTests
+{
+    static StatementImportExcelHelperTests()
+    {
+        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+    }
+
+    private static StatementImportConfig DefaultConfig() => new()
+    {
+        SkipRows = 1,
+        DateColumn = 0,
+        DateFormat = "d/M/yyyy",
+        ConceptColumn = 1,
+        AmountColumn = 2,
+        DecimalSeparator = ",",
+        ThousandsSeparator = ".",
+        AmountNegate = false,
+    };
+
+    private static IFormFile BuildCsvFile(string content, string fileName = "test.csv")
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var stream = new MemoryStream(bytes);
+        var file = new Mock<IFormFile>();
+        file.Setup(f => f.FileName).Returns(fileName);
+        file.Setup(f => f.Length).Returns(stream.Length);
+        file.Setup(f => f.OpenReadStream()).Returns(stream);
+        return file.Object;
+    }
+
+    [Fact]
+    public void Read_ValidCsv_ParsesRowsCorrectly()
+    {
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,1500\r\n5/6/2025,Uber,300";
+        var file = BuildCsvFile(csv);
+        var helper = new StatementImportExcelHelper();
+
+        var rows = helper.Read(file, DefaultConfig()).ToArray();
+
+        Assert.Equal(2, rows.Length);
+        Assert.Equal(new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc), rows[0].Date);
+        Assert.Equal("Netflix", rows[0].Concept);
+        Assert.Equal(1500m, rows[0].Amount);
+        Assert.Equal(new DateTime(2025, 6, 5, 0, 0, 0, DateTimeKind.Utc), rows[1].Date);
+        Assert.Equal("Uber", rows[1].Concept);
+        Assert.Equal(300m, rows[1].Amount);
+    }
+
+    [Fact]
+    public void Read_NullFile_ThrowsException()
+    {
+        var helper = new StatementImportExcelHelper();
+
+        Assert.Throws<Exception>(() => helper.Read(null!, DefaultConfig()).ToArray());
+    }
+
+    [Fact]
+    public void Read_EmptyFile_ThrowsException()
+    {
+        var file = new Mock<IFormFile>();
+        file.Setup(f => f.FileName).Returns("test.csv");
+        file.Setup(f => f.Length).Returns(0);
+        var helper = new StatementImportExcelHelper();
+
+        Assert.Throws<Exception>(() => helper.Read(file.Object, DefaultConfig()).ToArray());
+    }
+
+    [Fact]
+    public void Read_UnsupportedExtension_ThrowsException()
+    {
+        var file = BuildCsvFile("a,b,c", "test.txt");
+        var helper = new StatementImportExcelHelper();
+
+        Assert.Throws<Exception>(() => helper.Read(file, DefaultConfig()).ToArray());
+    }
+
+    [Fact]
+    public void Read_SkipRows_OmitsHeaderRow()
+    {
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,1500";
+        var file = BuildCsvFile(csv);
+        var helper = new StatementImportExcelHelper();
+
+        var rows = helper.Read(file, DefaultConfig()).ToArray();
+
+        Assert.Single(rows);
+        Assert.Equal("Netflix", rows[0].Concept);
+    }
+
+    [Fact]
+    public void Read_AmountNegate_NegatesValues()
+    {
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,1500";
+        var file = BuildCsvFile(csv);
+        var config = DefaultConfig();
+        config.AmountNegate = true;
+        var helper = new StatementImportExcelHelper();
+
+        var rows = helper.Read(file, config).ToArray();
+
+        Assert.Equal(-1500m, rows[0].Amount);
+    }
+
+    [Fact]
+    public void Read_RowWithEmptyDateAndConcept_IsSkipped()
+    {
+        var csv = "Date,Concept,Amount\r\n,,100\r\n1/6/2025,Netflix,1500";
+        var file = BuildCsvFile(csv);
+        var helper = new StatementImportExcelHelper();
+
+        var rows = helper.Read(file, DefaultConfig()).ToArray();
+
+        Assert.Single(rows);
+        Assert.Equal("Netflix", rows[0].Concept);
+    }
+
+    [Fact]
+    public void Read_DollarSignInAmount_StripsCurrencySymbol()
+    {
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,$1500";
+        var config = DefaultConfig();
+        config.DecimalSeparator = ".";
+        config.ThousandsSeparator = ",";
+        var file = BuildCsvFile(csv);
+        var helper = new StatementImportExcelHelper();
+
+        var rows = helper.Read(file, config).ToArray();
+
+        Assert.Equal(1500m, rows[0].Amount);
+    }
+
+    [Fact]
+    public void Read_CommaDecimalSeparator_ParsesDecimalCorrectly()
+    {
+        var csv = "Date,Concept,Amount\r\n1/6/2025,Netflix,\"1.500,75\"";
+        var config = DefaultConfig();
+        config.DecimalSeparator = ",";
+        config.ThousandsSeparator = ".";
+        var file = BuildCsvFile(csv);
+        var helper = new StatementImportExcelHelper();
+
+        var rows = helper.Read(file, config).ToArray();
+
+        Assert.Equal(1500.75m, rows[0].Amount);
+    }
+}

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/StatementImportExcelHelperTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Helpers/StatementImportExcelHelperTests.cs
@@ -1,4 +1,3 @@
-using Finance.Application.Commands.CreditCards;
 using Finance.Helpers.ExcelHelper;
 using Microsoft.AspNetCore.Http;
 using System.Text;

--- a/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetCreditCardStatementImportTemplatesQueryHandlerTests.cs
+++ b/FinanceBackEnd/tests/Finance.Application.Tests/Queries/CreditCards/GetCreditCardStatementImportTemplatesQueryHandlerTests.cs
@@ -1,0 +1,167 @@
+using Finance.Application.Queries.CreditCards;
+using Finance.Application.Tests.Queries.Base;
+using Finance.Domain.Models.Auth;
+using Finance.Domain.Models.CreditCards;
+using Finance.Domain.Models.Identities;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+using System.Security.Principal;
+
+namespace Finance.Application.Tests.Queries.CreditCards;
+
+public class GetCreditCardStatementImportTemplatesQueryHandlerTests : QueryHandlerBaseTests
+{
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+
+    public GetCreditCardStatementImportTemplatesQueryHandlerTests()
+    {
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
+    }
+
+    private GetCreditCardStatementImportTemplatesQueryHandler CreateHandler() =>
+        new(_dbContext, _httpContextAccessor.Object);
+
+    private void SetupIdentity(string? name)
+    {
+        var identity = new Mock<IIdentity>();
+        identity.Setup(i => i.Name).Returns(name);
+        var principal = new Mock<ClaimsPrincipal>();
+        principal.Setup(p => p.Identity).Returns(identity.Object);
+        var ctx = new Mock<HttpContext>();
+        ctx.Setup(c => c.User).Returns(principal.Object);
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(ctx.Object);
+    }
+
+    private async Task<User> SeedCurrentUser()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            Identities = [new Identity { SourceId = "IdentityNotFound" }],
+        };
+        await _dbContext.User.AddAsync(user);
+        await _dbContext.SaveChangesAsync();
+        return user;
+    }
+
+    [Fact]
+    public async Task GetAll_WithNoIdentity_ReturnsOnlySystemTemplates()
+    {
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+
+        var systemTemplate = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "System",
+            IsSystem = true,
+            ConfigJson = "{}",
+        };
+        var userTemplate = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "User",
+            IsSystem = false,
+            UserId = Guid.NewGuid(),
+            ConfigJson = "{}",
+        };
+        await _dbContext.CreditCardStatementImportTemplate.AddRangeAsync(systemTemplate, userTemplate);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardStatementImportTemplatesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var mine = result.Data.Where(t => t.Id == systemTemplate.Id || t.Id == userTemplate.Id).ToList();
+        Assert.Single(mine);
+        Assert.Equal(systemTemplate.Id, mine[0].Id);
+    }
+
+    [Fact]
+    public async Task GetAll_WithUserIdentity_ReturnsSystemAndOwnTemplates()
+    {
+        var user = await SeedCurrentUser();
+        SetupIdentity("IdentityNotFound");
+
+        var systemTemplate = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "System",
+            IsSystem = true,
+            ConfigJson = "{}",
+        };
+        var myTemplate = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Mine",
+            IsSystem = false,
+            UserId = user.Id,
+            ConfigJson = "{}",
+        };
+        var otherTemplate = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Other",
+            IsSystem = false,
+            UserId = Guid.NewGuid(),
+            ConfigJson = "{}",
+        };
+        await _dbContext.CreditCardStatementImportTemplate.AddRangeAsync(systemTemplate, myTemplate, otherTemplate);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardStatementImportTemplatesQuery(), default);
+
+        Assert.True(result.IsSuccess);
+        var relevant = result.Data
+            .Where(t => t.Id == systemTemplate.Id || t.Id == myTemplate.Id || t.Id == otherTemplate.Id)
+            .ToList();
+        Assert.Equal(2, relevant.Count);
+        Assert.Contains(relevant, t => t.Id == systemTemplate.Id);
+        Assert.Contains(relevant, t => t.Id == myTemplate.Id);
+        Assert.DoesNotContain(relevant, t => t.Id == otherTemplate.Id);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsSystemTemplatesFirst_ThenAlphabetical()
+    {
+        var user = await SeedCurrentUser();
+        SetupIdentity("IdentityNotFound");
+
+        var templateB = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Banana",
+            IsSystem = false,
+            UserId = user.Id,
+            ConfigJson = "{}",
+        };
+        var templateSys = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Alpha System",
+            IsSystem = true,
+            ConfigJson = "{}",
+        };
+        var templateA = new CreditCardStatementImportTemplate
+        {
+            Id = Guid.NewGuid(),
+            Name = "Apple",
+            IsSystem = false,
+            UserId = user.Id,
+            ConfigJson = "{}",
+        };
+        await _dbContext.CreditCardStatementImportTemplate.AddRangeAsync(templateB, templateSys, templateA);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await CreateHandler().ExecuteAsync(new GetCreditCardStatementImportTemplatesQuery(), default);
+
+        var relevant = result.Data
+            .Where(t => t.Id == templateB.Id || t.Id == templateSys.Id || t.Id == templateA.Id)
+            .ToList();
+        Assert.Equal(3, relevant.Count);
+        Assert.Equal(templateSys.Id, relevant[0].Id);
+        Assert.Equal(templateA.Id, relevant[1].Id);
+        Assert.Equal(templateB.Id, relevant[2].Id);
+    }
+}

--- a/FinanceFrontEnd/FinanceApp/.eslintrc.cjs
+++ b/FinanceFrontEnd/FinanceApp/.eslintrc.cjs
@@ -43,7 +43,7 @@ module.exports = {
         commonjs: true,
         es6: true,
     },
-    ignorePatterns: ["!**/.server", "!**/.client", "app/components/ui/shadcn/**"],
+    ignorePatterns: ["!**/.server", "!**/.client", "app/components/ui/shadcn/**", "build/**"],
 
     // Base config
     extends: ["eslint:recommended"],

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -115,7 +115,7 @@ function StatementPicker({
   );
 }
 
-function buildTransactionColumns(transactions: CreditCardTransaction[]) {
+function buildTransactionColumns(transactions: CreditCardTransaction[], defaultCurrencySymbol: string) {
   const seen = new Set<string>();
   const currencies = transactions
     .filter((tx) => { const unseen = !seen.has(tx.currencyId); seen.add(tx.currencyId); return unseen; })
@@ -159,6 +159,20 @@ function buildTransactionColumns(transactions: CreditCardTransaction[]) {
     { id: 'timestamp', label: 'Fecha', formatter: (v: unknown) => formatDate(String(v ?? '')) },
     { id: 'concept', label: 'Concepto' },
     ...currencyCols,
+    {
+      id: 'convertedAmount',
+      label: `Total (${defaultCurrencySymbol})`,
+      class: 'text-right',
+      headerClass: 'w-36 text-right',
+      type: InputType.Decimal,
+      mapper: (r: unknown) => toNumber((r as CreditCardTransaction).convertedAmount as unknown as ValueLike, 0),
+      formatter: (v: unknown) => formatMoney(v),
+      totals: {
+        reducer: (acc: unknown, row: unknown) =>
+          (acc as number) + toNumber((row as CreditCardTransaction).convertedAmount as unknown as ValueLike, 0),
+        formatter: (v: unknown) => `${defaultCurrencySymbol}${formatMoney(v)}`,
+      },
+    },
   ];
 }
 
@@ -256,7 +270,8 @@ function CreateStatementModal({
 }
 
 function CreditCardDetail() {
-  const { card, cards, isAdmin } = useLoaderData<{ card: CreditCard; cards: CreditCard[]; isAdmin: boolean }>();
+  const { card, cards, isAdmin, defaultCurrency } = useLoaderData<{ card: CreditCard; cards: CreditCard[]; isAdmin: boolean; defaultCurrency: { id: string; symbol: string } | null }>();
+  const defaultCurrencySymbol = defaultCurrency?.symbol ?? '$';
   const navigate = useNavigate();
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [statements, setStatements] = useState<CreditCardStatement[]>([]);
@@ -406,7 +421,7 @@ function CreditCardDetail() {
       {loading ? (
         <div className="text-center py-10 text-muted-foreground">Cargando...</div>
       ) : (
-        <FetchTable name="transactions" data={transactions as never[]} columns={buildTransactionColumns(transactions)} />
+        <FetchTable name="transactions" data={transactions as never[]} columns={buildTransactionColumns(transactions, defaultCurrencySymbol)} />
       )}
 
       <CreateStatementModal

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -125,21 +125,18 @@ const TRANSACTION_COLUMNS = [
     label: 'Concepto',
   },
   {
-    id: 'currency',
-    label: 'Moneda',
-    headerClass: 'w-20',
-    mapper: (r: unknown) => {
-      const tx = r as CreditCardTransaction;
-      return tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '';
-    },
-  },
-  {
     id: 'amount',
     label: 'Monto',
     class: 'text-right',
-    headerClass: 'w-32 text-right',
+    headerClass: 'w-40 text-right',
     type: InputType.Decimal,
-    formatter: (v: unknown) => formatMoney(v),
+    mapper: (r: unknown) => r,
+    formatter: (v: unknown) => {
+      const tx = v as CreditCardTransaction;
+      const symbol = tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '';
+      const amount = formatMoney(tx.amount);
+      return symbol ? `${symbol} ${amount}` : amount;
+    },
     totals: {
       reducer: (acc: unknown, row: unknown) =>
         (acc as number) + toNumber((row as CreditCardTransaction).convertedAmount as unknown as ValueLike, 0),

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -119,9 +119,9 @@ function buildTransactionColumns(transactions: CreditCardTransaction[], defaultC
   const seen = new Set<string>();
   const currencies = transactions
     .filter((tx) => { const unseen = !seen.has(tx.currencyId); seen.add(tx.currencyId); return unseen; })
-    .map((tx) => ({ id: tx.currencyId, currency: tx.currency }));
+    .map((tx) => ({ id: tx.currencyId }));
 
-  const currencyCols = currencies.flatMap(({ id: currencyId, currency }) => [
+  const currencyCols = currencies.flatMap(({ id: currencyId }) => [
     {
       id: `currency_${currencyId}`,
       label: 'Moneda',

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -33,6 +33,7 @@ import {
 import urls from '@/utils/urls';
 import type { CreditCard, CreditCardStatement, CreditCardTransaction } from '@/types/creditCard';
 import EditStatementModal from './EditStatementModal';
+import ImportStatementModal from './ImportStatementModal';
 
 const formatDate = (dateStr: string) => {
   if (!dateStr) return '-';
@@ -271,6 +272,7 @@ function CreditCardDetail() {
   const [loading, setLoading] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
 
   useEffect(() => {
     if (!carouselApi) return;
@@ -380,6 +382,14 @@ function CreditCardDetail() {
           >
             Nuevo Resúmen
           </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-primary text-primary hover:bg-primary/10"
+            onClick={() => setShowImportModal(true)}
+          >
+            Importar Resúmen
+          </Button>
           {statements.length > 0 && (
             <Button
               variant="outline"
@@ -425,6 +435,17 @@ function CreditCardDetail() {
           }}
         />
       )}
+
+      <ImportStatementModal
+        show={showImportModal}
+        onHide={() => setShowImportModal(false)}
+        creditCardId={card.id}
+        defaultTemplateId={card.defaultImportTemplateId ?? null}
+        onImported={() => {
+          fetchStatements();
+          fetchTransactions();
+        }}
+      />
     </>
   );
 }

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -434,6 +434,7 @@ function CreditCardDetail() {
         creditCardId={card.id}
         defaultTemplateId={card.defaultImportTemplateId ?? null}
         isAdmin={isAdmin}
+        statements={statements}
         onImported={() => {
           fetchStatements();
           fetchTransactions();

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -263,7 +263,7 @@ function CreateStatementModal({
 }
 
 function CreditCardDetail() {
-  const { card, cards } = useLoaderData<{ card: CreditCard; cards: CreditCard[] }>();
+  const { card, cards, isAdmin } = useLoaderData<{ card: CreditCard; cards: CreditCard[]; isAdmin: boolean }>();
   const navigate = useNavigate();
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [statements, setStatements] = useState<CreditCardStatement[]>([]);
@@ -441,6 +441,7 @@ function CreditCardDetail() {
         onHide={() => setShowImportModal(false)}
         creditCardId={card.id}
         defaultTemplateId={card.defaultImportTemplateId ?? null}
+        isAdmin={isAdmin}
         onImported={() => {
           fetchStatements();
           fetchTransactions();

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -1,14 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useLoaderData, useNavigate } from 'react-router';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/shadcn/table';
+import FetchTable from '@/components/ui/utils/FetchTable';
+import { InputType } from '@/components/ui/utils/InputType';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
@@ -121,53 +114,39 @@ function StatementPicker({
   );
 }
 
-function TransactionsTable({ transactions }: { transactions: CreditCardTransaction[] }) {
-  const totalAmount = transactions.reduce(
-    (acc, tx) => acc + toNumber(tx.convertedAmount as unknown as ValueLike, 0),
-    0
-  );
-
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Fecha</TableHead>
-          <TableHead>Concepto</TableHead>
-          <TableHead className="w-20">Moneda</TableHead>
-          <TableHead className="w-32 text-right">Monto</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {transactions.length === 0 ? (
-          <TableRow>
-            <TableCell colSpan={4} className="text-center text-muted-foreground">
-              No se encontraron movimientos
-            </TableCell>
-          </TableRow>
-        ) : (
-          transactions.map((tx) => (
-            <TableRow key={tx.id}>
-              <TableCell>{formatDate(tx.timestamp)}</TableCell>
-              <TableCell>{tx.concept}</TableCell>
-              <TableCell>{tx.currency?.defaultSymbol ?? tx.currency?.shortName}</TableCell>
-              <TableCell className="text-right">{formatMoney(tx.amount)}</TableCell>
-            </TableRow>
-          ))
-        )}
-      </TableBody>
-      {transactions.length > 0 && (
-        <TableFooter>
-          <TableRow>
-            <TableCell className="font-medium">Total</TableCell>
-            <TableCell></TableCell>
-            <TableCell></TableCell>
-            <TableCell className="text-right font-medium">{formatMoney(totalAmount)}</TableCell>
-          </TableRow>
-        </TableFooter>
-      )}
-    </Table>
-  );
-}
+const TRANSACTION_COLUMNS = [
+  {
+    id: 'timestamp',
+    label: 'Fecha',
+    formatter: (v: unknown) => formatDate(String(v ?? '')),
+  },
+  {
+    id: 'concept',
+    label: 'Concepto',
+  },
+  {
+    id: 'currency',
+    label: 'Moneda',
+    headerClass: 'w-20',
+    mapper: (r: unknown) => {
+      const tx = r as CreditCardTransaction;
+      return tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '';
+    },
+  },
+  {
+    id: 'amount',
+    label: 'Monto',
+    class: 'text-right',
+    headerClass: 'w-32 text-right',
+    type: InputType.Decimal,
+    formatter: (v: unknown) => formatMoney(v),
+    totals: {
+      reducer: (acc: unknown, row: unknown) =>
+        (acc as number) + toNumber((row as CreditCardTransaction).convertedAmount as unknown as ValueLike, 0),
+      formatter: (v: unknown) => formatMoney(v),
+    },
+  },
+];
 
 function CreateStatementModal({
   show,
@@ -413,7 +392,7 @@ function CreditCardDetail() {
       {loading ? (
         <div className="text-center py-10 text-muted-foreground">Cargando...</div>
       ) : (
-        <TransactionsTable transactions={transactions} />
+        <FetchTable name="transactions" data={transactions as never[]} columns={TRANSACTION_COLUMNS} />
       )}
 
       <CreateStatementModal

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -30,7 +30,8 @@ import ImportStatementModal from './ImportStatementModal';
 
 const formatDate = (dateStr: string) => {
   if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleDateString('es-AR');
+  const [year, month, day] = dateStr.slice(0, 10).split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString();
 };
 
 const formatMoney = (value: unknown) => {

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -114,45 +114,52 @@ function StatementPicker({
   );
 }
 
-const TRANSACTION_COLUMNS = [
-  {
-    id: 'timestamp',
-    label: 'Fecha',
-    formatter: (v: unknown) => formatDate(String(v ?? '')),
-  },
-  {
-    id: 'concept',
-    label: 'Concepto',
-  },
-  {
-    id: 'currency',
-    label: 'Moneda',
-    headerClass: 'w-20',
-    mapper: (r: unknown) => {
-      const tx = r as CreditCardTransaction;
-      return tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '';
+function buildTransactionColumns(transactions: CreditCardTransaction[]) {
+  const seen = new Set<string>();
+  const currencies = transactions
+    .filter((tx) => { const unseen = !seen.has(tx.currencyId); seen.add(tx.currencyId); return unseen; })
+    .map((tx) => ({ id: tx.currencyId, currency: tx.currency }));
+
+  const currencyCols = currencies.flatMap(({ id: currencyId, currency }) => [
+    {
+      id: `currency_${currencyId}`,
+      label: 'Moneda',
+      headerClass: 'w-20',
+      mapper: (r: unknown) => {
+        const tx = r as CreditCardTransaction;
+        return tx.currencyId === currencyId
+          ? (tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '')
+          : '';
+      },
     },
-  },
-  {
-    id: 'amount',
-    label: 'Monto',
-    class: 'text-right',
-    headerClass: 'w-32 text-right',
-    type: InputType.Decimal,
-    mapper: (r: unknown) => r,
-    formatter: (v: unknown) => {
-      const tx = v as CreditCardTransaction;
-      const symbol = tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '';
-      const amount = formatMoney(tx.amount);
-      return symbol ? `${symbol} ${amount}` : amount;
+    {
+      id: `amount_${currencyId}`,
+      label: 'Monto',
+      class: 'text-right',
+      headerClass: 'w-32 text-right',
+      type: InputType.Decimal,
+      mapper: (r: unknown) => {
+        const tx = r as CreditCardTransaction;
+        return tx.currencyId === currencyId ? tx.amount : null;
+      },
+      formatter: (v: unknown) => (v != null ? formatMoney(v) : ''),
+      totals: {
+        reducer: (acc: unknown, row: unknown) =>
+          (acc as number) +
+          (( row as CreditCardTransaction).currencyId === currencyId
+            ? toNumber((row as CreditCardTransaction).amount as unknown as ValueLike, 0)
+            : 0),
+        formatter: (v: unknown) => formatMoney(v),
+      },
     },
-    totals: {
-      reducer: (acc: unknown, row: unknown) =>
-        (acc as number) + toNumber((row as CreditCardTransaction).convertedAmount as unknown as ValueLike, 0),
-      formatter: (v: unknown) => formatMoney(v),
-    },
-  },
-];
+  ]);
+
+  return [
+    { id: 'timestamp', label: 'Fecha', formatter: (v: unknown) => formatDate(String(v ?? '')) },
+    { id: 'concept', label: 'Concepto' },
+    ...currencyCols,
+  ];
+}
 
 function CreateStatementModal({
   show,
@@ -398,7 +405,7 @@ function CreditCardDetail() {
       {loading ? (
         <div className="text-center py-10 text-muted-foreground">Cargando...</div>
       ) : (
-        <FetchTable name="transactions" data={transactions as never[]} columns={TRANSACTION_COLUMNS} />
+        <FetchTable name="transactions" data={transactions as never[]} columns={buildTransactionColumns(transactions)} />
       )}
 
       <CreateStatementModal

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/CreditCardDetail.tsx
@@ -125,10 +125,19 @@ const TRANSACTION_COLUMNS = [
     label: 'Concepto',
   },
   {
+    id: 'currency',
+    label: 'Moneda',
+    headerClass: 'w-20',
+    mapper: (r: unknown) => {
+      const tx = r as CreditCardTransaction;
+      return tx.currency?.defaultSymbol ?? tx.currency?.shortName ?? '';
+    },
+  },
+  {
     id: 'amount',
     label: 'Monto',
     class: 'text-right',
-    headerClass: 'w-40 text-right',
+    headerClass: 'w-32 text-right',
     type: InputType.Decimal,
     mapper: (r: unknown) => r,
     formatter: (v: unknown) => {

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
@@ -53,6 +53,7 @@ export default function EditStatementModal({
   const [expiringDate, setExpiringDate] = useState('');
   const [draftTxs, setDraftTxs] = useState<DraftTransaction[]>([]);
   const [submitting, setSubmitting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [currencies, setCurrencies] = useState<Currency[]>([]);
 
   useEffect(() => {
@@ -112,6 +113,25 @@ export default function EditStatementModal({
         isModified: false,
       },
     ]);
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('¿Eliminar este resúmen? Se perderán todos sus movimientos.')) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(String(urls.creditCardStatements.endpoint), {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: statement.id }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      onSaved();
+      onHide();
+    } catch (err) {
+      alert(`Error al eliminar resúmen: ${err}`);
+    } finally {
+      setDeleting(false);
+    }
   };
 
   const handleSave = async (e: React.FormEvent) => {
@@ -309,13 +329,23 @@ export default function EditStatementModal({
           </div>
         </ModalBody>
         <ModalFooter>
-          <div className="flex justify-end space-x-2 mt-6">
-            <Button type="button" variant="outline" onClick={onHide}>
-              Cancelar
+          <div className="flex justify-between mt-6">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleting || submitting}
+              onClick={handleDelete}
+            >
+              {deleting ? 'Eliminando...' : 'Eliminar resúmen'}
             </Button>
-            <Button type="submit" disabled={submitting}>
-              {submitting ? 'Guardando...' : 'Guardar'}
-            </Button>
+            <div className="flex space-x-2">
+              <Button type="button" variant="outline" onClick={onHide}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={submitting || deleting}>
+                {submitting ? 'Guardando...' : 'Guardar'}
+              </Button>
+            </div>
           </div>
         </ModalFooter>
       </form>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/EditStatementModal.tsx
@@ -122,7 +122,7 @@ export default function EditStatementModal({
       const res = await fetch(String(urls.creditCardStatements.endpoint), {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: statement.id }),
+        body: JSON.stringify({ ids: [statement.id] }),
       });
       if (!res.ok) throw new Error(await res.text());
       onSaved();

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
@@ -11,11 +11,15 @@ import {
   ModalFooter,
 } from '@/components/ui/utils/Modal';
 import urls from '@/utils/urls';
+import { Checkbox } from '@/components/ui/utils/Checkbox';
+import Picker from '@/components/ui/utils/Picker';
 import type {
   CreditCardStatementImportTemplate,
   StatementImportConfig,
 } from '@/types/creditCardStatementImportTemplate';
 import type { CatalogItem } from '@/types/catalog';
+
+type TemplateMode = 'select' | 'import-file' | 'create';
 
 const DEFAULT_CONFIG: StatementImportConfig = {
   skipRows: 1,
@@ -28,7 +32,39 @@ const DEFAULT_CONFIG: StatementImportConfig = {
   decimalSeparator: ',',
   thousandsSeparator: '.',
   amountNegate: false,
+  installmentsColumn: undefined,
+  installmentsPattern: undefined,
 };
+
+function ModeSwitcher({
+  mode,
+  onChange,
+}: {
+  mode: TemplateMode;
+  onChange: (m: TemplateMode) => void;
+}) {
+  const tabs: { key: TemplateMode; label: string }[] = [
+    { key: 'select', label: 'Seleccionar' },
+    { key: 'import-file', label: 'Importar archivo' },
+    { key: 'create', label: 'Crear nueva' },
+  ];
+  return (
+    <div className="flex rounded-md border overflow-hidden">
+      {tabs.map(({ key, label }) => (
+        <Button
+          key={key}
+          type="button"
+          variant={mode === key ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => onChange(key)}
+          className="flex-1 rounded-none"
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  );
+}
 
 function TemplateForm({
   initial,
@@ -42,7 +78,7 @@ function TemplateForm({
   currencies: CatalogItem[];
   creditCardId?: string;
   isAdmin?: boolean;
-  onSave: () => void;
+  onSave: (savedName: string) => void;
   onCancel: () => void;
 }) {
   const [name, setName] = useState(initial?.name ?? '');
@@ -79,7 +115,7 @@ function TemplateForm({
         body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error(await res.text());
-      onSave();
+      onSave(name);
     } catch (err) {
       alert(`Error al guardar plantilla: ${err}`);
     } finally {
@@ -88,7 +124,7 @@ function TemplateForm({
   };
 
   return (
-    <form onSubmit={handleSave} className="space-y-4 border rounded-md p-4 bg-muted/30">
+    <form onSubmit={handleSave} className="space-y-4">
       <div className="grid grid-cols-2 gap-4">
         <div>
           <Label className="block mb-1">Nombre</Label>
@@ -96,14 +132,13 @@ function TemplateForm({
         </div>
         {isAdmin && (
           <div className="flex items-end gap-2">
-            <label className="flex items-center gap-2 text-sm cursor-pointer">
-              <input
-                type="checkbox"
+            <Label className="flex items-center gap-2 text-sm cursor-pointer font-normal">
+              <Checkbox
                 checked={isSystem}
-                onChange={(e) => setIsSystem(e.target.checked)}
+                onCheckedChange={(checked) => setIsSystem(checked)}
               />
               Plantilla del sistema
-            </label>
+            </Label>
           </div>
         )}
       </div>
@@ -167,19 +202,15 @@ function TemplateForm({
         </div>
         <div>
           <Label className="block mb-1 text-sm">Moneda por defecto</Label>
-          <select
+          <Picker
+            id="currency-picker"
             value={config.defaultCurrencyId}
-            onChange={(e) => updateConfig('defaultCurrencyId', e.target.value)}
-            className="h-9 w-full text-sm rounded-md border border-input bg-background px-2"
-            required
-          >
-            <option value="">Seleccionar...</option>
-            {currencies.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
+            data={currencies}
+            mapper={{ id: 'id', label: 'name' }}
+            placeholder="Seleccionar..."
+            onChange={(e: { value: string | number }) => updateConfig('defaultCurrencyId', String(e.value))}
+            className="w-full"
+          />
         </div>
         <div>
           <Label className="block mb-1 text-sm">Sep. decimal</Label>
@@ -198,14 +229,38 @@ function TemplateForm({
           />
         </div>
         <div className="flex items-end pb-1">
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
+          <Label className="flex items-center gap-2 text-sm cursor-pointer font-normal">
+            <Checkbox
               checked={config.amountNegate}
-              onChange={(e) => updateConfig('amountNegate', e.target.checked)}
+              onCheckedChange={(checked) => updateConfig('amountNegate', checked)}
             />
             Invertir signo
-          </label>
+          </Label>
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Col. Cuotas (opcional)</Label>
+          <Input
+            type="number"
+            min={0}
+            placeholder="—"
+            value={config.installmentsColumn ?? ''}
+            onChange={(e) =>
+              updateConfig(
+                'installmentsColumn',
+                e.target.value === '' ? undefined : Number(e.target.value)
+              )
+            }
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Patrón de cuotas (regex, opcional)</Label>
+          <Input
+            placeholder="ej. \d+/\d+"
+            value={config.installmentsPattern ?? ''}
+            onChange={(e) =>
+              updateConfig('installmentsPattern', e.target.value === '' ? undefined : e.target.value)
+            }
+          />
         </div>
       </div>
       <div className="flex justify-end gap-2">
@@ -213,10 +268,115 @@ function TemplateForm({
           Cancelar
         </Button>
         <Button type="submit" size="sm" disabled={saving}>
-          {saving ? 'Guardando...' : 'Guardar plantilla'}
+          {saving ? 'Guardando...' : initial ? 'Guardar cambios' : 'Guardar plantilla'}
         </Button>
       </div>
     </form>
+  );
+}
+
+function ImportTemplateFile({
+  creditCardId,
+  isAdmin,
+  onSaved,
+  onCancel,
+}: {
+  creditCardId: string;
+  isAdmin?: boolean;
+  onSaved: (savedName: string) => void;
+  onCancel: () => void;
+}) {
+  const [templateFile, setTemplateFile] = useState<File | null>(null);
+  const [templateName, setTemplateName] = useState('');
+  const [isSystem, setIsSystem] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0] ?? null;
+    setTemplateFile(f);
+    if (f) {
+      try {
+        const parsed = JSON.parse(await f.text());
+        if (typeof parsed.name === 'string') setTemplateName(parsed.name);
+        else setTemplateName((prev) => prev || f.name.replace(/\.[^.]+$/, ''));
+        if (typeof parsed.isSystem === 'boolean') setIsSystem(parsed.isSystem);
+      } catch {
+        setTemplateName((prev) => prev || f.name.replace(/\.[^.]+$/, ''));
+      }
+    }
+  };
+
+  const handleSave = async () => {
+    if (!templateFile || !templateName) return;
+    setSaving(true);
+    try {
+      const text = await templateFile.text();
+      const parsed = JSON.parse(text);
+      let configJson: string;
+      if (typeof parsed.configJson === 'string') {
+        configJson = parsed.configJson;
+      } else if (parsed.configJson && typeof parsed.configJson === 'object') {
+        configJson = JSON.stringify(parsed.configJson);
+      } else if (parsed.config && typeof parsed.config === 'object') {
+        configJson = JSON.stringify(parsed.config);
+      } else {
+        configJson = JSON.stringify(parsed);
+      }
+      const res = await fetch(String(urls.creditCardStatementImportTemplates.endpoint), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: templateName, isSystem, configJson, creditCardId }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      onSaved(templateName);
+    } catch (err) {
+      alert(`Error al importar plantilla: ${err}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label className="block mb-1">Archivo de plantilla (.json)</Label>
+        <Input type="file" accept=".json" onChange={handleFileChange} />
+      </div>
+      {templateFile && (
+        <>
+          <div>
+            <Label className="block mb-1">Nombre</Label>
+            <Input
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              required
+            />
+          </div>
+          {isAdmin && (
+            <Label className="flex items-center gap-2 text-sm cursor-pointer font-normal">
+              <Checkbox
+                checked={isSystem}
+                onCheckedChange={(checked) => setIsSystem(checked)}
+              />
+              Plantilla del sistema
+            </Label>
+          )}
+        </>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          disabled={!templateFile || !templateName || saving}
+          onClick={handleSave}
+        >
+          {saving ? 'Guardando...' : 'Guardar plantilla'}
+        </Button>
+      </div>
+    </div>
   );
 }
 
@@ -242,7 +402,7 @@ export default function ImportStatementModal({
   const [file, setFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [currencies, setCurrencies] = useState<CatalogItem[]>([]);
-  const [showTemplateForm, setShowTemplateForm] = useState(false);
+  const [templateMode, setTemplateMode] = useState<TemplateMode>('select');
   const [editingTemplate, setEditingTemplate] = useState<CreditCardStatementImportTemplate | null>(null);
   const [otherTemplates, setOtherTemplates] = useState<CreditCardStatementImportTemplate[]>([]);
 
@@ -255,31 +415,58 @@ export default function ImportStatementModal({
       ]);
       const cardData = await cardRes.json();
       const allData = await allRes.json();
-      const cardTemplates: CreditCardStatementImportTemplate[] = Array.isArray(cardData) ? cardData : (cardData.items ?? []);
-      const allList: CreditCardStatementImportTemplate[] = Array.isArray(allData) ? allData : (allData.items ?? []);
+      const cardTemplates: CreditCardStatementImportTemplate[] = Array.isArray(cardData)
+        ? cardData
+        : (cardData.items ?? []);
+      const allList: CreditCardStatementImportTemplate[] = Array.isArray(allData)
+        ? allData
+        : (allData.items ?? []);
       const cardIds = new Set(cardTemplates.map((t) => t.id));
       setTemplates(cardTemplates);
       setOtherTemplates(allList.filter((t) => !t.isSystem && !cardIds.has(t.id)));
+      return cardTemplates;
     } catch {
       setTemplates([]);
       setOtherTemplates([]);
+      return [];
     }
   }, [creditCardId]);
 
   useEffect(() => {
-    if (show && defaultTemplateId) {
-      setSelectedTemplateId(defaultTemplateId);
-    }
-  }, [show, defaultTemplateId]);
-
-  useEffect(() => {
     if (!show) return;
-    loadTemplates();
+    setTemplateMode('select');
+    setEditingTemplate(null);
+    loadTemplates().then((loaded) => {
+      setSelectedTemplateId((current) => {
+        if (current && loaded.some((t) => t.id === current)) return current;
+        if (defaultTemplateId && loaded.some((t) => t.id === defaultTemplateId)) return defaultTemplateId;
+        if (loaded.length === 1) return loaded[0].id;
+        return '';
+      });
+    });
     fetch(String(urls.catalog.currencies.endpoint))
       .then((r) => r.json())
       .then((data: CatalogItem[]) => setCurrencies(data))
       .catch(() => {});
-  }, [show, loadTemplates]);
+  }, [show, loadTemplates, defaultTemplateId]);
+
+  const handleTemplateSaved = async (savedName: string) => {
+    const reloaded = await loadTemplates();
+    const found = reloaded.find((t) => t.name === savedName);
+    if (found) setSelectedTemplateId(found.id);
+    setTemplateMode('select');
+    setEditingTemplate(null);
+  };
+
+  const handleSwitchMode = (mode: TemplateMode) => {
+    setTemplateMode(mode);
+    if (mode !== 'create') setEditingTemplate(null);
+  };
+
+  const handleEditTemplate = (t: CreditCardStatementImportTemplate) => {
+    setEditingTemplate(t);
+    setTemplateMode('create');
+  };
 
   const handleAssociateTemplate = async (templateId: string) => {
     try {
@@ -396,114 +583,122 @@ export default function ImportStatementModal({
 
             <Separator />
 
-            <div>
-              <div className="flex items-center justify-between mb-3">
-                <p className="text-sm font-medium">Plantilla de importación</p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => { setEditingTemplate(null); setShowTemplateForm(true); }}
-                >
-                  + Nueva plantilla
-                </Button>
-              </div>
+            <div className="space-y-3">
+              <p className="text-sm font-medium">Plantilla de importación</p>
+              <ModeSwitcher mode={templateMode} onChange={handleSwitchMode} />
 
-              {showTemplateForm && (
-                <div className="mb-4">
-                  <TemplateForm
-                    initial={editingTemplate}
-                    currencies={currencies}
-                    creditCardId={creditCardId}
-                    isAdmin={isAdmin}
-                    onSave={async () => { await loadTemplates(); setShowTemplateForm(false); setEditingTemplate(null); }}
-                    onCancel={() => { setShowTemplateForm(false); setEditingTemplate(null); }}
-                  />
+              {templateMode === 'select' && (
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    {templates.length === 0 && (
+                      <p className="text-sm text-muted-foreground">
+                        No hay plantillas disponibles. Creá una nueva o importá un archivo.
+                      </p>
+                    )}
+                    {templates.map((t) => (
+                      <div
+                        key={t.id}
+                        role="button"
+                        tabIndex={0}
+                        className={`flex items-center justify-between px-3 py-2 rounded-md border cursor-pointer text-sm transition-colors ${
+                          selectedTemplateId === t.id
+                            ? 'border-primary bg-primary/10'
+                            : 'hover:bg-muted'
+                        }`}
+                        onClick={() => setSelectedTemplateId(t.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') setSelectedTemplateId(t.id);
+                        }}
+                      >
+                        <div className="flex items-center gap-2">
+                          <span>{t.name}</span>
+                          {t.isSystem && (
+                            <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                              Sistema
+                            </span>
+                          )}
+                        </div>
+                        {!t.isSystem && (
+                          <div className="flex gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 px-2 text-xs"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleEditTemplate(t);
+                              }}
+                            >
+                              Editar
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteTemplate(t.id);
+                              }}
+                            >
+                              ×
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+
+                  {otherTemplates.length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+                        Otras plantillas disponibles
+                      </p>
+                      <div className="space-y-1">
+                        {otherTemplates.map((t) => (
+                          <div
+                            key={t.id}
+                            className="flex items-center justify-between px-3 py-2 rounded-md border text-sm bg-muted/20"
+                          >
+                            <span>{t.name}</span>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-6 px-2 text-xs"
+                              onClick={() => handleAssociateTemplate(t.id)}
+                            >
+                              Usar
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 
-              <div className="space-y-1">
-                {templates.length === 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    No hay plantillas disponibles. Creá una nueva.
-                  </p>
-                )}
-                {templates.map((t) => (
-                  <div
-                    key={t.id}
-                    role="button"
-                    tabIndex={0}
-                    className={`flex items-center justify-between px-3 py-2 rounded-md border cursor-pointer text-sm transition-colors ${
-                      selectedTemplateId === t.id
-                        ? 'border-primary bg-primary/10'
-                        : 'hover:bg-muted'
-                    }`}
-                    onClick={() => setSelectedTemplateId(t.id)}
-                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedTemplateId(t.id); }}
-                  >
-                    <div className="flex items-center gap-2">
-                      <span>{t.name}</span>
-                      {t.isSystem && (
-                        <span className="text-xs bg-muted px-1.5 py-0.5 rounded">Sistema</span>
-                      )}
-                    </div>
-                    {!t.isSystem && (
-                      <div className="flex gap-1">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-2 text-xs"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setEditingTemplate(t);
-                            setShowTemplateForm(true);
-                          }}
-                        >
-                          Editar
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-                          onClick={(e) => { e.stopPropagation(); handleDeleteTemplate(t.id); }}
-                        >
-                          ×
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
+              {templateMode === 'import-file' && (
+                <ImportTemplateFile
+                  creditCardId={creditCardId}
+                  isAdmin={isAdmin}
+                  onSaved={handleTemplateSaved}
+                  onCancel={() => setTemplateMode('select')}
+                />
+              )}
 
-            {otherTemplates.length > 0 && (
-              <div>
-                <p className="text-sm font-medium mb-2 text-muted-foreground">
-                  Otras plantillas disponibles
-                </p>
-                <div className="space-y-1">
-                  {otherTemplates.map((t) => (
-                    <div
-                      key={t.id}
-                      className="flex items-center justify-between px-3 py-2 rounded-md border text-sm bg-muted/20"
-                    >
-                      <span>{t.name}</span>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-6 px-2 text-xs"
-                        onClick={() => handleAssociateTemplate(t.id)}
-                      >
-                        Usar
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
+              {templateMode === 'create' && (
+                <TemplateForm
+                  initial={editingTemplate}
+                  currencies={currencies}
+                  creditCardId={creditCardId}
+                  isAdmin={isAdmin}
+                  onSave={handleTemplateSaved}
+                  onCancel={() => handleSwitchMode('select')}
+                />
+              )}
+            </div>
 
             <Separator />
 

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
@@ -717,12 +717,12 @@ export default function ImportStatementModal({
 
             <div>
               <Label htmlFor="import-file" className="block mb-2">
-                Archivo (.xls, .xlsx, .csv)
+                Archivo (.xls, .xlsx, .csv, .pdf)
               </Label>
               <Input
                 id="import-file"
                 type="file"
-                accept=".xls,.xlsx,.csv"
+                accept=".xls,.xlsx,.csv,.pdf"
                 required
                 onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               />

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
@@ -34,12 +34,14 @@ function TemplateForm({
   initial,
   currencies,
   creditCardId,
+  isAdmin,
   onSave,
   onCancel,
 }: {
   initial?: CreditCardStatementImportTemplate | null;
   currencies: CatalogItem[];
   creditCardId?: string;
+  isAdmin?: boolean;
   onSave: () => void;
   onCancel: () => void;
 }) {
@@ -92,16 +94,18 @@ function TemplateForm({
           <Label className="block mb-1">Nombre</Label>
           <Input value={name} onChange={(e) => setName(e.target.value)} required />
         </div>
-        <div className="flex items-end gap-2">
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
-              checked={isSystem}
-              onChange={(e) => setIsSystem(e.target.checked)}
-            />
-            Plantilla del sistema
-          </label>
-        </div>
+        {isAdmin && (
+          <div className="flex items-end gap-2">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={isSystem}
+                onChange={(e) => setIsSystem(e.target.checked)}
+              />
+              Plantilla del sistema
+            </label>
+          </div>
+        )}
       </div>
       <Separator />
       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -221,12 +225,14 @@ export default function ImportStatementModal({
   onHide,
   creditCardId,
   defaultTemplateId,
+  isAdmin,
   onImported,
 }: {
   show: boolean;
   onHide: () => void;
   creditCardId: string;
   defaultTemplateId: string | null;
+  isAdmin?: boolean;
   onImported: () => void;
 }) {
   const [closureDate, setClosureDate] = useState('');
@@ -409,6 +415,7 @@ export default function ImportStatementModal({
                     initial={editingTemplate}
                     currencies={currencies}
                     creditCardId={creditCardId}
+                    isAdmin={isAdmin}
                     onSave={async () => { await loadTemplates(); setShowTemplateForm(false); setEditingTemplate(null); }}
                     onCancel={() => { setShowTemplateForm(false); setEditingTemplate(null); }}
                   />

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
@@ -18,6 +18,7 @@ import type {
   StatementImportConfig,
 } from '@/types/creditCardStatementImportTemplate';
 import type { CatalogItem } from '@/types/catalog';
+import type { CreditCardStatement } from '@/types/creditCard';
 
 type TemplateMode = 'select' | 'import-file' | 'create';
 
@@ -386,6 +387,7 @@ export default function ImportStatementModal({
   creditCardId,
   defaultTemplateId,
   isAdmin,
+  statements,
   onImported,
 }: {
   show: boolean;
@@ -393,6 +395,7 @@ export default function ImportStatementModal({
   creditCardId: string;
   defaultTemplateId: string | null;
   isAdmin?: boolean;
+  statements: CreditCardStatement[];
   onImported: () => void;
 }) {
   const [closureDate, setClosureDate] = useState('');
@@ -504,22 +507,32 @@ export default function ImportStatementModal({
 
     setSubmitting(true);
     try {
-      const stmtRes = await fetch(String(urls.creditCardStatements.endpoint), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          creditCardId,
-          closureDate: new Date(closureDate).toISOString(),
-          expiringDate: new Date(expiringDate).toISOString(),
-        }),
-      });
-      if (!stmtRes.ok) throw new Error(`Error creando resúmen: ${await stmtRes.text()}`);
-      const stmt = await stmtRes.json();
+      const existing = statements.find(
+        (s) => s.closureDate.slice(0, 10) === closureDate && s.expiringDate.slice(0, 10) === expiringDate
+      );
+
+      let stmtId: string;
+      if (existing) {
+        stmtId = existing.id;
+      } else {
+        const stmtRes = await fetch(String(urls.creditCardStatements.endpoint), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            creditCardId,
+            closureDate: new Date(closureDate).toISOString(),
+            expiringDate: new Date(expiringDate).toISOString(),
+          }),
+        });
+        if (!stmtRes.ok) throw new Error(`Error creando resúmen: ${await stmtRes.text()}`);
+        const stmt = await stmtRes.json();
+        stmtId = stmt.id;
+      }
 
       const form = new FormData();
       form.append('file', file);
       form.append('templateId', selectedTemplateId);
-      form.append('statementId', stmt.id);
+      form.append('statementId', stmtId);
 
       const importRes = await fetch(String(urls.creditCardStatements.import), {
         method: 'POST',

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
@@ -19,6 +19,7 @@ import type { CatalogItem } from '@/types/catalog';
 
 const DEFAULT_CONFIG: StatementImportConfig = {
   skipRows: 1,
+  skipLastRows: 0,
   dateColumn: 0,
   dateFormat: 'd/M/yyyy',
   conceptColumn: 1,
@@ -32,11 +33,13 @@ const DEFAULT_CONFIG: StatementImportConfig = {
 function TemplateForm({
   initial,
   currencies,
+  creditCardId,
   onSave,
   onCancel,
 }: {
   initial?: CreditCardStatementImportTemplate | null;
   currencies: CatalogItem[];
+  creditCardId?: string;
   onSave: () => void;
   onCancel: () => void;
 }) {
@@ -65,7 +68,9 @@ function TemplateForm({
     try {
       const body = { name, isSystem, configJson: JSON.stringify(config) };
       const method = initial ? 'PUT' : 'POST';
-      const payload = initial ? { id: initial.id, ...body } : body;
+      const payload = initial
+        ? { id: initial.id, ...body }
+        : { ...body, creditCardId: creditCardId ?? null };
       const res = await fetch(String(urls.creditCardStatementImportTemplates.endpoint), {
         method,
         headers: { 'Content-Type': 'application/json' },
@@ -104,12 +109,21 @@ function TemplateForm({
       </p>
       <div className="grid grid-cols-3 gap-3">
         <div>
-          <Label className="block mb-1 text-sm">Filas a omitir</Label>
+          <Label className="block mb-1 text-sm">Filas a omitir (inicio)</Label>
           <Input
             type="number"
             min={0}
             value={config.skipRows}
             onChange={(e) => updateConfig('skipRows', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Filas a omitir (final)</Label>
+          <Input
+            type="number"
+            min={0}
+            value={config.skipLastRows}
+            onChange={(e) => updateConfig('skipLastRows', Number(e.target.value))}
           />
         </div>
         <div>
@@ -224,16 +238,27 @@ export default function ImportStatementModal({
   const [currencies, setCurrencies] = useState<CatalogItem[]>([]);
   const [showTemplateForm, setShowTemplateForm] = useState(false);
   const [editingTemplate, setEditingTemplate] = useState<CreditCardStatementImportTemplate | null>(null);
+  const [otherTemplates, setOtherTemplates] = useState<CreditCardStatementImportTemplate[]>([]);
 
   const loadTemplates = useCallback(async () => {
     try {
-      const res = await fetch(String(urls.creditCardStatementImportTemplates.endpoint));
-      const data = await res.json();
-      setTemplates(Array.isArray(data) ? data : (data.items ?? []));
+      const cardUrl = `${urls.creditCardStatementImportTemplates.endpoint}?creditCardId=${creditCardId}`;
+      const [cardRes, allRes] = await Promise.all([
+        fetch(cardUrl),
+        fetch(String(urls.creditCardStatementImportTemplates.endpoint)),
+      ]);
+      const cardData = await cardRes.json();
+      const allData = await allRes.json();
+      const cardTemplates: CreditCardStatementImportTemplate[] = Array.isArray(cardData) ? cardData : (cardData.items ?? []);
+      const allList: CreditCardStatementImportTemplate[] = Array.isArray(allData) ? allData : (allData.items ?? []);
+      const cardIds = new Set(cardTemplates.map((t) => t.id));
+      setTemplates(cardTemplates);
+      setOtherTemplates(allList.filter((t) => !t.isSystem && !cardIds.has(t.id)));
     } catch {
       setTemplates([]);
+      setOtherTemplates([]);
     }
-  }, []);
+  }, [creditCardId]);
 
   useEffect(() => {
     if (show && defaultTemplateId) {
@@ -249,6 +274,20 @@ export default function ImportStatementModal({
       .then((data: CatalogItem[]) => setCurrencies(data))
       .catch(() => {});
   }, [show, loadTemplates]);
+
+  const handleAssociateTemplate = async (templateId: string) => {
+    try {
+      await fetch(String(urls.creditCardStatementImportTemplates.associate(templateId)), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ creditCardId }),
+      });
+      await loadTemplates();
+      setSelectedTemplateId(templateId);
+    } catch (err) {
+      alert(`Error al asociar plantilla: ${err}`);
+    }
+  };
 
   const handleDeleteTemplate = async (id: string) => {
     if (!confirm('¿Eliminar esta plantilla?')) return;
@@ -369,6 +408,7 @@ export default function ImportStatementModal({
                   <TemplateForm
                     initial={editingTemplate}
                     currencies={currencies}
+                    creditCardId={creditCardId}
                     onSave={async () => { await loadTemplates(); setShowTemplateForm(false); setEditingTemplate(null); }}
                     onCancel={() => { setShowTemplateForm(false); setEditingTemplate(null); }}
                   />
@@ -430,6 +470,33 @@ export default function ImportStatementModal({
                 ))}
               </div>
             </div>
+
+            {otherTemplates.length > 0 && (
+              <div>
+                <p className="text-sm font-medium mb-2 text-muted-foreground">
+                  Otras plantillas disponibles
+                </p>
+                <div className="space-y-1">
+                  {otherTemplates.map((t) => (
+                    <div
+                      key={t.id}
+                      className="flex items-center justify-between px-3 py-2 rounded-md border text-sm bg-muted/20"
+                    >
+                      <span>{t.name}</span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={() => handleAssociateTemplate(t.id)}
+                      >
+                        Usar
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
 
             <Separator />
 

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/ImportStatementModal.tsx
@@ -1,0 +1,463 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/shadcn/button';
+import { Input } from '@/components/ui/shadcn/input';
+import { Label } from '@/components/ui/shadcn/label';
+import { Separator } from '@/components/ui/shadcn/separator';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalBody,
+  ModalFooter,
+} from '@/components/ui/utils/Modal';
+import urls from '@/utils/urls';
+import type {
+  CreditCardStatementImportTemplate,
+  StatementImportConfig,
+} from '@/types/creditCardStatementImportTemplate';
+import type { CatalogItem } from '@/types/catalog';
+
+const DEFAULT_CONFIG: StatementImportConfig = {
+  skipRows: 1,
+  dateColumn: 0,
+  dateFormat: 'd/M/yyyy',
+  conceptColumn: 1,
+  amountColumn: 2,
+  defaultCurrencyId: '',
+  decimalSeparator: ',',
+  thousandsSeparator: '.',
+  amountNegate: false,
+};
+
+function TemplateForm({
+  initial,
+  currencies,
+  onSave,
+  onCancel,
+}: {
+  initial?: CreditCardStatementImportTemplate | null;
+  currencies: CatalogItem[];
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [isSystem, setIsSystem] = useState(initial?.isSystem ?? false);
+  const [config, setConfig] = useState<StatementImportConfig>(() => {
+    if (initial?.configJson) {
+      try {
+        return JSON.parse(initial.configJson) as StatementImportConfig;
+      } catch {
+        return { ...DEFAULT_CONFIG };
+      }
+    }
+    return { ...DEFAULT_CONFIG };
+  });
+  const [saving, setSaving] = useState(false);
+
+  const updateConfig = <K extends keyof StatementImportConfig>(
+    key: K,
+    value: StatementImportConfig[K]
+  ) => setConfig((prev) => ({ ...prev, [key]: value }));
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const body = { name, isSystem, configJson: JSON.stringify(config) };
+      const method = initial ? 'PUT' : 'POST';
+      const payload = initial ? { id: initial.id, ...body } : body;
+      const res = await fetch(String(urls.creditCardStatementImportTemplates.endpoint), {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      onSave();
+    } catch (err) {
+      alert(`Error al guardar plantilla: ${err}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSave} className="space-y-4 border rounded-md p-4 bg-muted/30">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label className="block mb-1">Nombre</Label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
+        <div className="flex items-end gap-2">
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isSystem}
+              onChange={(e) => setIsSystem(e.target.checked)}
+            />
+            Plantilla del sistema
+          </label>
+        </div>
+      </div>
+      <Separator />
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Configuración de columnas (índice 0 = primera columna)
+      </p>
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <Label className="block mb-1 text-sm">Filas a omitir</Label>
+          <Input
+            type="number"
+            min={0}
+            value={config.skipRows}
+            onChange={(e) => updateConfig('skipRows', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Col. Fecha</Label>
+          <Input
+            type="number"
+            min={0}
+            value={config.dateColumn}
+            onChange={(e) => updateConfig('dateColumn', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Formato fecha</Label>
+          <Input
+            value={config.dateFormat}
+            onChange={(e) => updateConfig('dateFormat', e.target.value)}
+            placeholder="d/M/yyyy"
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Col. Concepto</Label>
+          <Input
+            type="number"
+            min={0}
+            value={config.conceptColumn}
+            onChange={(e) => updateConfig('conceptColumn', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Col. Monto</Label>
+          <Input
+            type="number"
+            min={0}
+            value={config.amountColumn}
+            onChange={(e) => updateConfig('amountColumn', Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Moneda por defecto</Label>
+          <select
+            value={config.defaultCurrencyId}
+            onChange={(e) => updateConfig('defaultCurrencyId', e.target.value)}
+            className="h-9 w-full text-sm rounded-md border border-input bg-background px-2"
+            required
+          >
+            <option value="">Seleccionar...</option>
+            {currencies.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Sep. decimal</Label>
+          <Input
+            value={config.decimalSeparator}
+            maxLength={1}
+            onChange={(e) => updateConfig('decimalSeparator', e.target.value)}
+          />
+        </div>
+        <div>
+          <Label className="block mb-1 text-sm">Sep. miles</Label>
+          <Input
+            value={config.thousandsSeparator}
+            maxLength={1}
+            onChange={(e) => updateConfig('thousandsSeparator', e.target.value)}
+          />
+        </div>
+        <div className="flex items-end pb-1">
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={config.amountNegate}
+              onChange={(e) => updateConfig('amountNegate', e.target.checked)}
+            />
+            Invertir signo
+          </label>
+        </div>
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button type="submit" size="sm" disabled={saving}>
+          {saving ? 'Guardando...' : 'Guardar plantilla'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default function ImportStatementModal({
+  show,
+  onHide,
+  creditCardId,
+  defaultTemplateId,
+  onImported,
+}: {
+  show: boolean;
+  onHide: () => void;
+  creditCardId: string;
+  defaultTemplateId: string | null;
+  onImported: () => void;
+}) {
+  const [closureDate, setClosureDate] = useState('');
+  const [expiringDate, setExpiringDate] = useState('');
+  const [templates, setTemplates] = useState<CreditCardStatementImportTemplate[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [currencies, setCurrencies] = useState<CatalogItem[]>([]);
+  const [showTemplateForm, setShowTemplateForm] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<CreditCardStatementImportTemplate | null>(null);
+
+  const loadTemplates = useCallback(async () => {
+    try {
+      const res = await fetch(String(urls.creditCardStatementImportTemplates.endpoint));
+      const data = await res.json();
+      setTemplates(Array.isArray(data) ? data : (data.items ?? []));
+    } catch {
+      setTemplates([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (show && defaultTemplateId) {
+      setSelectedTemplateId(defaultTemplateId);
+    }
+  }, [show, defaultTemplateId]);
+
+  useEffect(() => {
+    if (!show) return;
+    loadTemplates();
+    fetch(String(urls.catalog.currencies.endpoint))
+      .then((r) => r.json())
+      .then((data: CatalogItem[]) => setCurrencies(data))
+      .catch(() => {});
+  }, [show, loadTemplates]);
+
+  const handleDeleteTemplate = async (id: string) => {
+    if (!confirm('¿Eliminar esta plantilla?')) return;
+    try {
+      await fetch(String(urls.creditCardStatementImportTemplates.endpoint), {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: [id] }),
+      });
+      await loadTemplates();
+      if (selectedTemplateId === id) setSelectedTemplateId('');
+    } catch (err) {
+      alert(`Error al eliminar plantilla: ${err}`);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) { alert('Seleccioná un archivo'); return; }
+    if (!selectedTemplateId) { alert('Seleccioná una plantilla'); return; }
+
+    setSubmitting(true);
+    try {
+      const stmtRes = await fetch(String(urls.creditCardStatements.endpoint), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          creditCardId,
+          closureDate: new Date(closureDate).toISOString(),
+          expiringDate: new Date(expiringDate).toISOString(),
+        }),
+      });
+      if (!stmtRes.ok) throw new Error(`Error creando resúmen: ${await stmtRes.text()}`);
+      const stmt = await stmtRes.json();
+
+      const form = new FormData();
+      form.append('file', file);
+      form.append('templateId', selectedTemplateId);
+      form.append('statementId', stmt.id);
+
+      const importRes = await fetch(String(urls.creditCardStatements.import), {
+        method: 'POST',
+        body: form,
+      });
+      if (!importRes.ok) throw new Error(`Error importando: ${await importRes.text()}`);
+
+      if (selectedTemplateId !== defaultTemplateId) {
+        await fetch(String(urls.creditCards.defaultImportTemplate(creditCardId)), {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ templateId: selectedTemplateId }),
+        }).catch(() => {});
+      }
+
+      onHide();
+      onImported();
+    } catch (err) {
+      alert(`${err}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} size="4xl">
+      <form onSubmit={handleSubmit}>
+        <ModalHeader closeButton>
+          <ModalTitle>
+            <h3 className="text-lg font-medium">Importar Resúmen desde archivo</h3>
+          </ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          <div className="space-y-5">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="import-closure-date" className="block mb-2">
+                  Fecha de Cierre
+                </Label>
+                <Input
+                  id="import-closure-date"
+                  type="date"
+                  required
+                  value={closureDate}
+                  onChange={(e) => setClosureDate(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="import-expiring-date" className="block mb-2">
+                  Fecha de Vencimiento
+                </Label>
+                <Input
+                  id="import-expiring-date"
+                  type="date"
+                  required
+                  value={expiringDate}
+                  onChange={(e) => setExpiringDate(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <Separator />
+
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <p className="text-sm font-medium">Plantilla de importación</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => { setEditingTemplate(null); setShowTemplateForm(true); }}
+                >
+                  + Nueva plantilla
+                </Button>
+              </div>
+
+              {showTemplateForm && (
+                <div className="mb-4">
+                  <TemplateForm
+                    initial={editingTemplate}
+                    currencies={currencies}
+                    onSave={async () => { await loadTemplates(); setShowTemplateForm(false); setEditingTemplate(null); }}
+                    onCancel={() => { setShowTemplateForm(false); setEditingTemplate(null); }}
+                  />
+                </div>
+              )}
+
+              <div className="space-y-1">
+                {templates.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    No hay plantillas disponibles. Creá una nueva.
+                  </p>
+                )}
+                {templates.map((t) => (
+                  <div
+                    key={t.id}
+                    role="button"
+                    tabIndex={0}
+                    className={`flex items-center justify-between px-3 py-2 rounded-md border cursor-pointer text-sm transition-colors ${
+                      selectedTemplateId === t.id
+                        ? 'border-primary bg-primary/10'
+                        : 'hover:bg-muted'
+                    }`}
+                    onClick={() => setSelectedTemplateId(t.id)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedTemplateId(t.id); }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span>{t.name}</span>
+                      {t.isSystem && (
+                        <span className="text-xs bg-muted px-1.5 py-0.5 rounded">Sistema</span>
+                      )}
+                    </div>
+                    {!t.isSystem && (
+                      <div className="flex gap-1">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-xs"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setEditingTemplate(t);
+                            setShowTemplateForm(true);
+                          }}
+                        >
+                          Editar
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+                          onClick={(e) => { e.stopPropagation(); handleDeleteTemplate(t.id); }}
+                        >
+                          ×
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <Separator />
+
+            <div>
+              <Label htmlFor="import-file" className="block mb-2">
+                Archivo (.xls, .xlsx, .csv)
+              </Label>
+              <Input
+                id="import-file"
+                type="file"
+                accept=".xls,.xlsx,.csv"
+                required
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              />
+            </div>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <div className="flex justify-end space-x-2 mt-6">
+            <Button type="button" variant="outline" onClick={onHide}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Importando...' : 'Importar'}
+            </Button>
+          </div>
+        </ModalFooter>
+      </form>
+    </Modal>
+  );
+}

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/CreditCards/index.tsx
@@ -10,6 +10,11 @@ import {
 import { Separator } from '@/components/ui/shadcn/separator';
 import type { CreditCard, CreditCardsData } from '@/types/creditCard';
 
+const formatDate = (dateStr: string) => {
+  const [y, m, d] = dateStr.slice(0, 10).split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString();
+};
+
 function CreditCardList({
   creditCards,
   onSelectCard,
@@ -50,7 +55,7 @@ function CreditCardList({
                 <TableCell>{card.bank?.name ?? '-'}</TableCell>
                 <TableCell className="text-right">
                   {card.creditCardStatement
-                    ? new Date(card.creditCardStatement.closureDate).toLocaleDateString('es-AR')
+                    ? formatDate(card.creditCardStatement.closureDate)
                     : '-'}
                 </TableCell>
               </TableRow>

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -164,7 +164,7 @@ export default function Dashboard() {
                               const total = rows.reduce((acc, r) => {
                                 return acc + getSafeValueFrom(r, 'convertedAmount');
                               }, 0);
-                              return `${data.name}: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
+                              return `${data.name} ${data.bank?.name}: ${defaultCurrencySymbol}${moneyFormatter(total)}`;
                             }
                           }}
                         />

--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Navigation/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Navigation/index.tsx
@@ -24,13 +24,13 @@ const NavLink = ({ text, link }: { text: string; link: string }) => {
 
 export default function Navigation() {
     const [isDarkMode, setIsDarkMode] = useState(false);
+    const location = useLocation();
 
     useEffect(() => {
-        // Check localStorage and current document state for dark mode
-        const storedTheme = localStorage.getItem('theme');
-        const isDark = storedTheme === 'dark' || document.documentElement.classList.contains('dark');
+        const isDark = localStorage.getItem('theme') === 'dark';
         setIsDarkMode(isDark);
-    }, []);
+        document.documentElement.classList.toggle('dark', isDark);
+    }, [location.pathname]);
 
     const toggleDarkMode = () => {
         const newDarkMode = !isDarkMode;

--- a/FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/BackendClient.ts
@@ -14,6 +14,7 @@ import { CurrencyExchangeRatesQuery } from "./queries/CurrencyExchangeRatesQuery
 import { DebitsQuery } from "./queries/DebitsQuery";
 import { PaginatedDebitsQuery } from "./queries/PaginatedDebitsQuery";
 import { PaginatedSubscriptionsQuery } from "./queries/PaginatedSubscriptionsQuery";
+import { SessionQuery } from "./queries/SessionQuery";
 
 const httpsAgent = new Agent({ rejectUnauthorized: false });
 
@@ -33,6 +34,7 @@ export class BackendClient {
     private CurrenciesQuery: CurrenciesQuery;
     private FrequenciesQuery: FrequenciesQuery;
     private CurrencyExchangeRatesQuery: CurrencyExchangeRatesQuery;
+    private SessionQuery: SessionQuery;
 
     constructor(accessToken: string) {
         this.HttpsAgent = httpsAgent;
@@ -71,6 +73,7 @@ export class BackendClient {
             httpsAgent,
             this.AccessToken
         );
+        this.SessionQuery = new SessionQuery(httpsAgent, this.AccessToken);
     }
 
     public GetBanksQuery = (): BanksQuery => this.BanksQuery;
@@ -88,6 +91,7 @@ export class BackendClient {
     public GetFrequenciesQuery = (): FrequenciesQuery => this.FrequenciesQuery;
     public GetCurrencyExchangeRatesQuery = (): CurrencyExchangeRatesQuery =>
         this.CurrencyExchangeRatesQuery;
+    public GetSessionQuery = (): SessionQuery => this.SessionQuery;
 
     async get<TFilter>(endpoint: string, filters?: TFilter) {
         try {

--- a/FinanceFrontEnd/FinanceApp/app/data/queries/SessionQuery.ts
+++ b/FinanceFrontEnd/FinanceApp/app/data/queries/SessionQuery.ts
@@ -1,0 +1,19 @@
+import urls from "@/utils/urls";
+import { Agent } from "https";
+import { BaseQuery } from "../base/BaseQuery";
+
+export interface SessionInfo {
+  userId: string;
+  fullName: string;
+  username: string;
+  sourceId: string;
+  roles: string[];
+}
+
+export class SessionQuery extends BaseQuery {
+  constructor(httpsAgent: Agent, accessToken: string) {
+    super(httpsAgent, accessToken, {
+      get: urls.session.me,
+    });
+  }
+}

--- a/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.statement.$id.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.statement.$id.tsx
@@ -2,17 +2,24 @@ import { LoaderFunctionArgs, redirect } from 'react-router';
 import { getBackendClient } from '@/data/getBackendClient';
 import { requireAuth } from '@/services/auth/session.server';
 import type { CreditCard } from '@/types/creditCard';
+import type { SessionInfo } from '@/data/queries/SessionQuery';
 import CreditCardDetail from '@/components/ui/CreditCards/CreditCardDetail';
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const user = await requireAuth(request);
   const client = await getBackendClient(user.accessToken!);
 
-  const cards = (await client.GetCreditCardsQuery().get()) as CreditCard[];
+  const [cards, session] = await Promise.all([
+    client.GetCreditCardsQuery().get() as Promise<CreditCard[]>,
+    client.GetSessionQuery().get<void>().catch(() => null) as Promise<SessionInfo | null>,
+  ]);
+
   const card = cards.find((c) => c.id === params.id);
   if (!card) return redirect('/credit-cards');
 
-  return { card, cards };
+  const isAdmin = session?.roles?.includes('Admin') ?? false;
+
+  return { card, cards, isAdmin };
 };
 
 export const meta = ({ data }: { data: { card: CreditCard } | undefined }) => {

--- a/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.statement.$id.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/routes/credit-cards.statement.$id.tsx
@@ -3,23 +3,29 @@ import { getBackendClient } from '@/data/getBackendClient';
 import { requireAuth } from '@/services/auth/session.server';
 import type { CreditCard } from '@/types/creditCard';
 import type { SessionInfo } from '@/data/queries/SessionQuery';
+import { CURRENCY_IDS } from '@/utils/currency.constants';
 import CreditCardDetail from '@/components/ui/CreditCards/CreditCardDetail';
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const user = await requireAuth(request);
   const client = await getBackendClient(user.accessToken!);
 
-  const [cards, session] = await Promise.all([
+  const [cards, session, currencyResult] = await Promise.all([
     client.GetCreditCardsQuery().get() as Promise<CreditCard[]>,
     client.GetSessionQuery().get<void>().catch(() => null) as Promise<SessionInfo | null>,
+    client.GetCurrenciesQuery().getById(CURRENCY_IDS.ARS).catch(() => null),
   ]);
 
   const card = cards.find((c) => c.id === params.id);
   if (!card) return redirect('/credit-cards');
 
   const isAdmin = session?.roles?.includes('Admin') ?? false;
+  const symbol = (currencyResult as { defaultSymbol?: string } | null)?.defaultSymbol;
+  const defaultCurrency: { id: string; symbol: string } | null = symbol
+    ? { id: CURRENCY_IDS.ARS, symbol }
+    : null;
 
-  return { card, cards, isAdmin };
+  return { card, cards, isAdmin, defaultCurrency };
 };
 
 export const meta = ({ data }: { data: { card: CreditCard } | undefined }) => {

--- a/FinanceFrontEnd/FinanceApp/app/types/creditCard.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/creditCard.ts
@@ -9,6 +9,7 @@ export interface CreditCard {
   recordCount: number;
   creditCardStatement?: CreditCardStatement;
   deactivated: boolean;
+  defaultImportTemplateId?: string | null;
 }
 
 export interface CreditCardStatement {

--- a/FinanceFrontEnd/FinanceApp/app/types/creditCardStatementImportTemplate.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/creditCardStatementImportTemplate.ts
@@ -1,5 +1,6 @@
 export interface StatementImportConfig {
   skipRows: number;
+  skipLastRows: number;
   dateColumn: number;
   dateFormat: string;
   conceptColumn: number;

--- a/FinanceFrontEnd/FinanceApp/app/types/creditCardStatementImportTemplate.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/creditCardStatementImportTemplate.ts
@@ -1,0 +1,20 @@
+export interface StatementImportConfig {
+  skipRows: number;
+  dateColumn: number;
+  dateFormat: string;
+  conceptColumn: number;
+  amountColumn: number;
+  defaultCurrencyId: string;
+  decimalSeparator: string;
+  thousandsSeparator: string;
+  amountNegate: boolean;
+}
+
+export interface CreditCardStatementImportTemplate {
+  id: string;
+  name: string;
+  isSystem: boolean;
+  userId: string | null;
+  configJson: string;
+  deactivated: boolean;
+}

--- a/FinanceFrontEnd/FinanceApp/app/types/creditCardStatementImportTemplate.ts
+++ b/FinanceFrontEnd/FinanceApp/app/types/creditCardStatementImportTemplate.ts
@@ -9,6 +9,8 @@ export interface StatementImportConfig {
   decimalSeparator: string;
   thousandsSeparator: string;
   amountNegate: boolean;
+  installmentsColumn?: number;
+  installmentsPattern?: string;
 }
 
 export interface CreditCardStatementImportTemplate {

--- a/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
@@ -85,6 +85,9 @@ const urls = {
     get get() {
       return new BackendUrl(`${getApiBaseUrl()}/credit-cards/`);
     },
+    defaultImportTemplate(cardId: string) {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-cards/${cardId}/default-import-template`);
+    },
   },
   creditCardTransactions: {
     get endpoint() {
@@ -101,11 +104,19 @@ const urls = {
     get endpoint() {
       return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements`);
     },
+    get import() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements/import`);
+    },
     get latest() {
       return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements/latest`);
     },
     get paginated() {
       return new BackendUrl(`${getApiBaseUrl()}/credit-card-statements/paginated`);
+    },
+  },
+  creditCardStatementImportTemplates: {
+    get endpoint() {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statement-import-templates`);
     },
   },
   creditCardPayments: {

--- a/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
@@ -118,6 +118,9 @@ const urls = {
     get endpoint() {
       return new BackendUrl(`${getApiBaseUrl()}/credit-card-statement-import-templates`);
     },
+    associate(templateId: string) {
+      return new BackendUrl(`${getApiBaseUrl()}/credit-card-statement-import-templates/${templateId}/associate`);
+    },
   },
   creditCardPayments: {
     get endpoint() {

--- a/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
+++ b/FinanceFrontEnd/FinanceApp/app/utils/urls.ts
@@ -258,6 +258,11 @@ const urls = {
       return new BackendUrl(`${getApiBaseUrl()}/subscriptions/paginated`);
     },
   },
+  session: {
+    get me() {
+      return new BackendUrl(`${getApiBaseUrl()}/session/me`);
+    },
+  },
 };
 
 export default urls;

--- a/FinanceFrontEnd/FinanceApp/package-lock.json
+++ b/FinanceFrontEnd/FinanceApp/package-lock.json
@@ -72,11 +72,15 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.10.10",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
+        "@vitest/coverage-v8": "^4.1.8",
         "autoprefixer": "^10.4.24",
         "eslint": "^8.38.0",
         "eslint-import-resolver-typescript": "^3.6.1",
@@ -84,16 +88,25 @@
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.6",
         "sass-embedded": "^1.92.1",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.1.6",
         "vite": "^5.4.21",
-        "vite-tsconfig-paths": "^4.2.1"
+        "vite-tsconfig-paths": "^4.2.1",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -128,6 +141,57 @@
         "nup": "bin/nup.mjs"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -156,6 +220,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -377,18 +442,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -417,12 +482,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -557,13 +622,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -623,12 +688,177 @@
         }
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "devOptional": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
@@ -794,6 +1024,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -845,33 +1076,10 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1151,6 +1359,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1167,6 +1392,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1181,6 +1423,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1334,6 +1593,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
@@ -1401,6 +1678,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -2125,6 +2403,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2231,6 +2510,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2871,10 +3151,21 @@
       "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2914,6 +3205,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2934,6 +3226,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2954,6 +3247,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2974,6 +3268,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2994,6 +3289,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3014,6 +3310,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3034,6 +3331,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3054,6 +3352,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3074,6 +3373,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3094,6 +3394,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3114,6 +3415,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3134,6 +3436,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3154,6 +3457,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3171,6 +3475,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5197,6 +5502,7 @@
       "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.13.0.tgz",
       "integrity": "sha512-bgpA3YdUvuSAQa0vRM9xeZaBsglgUvxsVCUqdJpxF87ZF9pT5uoAITrWYd1soDB8jSksnH3btJEXHasvG7cikA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
         "@react-router/express": "7.13.0",
@@ -5251,6 +5557,289 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@remix-run/node-fetch-server/-/node-fetch-server-0.13.0.tgz",
       "integrity": "sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5603,6 +6192,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -5678,6 +6274,106 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -5734,6 +6430,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -5799,6 +6513,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5850,6 +6571,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5861,6 +6583,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5926,6 +6649,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -6374,6 +7098,138 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -6401,6 +7257,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6771,6 +7628,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -6787,6 +7654,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -6944,6 +7830,16 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -7061,6 +7957,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7199,6 +8096,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7591,6 +8498,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7746,6 +8674,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -7847,6 +8789,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -7987,6 +8936,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8001,8 +8960,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8065,6 +9024,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8135,7 +9101,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -8182,6 +9149,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -8454,6 +9434,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8595,6 +9576,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8966,6 +9948,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9050,11 +10042,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -9967,9 +10970,30 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
       "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -10077,6 +11101,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -10549,6 +11583,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -10773,6 +11814,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -10796,6 +11876,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10840,6 +11921,58 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -10978,6 +12111,268 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -11121,6 +12516,54 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/match-sorter": {
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
@@ -11139,6 +12582,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -11262,6 +12712,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -11472,9 +12932,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -11535,6 +12995,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -11763,6 +13224,20 @@
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
       "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -12034,6 +13509,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -12263,9 +13751,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -12281,8 +13769,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12467,6 +13956,41 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -12809,6 +14333,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12842,6 +14367,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12855,6 +14381,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12969,6 +14496,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
       "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -13137,6 +14665,20 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -13210,6 +14752,7 @@
         "https://github.com/sponsors/sergiodxa"
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -13376,6 +14919,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rollup": {
@@ -13583,33 +15160,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/sass": {
-      "version": "1.97.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher": "^2.4.1"
-      }
-    },
     "node_modules/sass-embedded": {
       "version": "1.97.3",
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.3.tgz",
       "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "colorjs.io": "^0.5.0",
@@ -13656,6 +15213,7 @@
         "!riscv64",
         "!x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13669,6 +15227,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13685,6 +15244,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13701,6 +15261,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13717,6 +15278,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13733,6 +15295,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13749,6 +15312,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13765,6 +15329,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13781,6 +15346,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13797,6 +15363,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13813,6 +15380,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13829,6 +15397,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13845,6 +15414,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13861,6 +15431,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13877,6 +15448,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13890,6 +15462,7 @@
       "version": "1.97.3",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.3.tgz",
       "integrity": "sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13909,6 +15482,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13925,6 +15499,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13948,6 +15523,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -14274,6 +15862,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -14365,6 +15960,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -14379,6 +15981,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -14625,6 +16234,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -14694,6 +16316,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -14750,6 +16379,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14898,6 +16528,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -14908,13 +16545,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -14941,15 +16578,26 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -14992,15 +16640,28 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -15208,6 +16869,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15233,6 +16895,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -15511,6 +17183,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -15613,6 +17286,633 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -15620,6 +17920,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -15726,6 +18061,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -15791,6 +18143,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -15911,6 +18280,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/FinanceFrontEnd/FinanceApp/package-lock.json
+++ b/FinanceFrontEnd/FinanceApp/package-lock.json
@@ -1076,10 +1076,33 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1360,9 +1383,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1393,9 +1416,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1426,9 +1449,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -5780,6 +5803,17 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -11929,7 +11963,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -17292,6 +17325,7 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -17377,9 +17411,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -17394,9 +17428,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -17411,9 +17445,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -17428,9 +17462,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -17445,9 +17479,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -17462,9 +17496,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -17479,9 +17513,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -17496,9 +17530,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -17513,9 +17547,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -17530,9 +17564,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -17547,9 +17581,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -17564,9 +17598,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -17581,9 +17615,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -17598,9 +17632,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -17615,9 +17649,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -17632,9 +17666,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -17649,9 +17683,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -17666,9 +17700,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -17683,9 +17717,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -17700,9 +17734,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -17717,9 +17751,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -17734,9 +17768,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -17751,9 +17785,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],

--- a/FinanceFrontEnd/FinanceApp/package.json
+++ b/FinanceFrontEnd/FinanceApp/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "lint:fix": "eslint --fix --ignore-path .gitignore .",
     "start": "react-router-serve ./build/server/index.js",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
@@ -78,11 +81,15 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.10.10",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
+    "@vitest/coverage-v8": "^4.1.8",
     "autoprefixer": "^10.4.24",
     "eslint": "^8.38.0",
     "eslint-import-resolver-typescript": "^3.6.1",
@@ -90,12 +97,14 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.6",
     "sass-embedded": "^1.92.1",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.1.6",
     "vite": "^5.4.21",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/FinanceFrontEnd/FinanceApp/tests/components/ImportStatementModal.test.tsx
+++ b/FinanceFrontEnd/FinanceApp/tests/components/ImportStatementModal.test.tsx
@@ -73,6 +73,7 @@ const defaultProps = {
   onHide: vi.fn(),
   creditCardId: 'card-123',
   defaultTemplateId: null as string | null,
+  statements: [] as import('@/types/creditCard').CreditCardStatement[],
   onImported: vi.fn(),
 };
 

--- a/FinanceFrontEnd/FinanceApp/tests/components/ImportStatementModal.test.tsx
+++ b/FinanceFrontEnd/FinanceApp/tests/components/ImportStatementModal.test.tsx
@@ -1,0 +1,276 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import ImportStatementModal from '@/components/ui/CreditCards/ImportStatementModal';
+
+vi.mock('@/components/ui/utils/Modal', () => ({
+  Modal: ({ show, children }: { show: boolean; children: React.ReactNode }) =>
+    show ? <div data-testid="modal">{children}</div> : null,
+  ModalHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ModalTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ModalBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ModalFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/utils/urls', () => ({
+  default: {
+    creditCardStatementImportTemplates: { endpoint: '/api/templates' },
+    creditCardStatements: {
+      endpoint: '/api/statements',
+      import: '/api/statements/import',
+    },
+    creditCards: {
+      defaultImportTemplate: (id: string) => `/api/credit-cards/${id}/default-import-template`,
+    },
+    catalog: { currencies: { endpoint: '/api/catalog/currencies' } },
+  },
+}));
+
+const mockTemplates = [
+  { id: 'tmpl-1', name: 'My Template', isSystem: false, configJson: '{}' },
+  { id: 'tmpl-sys', name: 'System Template', isSystem: true, configJson: '{}' },
+];
+
+const mockCurrencies = [
+  { id: 'cur-ars', name: 'ARS' },
+  { id: 'cur-usd', name: 'USD' },
+];
+
+function buildFetchMock() {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.startsWith('/api/templates')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockTemplates),
+      });
+    }
+    if (url === '/api/catalog/currencies') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockCurrencies),
+      });
+    }
+    if (url === '/api/statements') {
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({ id: 'stmt-new' }),
+      });
+    }
+    if (url === '/api/statements/import') {
+      return Promise.resolve({ ok: true, text: () => Promise.resolve('') });
+    }
+    if (typeof url === 'string' && url.includes('default-import-template')) {
+      return Promise.resolve({ ok: true });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+  });
+}
+
+const defaultProps = {
+  show: true,
+  onHide: vi.fn(),
+  creditCardId: 'card-123',
+  defaultTemplateId: null as string | null,
+  onImported: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.alert = vi.fn();
+  global.confirm = vi.fn().mockReturnValue(true);
+  global.fetch = buildFetchMock();
+});
+
+function getForm() {
+  return screen.getByTestId('modal').querySelector('form')!;
+}
+
+describe('ImportStatementModal', () => {
+  it('does not render when show is false', () => {
+    render(<ImportStatementModal {...defaultProps} show={false} />);
+    expect(screen.queryByTestId('modal')).toBeNull();
+  });
+
+  it('renders the modal title when show is true', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    expect(screen.getByTestId('modal')).toBeDefined();
+    expect(screen.getByText('Importar Resúmen desde archivo')).toBeDefined();
+  });
+
+  it('fetches templates and currencies on open', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/templates'));
+      expect(global.fetch).toHaveBeenCalledWith('/api/catalog/currencies');
+    });
+  });
+
+  it('renders template list after loading', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('My Template')).toBeDefined();
+      expect(screen.getByText('System Template')).toBeDefined();
+    });
+  });
+
+  it('pre-selects the default template on open', async () => {
+    render(<ImportStatementModal {...defaultProps} defaultTemplateId="tmpl-1" />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    const templateRow = screen.getByText('My Template').closest('[role="button"]');
+    expect(templateRow?.className).toContain('border-primary');
+  });
+
+  it('selects a template when clicked', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    await userEvent.click(screen.getByText('My Template').closest('[role="button"]')!);
+
+    expect(
+      screen.getByText('My Template').closest('[role="button"]')?.className
+    ).toContain('border-primary');
+  });
+
+  it('shows new template form when clicking Nueva plantilla', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('+ Nueva plantilla'));
+
+    await userEvent.click(screen.getByText('+ Nueva plantilla'));
+
+    expect(screen.getByPlaceholderText('d/M/yyyy')).toBeDefined();
+  });
+
+  it('hides template form when clicking Cancelar inside the form', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('+ Nueva plantilla'));
+
+    await userEvent.click(screen.getByText('+ Nueva plantilla'));
+    expect(screen.getByPlaceholderText('d/M/yyyy')).toBeDefined();
+
+    const cancelButtons = screen.getAllByRole('button', { name: 'Cancelar' });
+    await userEvent.click(cancelButtons[0]);
+    expect(screen.queryByPlaceholderText('d/M/yyyy')).toBeNull();
+  });
+
+  it('shows alert when submitting without a file selected', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    fireEvent.change(screen.getByLabelText('Fecha de Cierre'), {
+      target: { value: '2025-06-30' },
+    });
+    fireEvent.change(screen.getByLabelText('Fecha de Vencimiento'), {
+      target: { value: '2025-07-10' },
+    });
+    await userEvent.click(screen.getByText('My Template').closest('[role="button"]')!);
+
+    fireEvent.submit(getForm());
+
+    expect(global.alert).toHaveBeenCalledWith('Seleccioná un archivo');
+  });
+
+  it('shows alert when submitting without a template selected', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    fireEvent.change(screen.getByLabelText('Fecha de Cierre'), {
+      target: { value: '2025-06-30' },
+    });
+    fireEvent.change(screen.getByLabelText('Fecha de Vencimiento'), {
+      target: { value: '2025-07-10' },
+    });
+    const fileInput = screen.getByLabelText('Archivo (.xls, .xlsx, .csv)');
+    const file = new File(['col1,col2'], 'test.csv', { type: 'text/csv' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    fireEvent.submit(getForm());
+
+    expect(global.alert).toHaveBeenCalledWith('Seleccioná una plantilla');
+  });
+
+  it('calls create-statement and import APIs on successful submit', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    fireEvent.change(screen.getByLabelText('Fecha de Cierre'), {
+      target: { value: '2025-06-30' },
+    });
+    fireEvent.change(screen.getByLabelText('Fecha de Vencimiento'), {
+      target: { value: '2025-07-10' },
+    });
+    const file = new File(['Date,Concept,Amount'], 'test.csv', { type: 'text/csv' });
+    fireEvent.change(screen.getByLabelText('Archivo (.xls, .xlsx, .csv)'), {
+      target: { files: [file] },
+    });
+    await userEvent.click(screen.getByText('My Template').closest('[role="button"]')!);
+
+    await act(async () => {
+      fireEvent.submit(getForm());
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/statements',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/statements/import',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(defaultProps.onHide).toHaveBeenCalled();
+      expect(defaultProps.onImported).toHaveBeenCalled();
+    });
+  });
+
+  it('patches default template after import when selected differs from default', async () => {
+    render(<ImportStatementModal {...defaultProps} defaultTemplateId="other-tmpl" />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    fireEvent.change(screen.getByLabelText('Fecha de Cierre'), {
+      target: { value: '2025-06-30' },
+    });
+    fireEvent.change(screen.getByLabelText('Fecha de Vencimiento'), {
+      target: { value: '2025-07-10' },
+    });
+    const file = new File(['Date,Concept'], 'test.csv', { type: 'text/csv' });
+    fireEvent.change(screen.getByLabelText('Archivo (.xls, .xlsx, .csv)'), {
+      target: { files: [file] },
+    });
+    await userEvent.click(screen.getByText('My Template').closest('[role="button"]')!);
+
+    await act(async () => {
+      fireEvent.submit(getForm());
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/credit-cards/card-123/default-import-template',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+  });
+
+  it('shows edit button only for non-system templates', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    expect(screen.queryAllByRole('button', { name: 'Editar' })).toHaveLength(1);
+  });
+
+  it('calls delete API and reloads templates when delete clicked', async () => {
+    render(<ImportStatementModal {...defaultProps} />);
+    await waitFor(() => screen.getByText('My Template'));
+
+    await userEvent.click(screen.getByRole('button', { name: '×' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/templates',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+});

--- a/FinanceFrontEnd/FinanceApp/tests/setup.ts
+++ b/FinanceFrontEnd/FinanceApp/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/FinanceFrontEnd/FinanceApp/tsconfig.json
+++ b/FinanceFrontEnd/FinanceApp/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
-    "types": ["@react-router/node", "vite/client"],
+    "types": ["@react-router/node", "vite/client", "vitest/globals"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
@@ -25,6 +25,8 @@
     ".tsx",
     "**/*.ts",
     "**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
     "**/.server/**/*.ts",
     "**/.server/**/*.tsx",
     "**/.client/**/*.ts",

--- a/FinanceFrontEnd/FinanceApp/vite.config.ts
+++ b/FinanceFrontEnd/FinanceApp/vite.config.ts
@@ -3,8 +3,8 @@ import { reactRouter } from '@react-router/dev/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-export default defineConfig({
-  plugins: [reactRouter(), tsconfigPaths()],
+export default defineConfig(({ mode }) => ({
+  plugins: mode === 'test' ? [tsconfigPaths()] : [reactRouter(), tsconfigPaths()],
   server: {
     port: parseInt(process.env.PORT || '5100'),
   },
@@ -14,7 +14,6 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    // Force Vite to pre-bundle these CJS packages so named exports resolve in the browser
     include: [
       '@opentelemetry/resources',
       '@opentelemetry/sdk-trace-web',
@@ -27,4 +26,13 @@ export default defineConfig({
       '@opentelemetry/api',
     ],
   },
-});
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+    alias: {
+      '@': path.resolve(__dirname, './app'),
+    },
+  },
+}));


### PR DESCRIPTION
# Why

Credit card statement imports needed templates scoped to specific cards rather than globally to all of a user's cards. Banks produce the same Excel/CSV format for all their credit cards, so a template created for one card should be reusable across other cards. This PR introduces a many-to-many relationship between `CreditCard` and `CreditCardStatementImportTemplate`, scopes template visibility by card, adds a UI section for reusing templates from other cards, and fixes a bug where totals rows at the end of import files were incorrectly parsed as transactions.

It also extends the import pipeline to support **PDF statements** — banks increasingly issue statements as PDFs, so the importer now dispatches to a PDF parser (PdfPig) when the uploaded file has a `.pdf` extension or the template `sourceType` is `Pdf`. Column positions in a PDF are expressed as fractional x-bounds (0-1 relative to page width) instead of column indexes, and a `/pdf-diagnose` endpoint helps calibrate those bounds against a real file.

## What is the solution?

- Added a `CreditCardImportTemplate` join table (EF many-to-many) between `CreditCard` and `CreditCardStatementImportTemplate`.
- `GetCreditCardStatementImportTemplatesQuery` now accepts a `creditCardId` parameter; when provided it filters to system templates + templates associated with that card.
- `CreateCreditCardStatementImportTemplateCommand` accepts an optional `creditCardId` to auto-associate the new template on creation.
- `ImportCreditCardStatementTransactionsCommand` auto-associates the used template with the statement's credit card after a successful import.
- New `AssociateCreditCardImportTemplateCommand` + `POST /{templateId}/associate` endpoint to link an existing template to any card.
- `StatementImportConfig` gained a `skipLastRows` field (default 0) to trim trailing totals/summary rows from import files.
- `StatementImportConfig` extended with `sourceType` (Tabular or Pdf), `skipPages`, `utcOffsetHours`, and per-column `xMin`/`xMax` bounds for PDF extraction.
- `StatementImportPdfHelper` added — uses PdfPig to group words into lines by Y proximity, extract column text by fractional X bounds, and parse dates/amounts using the same config as the Excel helper.
- `StatementImportPdfHelper.Diagnose` returns a structured word map (text, x/y centers, bounds as page fractions) to help configure PDF templates without guessing.
- `POST /credit-card-statements/pdf-diagnose` endpoint exposes the diagnose helper directly.
- `ImportCreditCardStatementTransactionsCommand` dispatches to PDF or Excel helper based on file extension / `sourceType`; on zero-row result from PDF it returns a diagnostic snippet inline.
- `StatementImportExcelHelper` date parsing updated to respect `utcOffsetHours` for timezone-safe storage.
- `ImportStatementModal` now fetches card-scoped templates and shows an "Otras plantillas disponibles" section listing templates accessible to the user but not yet linked to the current card.
- Modal file input now accepts `.pdf` in addition to `.xls`, `.xlsx`, `.csv`.
- xUnit tests added for all five commands/queries and the Excel helper (439 total, all passing).
- Vitest + React Testing Library wired up; 14 component tests added for `ImportStatementModal`.
- Added `/commit` Claude skill for committing changes in logical batches without creating a PR.
- Fixed `/pr` Claude skill branch guard: when already on a feature branch, check for an existing PR first instead of always stopping.

## What areas of the site does it impact?

- Credit card detail page → import statement modal (now accepts PDFs).
- `GET /api/credit-card-statement-import-templates` (new `creditCardId` query param).
- `POST /api/credit-card-statement-import-templates` (new optional `creditCardId` body field).
- `POST /api/credit-card-statement-import-templates/{templateId}/associate` (new endpoint).
- `POST /api/credit-card-statements/import` (now auto-links template to card after import; dispatches to PDF parser when applicable).
- `POST /api/credit-card-statements/pdf-diagnose` (new endpoint for PDF column calibration).

## Test scenarios

```gherkin
Scenario: Import using a card-specific template
  Given a credit card with an associated import template
  When the user opens the import modal for that card
  Then only system templates and templates linked to that card are shown in the main list

Scenario: Reuse a template from another card
  Given a template linked to card A but not card B
  When the user opens the import modal for card B
  Then the template appears under "Otras plantillas disponibles"
  When the user clicks "Usar"
  Then the template is associated with card B and moves to the main list

Scenario: Create a new template from the import modal
  Given the user is importing for card X
  When the user creates a new template via "+ Nueva plantilla"
  Then the new template is automatically associated with card X

Scenario: Totals rows are excluded from import
  Given a CSV with a trailing totals summary row
  And the template has skipLastRows = 2
  When the file is imported
  Then no garbage transaction is created for the totals row

Scenario: Import a PDF statement
  Given a credit card with a PDF-type import template (sourceType=Pdf, column xMin/xMax configured)
  When the user uploads a .pdf bank statement
  Then the importer reads transactions from the PDF using column x-bounds
  And stores them with timezone-corrected UTC dates

Scenario: Calibrate PDF column positions
  Given a PDF bank statement
  When POST /credit-card-statements/pdf-diagnose is called with the file
  Then the response returns each page word positions as fractional x/y coordinates
  So the user can identify the correct xMin/xMax bounds for each column
```

## Other Notes

- `skipLastRows` defaults to 0, so existing templates are unaffected.
- The `CreditCardImportTemplate` join table uses cascade delete on both sides.
- PDF column bounds (`xMin`, `xMax`) are fractions of page width (0-1), making them resolution-independent.
- `utcOffsetHours` defaults to 0; set to e.g. `-3` for Argentine bank statements to get correct UTC midnight storage.
- The `/pdf-diagnose` endpoint is a developer/admin tool for template setup; it is not exposed in the UI.
