### PR TITLE
infra(ci): disable deployment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ jobs:
     deployment:
         name: Deployment
         runs-on: ubuntu-latest
-        if: >-
-            (github.event_name == 'push' && contains(join(github.event.commits.*.modified, ','), 'FinanceBackEnd/Finance.Migrations/')) ||
-            (github.event_name == 'pull_request' && contains(join(github.event.pull_request.changed_files, ','), 'FinanceBackEnd/Finance.Migrations/'))
+        if: false
         steps:
             - name: Check Supabase DB availability
               run: |


### PR DESCRIPTION
# Why
The deployment job in `ci.yml` needs to be temporarily disabled.

## What is the solution?
Set `if: false` on the `deployment` job in `.github/workflows/ci.yml`. This causes GitHub Actions to skip the job unconditionally without removing any of the job definition, making it easy to re-enable later by reverting the single-line change.

## What areas of the site does it impact?
CI only — no application code is affected. Automatic database migrations triggered on push/PR to `main` will no longer run while this is in place.

## Test scenarios

```gherkin
Scenario: Deployment job is skipped
  Given a push or PR targeting main
  When the CI workflow runs
  Then the "Deployment" job is skipped and all other jobs proceed normally
```

## Other Notes
To re-enable, revert the `if: false` line (or restore the original condition from git history).
