### PR TITLE
fix(ci): upgrade Node.js to v24 across all workflows (closes #44)

### DIFF
--- a/.github/workflows/codeql-funds.yml
+++ b/.github/workflows/codeql-funds.yml
@@ -24,9 +24,9 @@ jobs:
         languages: javascript
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Cache npm
       uses: actions/cache@v4

--- a/.github/workflows/codeql-remix.yml
+++ b/.github/workflows/codeql-remix.yml
@@ -24,9 +24,9 @@ jobs:
         languages: javascript
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '24'
 
     - name: Cache npm
       uses: actions/cache@v4

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Install dependencies (FinanceApp)
         working-directory: FinanceFrontEnd/FinanceApp

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
 
             - name: Install dependencies
               run: |
@@ -48,7 +48,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
 
             - name: Install dependencies
               run: |


### PR DESCRIPTION
## Why

All CI workflows were pinned to Node 18 or 20. Node 18 is EOL and react-router already requires Node >20. This upgrades every workflow to Node 24 (current) to resolve the engine mismatch and unblock npm ci on the frontend jobs.

Closes #44

## Changes

### Infrastructure
- `codeql-remix.yml` — Node 18 → 24, setup-node v3 → v4
- `codeql-funds.yml` — Node 20 → 24, setup-node v3 → v4
- `frontend-ci.yml` — Node 18 → 24
- `validate-config.yml` — Node 20 → 24 (both validate and validate-staging jobs)

## Verification

1. Merge this PR.
2. Open any PR that touches `FinanceFrontEnd/**`.
3. Confirm the Lint/Typecheck, CodeQL, and validate-config runs complete without the `EBADENGINE` / react-router Node version warning.
