### PR TITLE
fix(frontend): remove baseUrl from tsconfig to align with Bundler moduleResolution

### DIFF
--- a/FinanceFrontEnd/FinanceApp/tsconfig.json
+++ b/FinanceFrontEnd/FinanceApp/tsconfig.json
@@ -13,7 +13,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./app/*"]
     },


### PR DESCRIPTION
# Why

`FinanceFrontEnd/FinanceApp/tsconfig.json` had `"baseUrl": "."` combined with `"moduleResolution": "Bundler"`. With TypeScript 5+ Bundler resolution, `baseUrl` is not required alongside `paths` — and having it causes TypeScript to attempt resolving bare imports against the project root, which can shadow bundler aliases and produce false-positive type errors.

## What is the solution?

Removed `"baseUrl": "."` from `compilerOptions`. TypeScript 5.0+ allows `paths` to be declared without `baseUrl` when using `moduleResolution: "Bundler"`, so the `@/*` path alias continues to work correctly without the side-effect of root-relative bare import resolution.

## What areas of the site does it impact?

Only the TypeScript compiler configuration for `FinanceFrontEnd/FinanceApp`. No runtime behaviour changes — Vite already handles the `@/*` alias via `vite.config.ts`. All existing imports remain valid; `npm run typecheck` passes cleanly.

## Test scenarios

```gherkin
Scenario: Typecheck passes after removing baseUrl
  Given the FinanceApp project
  When running npm run typecheck
  Then tsc exits with code 0 and no errors are reported
```

## Other Notes

`paths` entries (`"@/*": ["./app/*"]`) are resolved relative to the tsconfig file location when `baseUrl` is absent, which matches the previous effective behaviour since `baseUrl` was `"."` (the tsconfig directory itself).
