### PR TITLE
fix(frontend): increase dashboard credit card page size to show full statement

### DIFF
--- a/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
+++ b/FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx
@@ -140,7 +140,7 @@ export default function Dashboard() {
                       const url = urls.creditCardMovements.latest.with({
                         CreditCardId: data.id,
                         Page: 1,
-                        PageSize: 10,
+                        PageSize: 1000,
                       });
                       const idx =
                         _index < backgroundClasses.length


### PR DESCRIPTION
# Why

The dashboard credit card tables were fetching only the first 10 transactions (`PageSize: 10`), causing them to show fewer items than the full statement visible in the Credit Cards detail page. Users noticed the totals and row counts did not match.

## What is the solution?

Increased `PageSize` from `10` to `1000` in the dashboard credit card URL builder so that all transactions in the latest statement are loaded, matching what the detail page shows.

## What areas of the site does it impact?

Only the Dashboard credit card tables (`FinanceFrontEnd/FinanceApp/app/components/ui/Dashboard/index.tsx`). No backend or API changes required.

## Test scenarios

```gherkin
Scenario: Dashboard credit card table shows all statement transactions
  Given a credit card with more than 10 transactions in the latest statement
  When the user views the Dashboard
  Then the credit card table shows all transactions for the latest statement
  And the collapsed summary total matches the Credit Cards detail page total
```

## Other Notes

`PageSize: 1000` is a practical cap for statement transactions. If statements ever grow beyond that, a proper "fetch all" endpoint (like the `/all` endpoint used in the detail page) would be the right long-term solution.
